### PR TITLE
Install runtime artifacts for TileDB target (eg for use in packaging)

### DIFF
--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -175,6 +175,13 @@ install(
 )
 
 install(
+  IMPORTED_RUNTIME_ARTIFACTS
+    TileDB::tiledb_shared
+  DESTINATION
+    ${CMAKE_INSTALL_LIBDIR}
+)
+
+install(
   TARGETS
     tiledbcs
   ARCHIVE


### PR DESCRIPTION
This let me build a nuget package on mac with the release bundle.