### PR TITLE
Minor CI follow-up

### DIFF
--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -6,6 +6,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   Linux_Example:


### PR DESCRIPTION
- Remove libtiledb install GHA step
  - Download is handled by cmake, so it is not necessary to have the separate
step here. In general, we should not expect or require libtiledb to
be installed in a system-wide location.

- Enable `workflow_dispatch` GHA option
  - This allows users with repository write permission to run workflow
manually on a specific branch.