### PR TITLE
Update README to demonstrate ProjectReference

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,63 +60,16 @@ cd examples/TileDB.Example/bin/x64/Release/net5.0
 dotnet TileDB.Example.dll
 ```
 
-#### To build your own example, you can add the reference library information in you csproj file
-##### For Windows
-```
-  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <None Include="..\..\dist\Windows\lib\tiledb.dll" Link="tiledb.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\dist\Windows\lib\tiledbcs.dll" Link="tiledbcs.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\dist\Windows\lib\zlib.dll" Link="zlib.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+# Building against TileDB.CSharp
 
-  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <Reference Include="TileDB.CSharp">
-      <HintPath>..\..\dist\Windows\lib\net5.0\TileDB.CSharp.dll</HintPath>
-    </Reference>
-  </ItemGroup>
+To build your own project, you can add `TileDB.CSharp` as a `ProjectReference`
+in your csproj file:
+
 ```
-##### For macOS
-```
-  <ItemGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
-    <None Include="..\..\dist\Darwin\lib\libtiledb.dylib" Link="libtiledb.dylib">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\dist\Darwin\lib\tiledbcs.dylib" Link="tiledbcs.dylib">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\dist\Darwin\lib\libz.dylib" Link="libz.dylib">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
-    <Reference Include="TileDB.CSharp">
-      <HintPath>..\..\dist\Darwin\lib\net5.0\TileDB.CSharp.dll</HintPath>
-    </Reference>
-  </ItemGroup>   
-```
-##### For Linux
-```
-  <ItemGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' ">
-    <None Include="..\..\dist\Linux\lib\libtiledb.so.2.3" Link="libtiledb.so.2.3">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\dist\Linux\lib\tiledbcs.so" Link="tiledbcs.so">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="..\..\dist\Linux\lib\libz.so" Link="libz.so">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-  <ItemGroup Condition=" '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' ">
-    <Reference Include="TileDB.CSharp">
-      <HintPath>..\..\dist\Linux\lib\net5.0\TileDB.CSharp.dll</HintPath>
-    </Reference>
+  <ItemGroup>
+    <ProjectReference Include="path/to/TileDB.CSharp\TileDB.CSharp.csproj"/>
   </ItemGroup>
 ```
 
+See sample usage in the [`tests/TileDBTests.csproj`](tests/TileDBTests.csproj)
+project.


### PR DESCRIPTION
And remove DLL copy sections, now handled by TileDB.CSharp project (https://github.com/TileDB-Inc/TileDB-CSharp/pull/12)