### PR TITLE
Add CI for triggering releases

### DIFF
--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -2,7 +2,7 @@ name: TileDB-CSharp
 
 on:
   push:
-    tags: [ v* ]
+    tags: [ '*' ]
     branches: [ main ]
   pull_request:
     branches: [ main ]
@@ -39,52 +39,48 @@ jobs:
       run: |
         $ErrorView = "NormalView"
         dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-
     # DotNet test
     - name: Test TileDB.CSharp
       shell: pwsh
       run: |
         $ErrorView = "NormalView"
-        dotnet test -c Release tests/TileDB.CSharp.Test --framework net5.0
+        dotnet test -c Release tests/TileDB.CSharp.Test
+  MacOS_Test:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        # Will be checking following versions
+        dotnet: ['5.0']
+    steps:
+    # Checks out repository
+    - uses: actions/checkout@v2
 
-  #MacOS_Test:
-  #  runs-on: macos-latest
-  #  strategy:
-  #    matrix:
-  #      # Will be checking following versions
-  #      dotnet: ['5.0']
-  #  steps:
-  #  # Checks out repository
-  #  - uses: actions/checkout@v2
+    # Following action sets up dotnet and uses the strategy matrix to test on
+    # specific versions
+    - name: Set up dotnet
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ matrix.dotnet }}
 
-  #  # Following action sets up dotnet and uses the strategy matrix to test on
-  #  # specific versions
-  #  - name: Set up dotnet
-  #    uses: actions/setup-dotnet@v1
-  #    with:
-  #      dotnet-version: ${{ matrix.dotnet }}
+    - name: Display dotnet version
+      run: |
+        dotnet --version
+    # Download tiledb
+    - name: Download tiledb
+      run: ./.github/scripts/install_tiledb.sh
 
-  #  - name: Display dotnet version
-  #    run: dotnet --version
-
-  #  # Download tiledb
-  #  - name: Download tiledb
-  #    run: ./.github/scripts/install_tiledb.sh
-
-  #  # DotNet build
-  #  - name: Dotnet build for TileDB.CSharp
-  #    shell: pwsh
-  #    run: |
-  #      $ErrorView = "NormalView"
-  #      dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-
-  #  # DotNet test
-  #  - name: Test TileDB.CSharp
-  #    shell: pwsh
-  #    run: |
-  #      $ErrorView = "NormalView"
-  #      dotnet test -c Release tests/TileDB.CSharp.Test --framework net"${{ matrix.dotnet-version }}"
-
+    # DotNet build
+    - name: Dotnet build for TileDB.CSharp
+      shell: pwsh
+      run: |
+        $ErrorView = "NormalView"
+        dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
+    # DotNet test
+    - name: Test TileDB.CSharp
+      shell: pwsh
+      run: |
+        $ErrorView = "NormalView"
+        dotnet test -c Release tests/TileDB.CSharp.Test
   Windows_Test:
     runs-on: windows-latest
     strategy:
@@ -112,22 +108,21 @@ jobs:
         cd cpp
         cmake .
         cmake --build . --target install
-
     # DotNet build
     - name: Dotnet build for TileDB.CSharp
       shell: pwsh
       run: |
         $ErrorView = "NormalView"
         dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-
     # DotNet test
     - name: Test TileDB.CSharp
       shell: pwsh
       run: |
         $ErrorView = "NormalView"
-        dotnet test -c Release tests/TileDB.CSharp.Test --framework net5.0
-
+        dotnet test -c Release tests/TileDB.CSharp.Test
   Release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [Linux_Test, MacOS_Test, Windows_Test]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -157,17 +152,28 @@ jobs:
       run: |
         $ErrorView = "NormalView"
         cp sources/TileDB.CSharp/runtimes/linux-x64/native/libtiledb.so.2.10 sources/TileDB.CSharp/runtimes/linux-x64/native/libtiledb.so
-
     # DotNet build
     - name: Dotnet build for TileDB.CSharp
       shell: pwsh
       run: |
         $ErrorView = "NormalView"
         dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-
     # DotNet pack
     - name: Dotnet pack for TileDB.CSharp
       shell: pwsh
       run: |
         $ErrorView = "NormalView"
         dotnet pack ./sources/TileDB.CSharp/TileDB.CSharp.csproj /p:NuspecFile=TileDB.CSharp.nuspec -c Release
+
+    - name: Create Release
+      id: create_release
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        files: sources/TileDB.CSharp/lib/*.nupkg
+        tag_name: ${{ github.ref_name }}
+        name: ${{ github.ref_name }}
+        body: ${{ steps.github_release.outputs.changelog }}
+        draft: false
+        prerelease: false

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -9,7 +9,45 @@ on:
   workflow_dispatch:
 
 jobs:
-  Linux_Test:
+  Run-Tests:
+    strategy:
+      matrix:
+        # Will be checking following versions
+        dotnet: ['5.0']
+        # Repeat this test for each os
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # Checks out repository
+      - uses: actions/checkout@v3
+
+      # Following action sets up dotnet and uses the strategy matrix to test on
+      # specific versions
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+
+      - name: Display dotnet version
+        run: dotnet --version
+
+      # Install tiledb
+      - name: Install tiledb
+        shell: bash
+        run: ./.github/scripts/install_tiledb.sh
+
+      # DotNet build
+      - name: Dotnet build for TileDB.CSharp
+        run: |
+          dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
+
+      # DotNet test
+      - name: Test TileDB.CSharp
+        run: |
+          dotnet test -c Release tests/TileDB.CSharp.Test
+
+  Stage-Release-Candidate:
+    needs: Run-Tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -17,131 +55,12 @@ jobs:
         dotnet: ['5.0']
     steps:
       # Checks out repository
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Following action sets up dotnet and uses the strategy matrix to test on
       # specific versions
       - name: Set up dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ matrix.dotnet }}
-
-      - name: Display dotnet version
-        run: dotnet --version
-
-      # Download tiledb
-      - name: Download tiledb
-        run: ./.github/scripts/install_tiledb.sh
-
-      # DotNet build
-      - name: Dotnet build for TileDB.CSharp
-        shell: pwsh
-        run: |
-          $ErrorView = "NormalView"
-          dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-
-      # DotNet test
-      - name: Test TileDB.CSharp
-        shell: pwsh
-        run: |
-          $ErrorView = "NormalView"
-          dotnet test -c Release tests/TileDB.CSharp.Test
-
-  MacOS_Test:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        # Will be checking following versions
-        dotnet: ['5.0']
-    steps:
-      # Checks out repository
-      - uses: actions/checkout@v2
-
-      # Following action sets up dotnet and uses the strategy matrix to test on
-      # specific versions
-      - name: Set up dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ matrix.dotnet }}
-
-      - name: Display dotnet version
-        run: |
-          dotnet --version
-      # Download tiledb
-      - name: Download tiledb
-        run: ./.github/scripts/install_tiledb.sh
-
-      # DotNet build
-      - name: Dotnet build for TileDB.CSharp
-        shell: pwsh
-        run: |
-          $ErrorView = "NormalView"
-          dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-
-      # DotNet test
-      - name: Test TileDB.CSharp
-        shell: pwsh
-        run: |
-          $ErrorView = "NormalView"
-          dotnet test -c Release tests/TileDB.CSharp.Test
-
-  Windows_Test:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        # Will be checking following versions
-        dotnet: ['5.0']
-    steps:
-      # Checks out repository
-      - uses: actions/checkout@v2
-
-      # Following action sets up dotnet and uses the strategy matrix to test on
-      # specific versions
-      - name: Set up dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: ${{ matrix.dotnet }}
-
-      - name: Display dotnet version
-        run: dotnet --version
-
-      # Download tiledb
-      - name: Download tiledb
-        run: |
-          $ErrorView = "NormalView"
-          cd cpp
-          cmake .
-          cmake --build . --target install
-
-      # DotNet build
-      - name: Dotnet build for TileDB.CSharp
-        shell: pwsh
-        run: |
-          $ErrorView = "NormalView"
-          dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-
-      # DotNet test
-      - name: Test TileDB.CSharp
-        shell: pwsh
-        run: |
-          $ErrorView = "NormalView"
-          dotnet test -c Release tests/TileDB.CSharp.Test
-
-  Stage-Release:
-    needs: [Linux_Test, MacOS_Test, Windows_Test]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # Will be checking following versions
-        dotnet: ['5.0']
-    steps:
-      # Checks out repository
-      - uses: actions/checkout@v2
-
-      # Following action sets up dotnet and uses the strategy matrix to test on
-      # specific versions
-      - name: Set up dotnet
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v2
         with:
           dotnet-version: ${{ matrix.dotnet }}
 
@@ -152,25 +71,18 @@ jobs:
       - name: Download tiledb
         run: ./.github/scripts/download_tiledb.sh
 
-      # Download tiledb
       - name: Copy tiledb lib
-        shell: pwsh
         run: |
-          $ErrorView = "NormalView"
           cp sources/TileDB.CSharp/runtimes/linux-x64/native/libtiledb.so.2.10 sources/TileDB.CSharp/runtimes/linux-x64/native/libtiledb.so
 
       # DotNet build
       - name: Dotnet build for TileDB.CSharp
-        shell: pwsh
         run: |
-          $ErrorView = "NormalView"
           dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
 
       # DotNet pack
       - name: Dotnet pack for TileDB.CSharp
-        shell: pwsh
         run: |
-          $ErrorView = "NormalView"
           dotnet pack ./sources/TileDB.CSharp/TileDB.CSharp.csproj /p:NuspecFile=TileDB.CSharp.nuspec -c Release
 
       - name: Archive nuget artifact
@@ -179,12 +91,53 @@ jobs:
           name: TileDB NuGet Package
           path: sources/TileDB.CSharp/lib/TileDB.CSharp.*.nupkg
 
+  Test-NuGet-Release:
+    needs: Stage-Release-Candidate
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        dotnet: ['5.0']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout TileDB-CSharp repository
+        uses: actions/checkout@v3
+
+      - name: Download TileDB.CSharp NuGet artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: TileDB NuGet Package
+
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v2
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
+
+      - name: Display dotnet version
+        run: dotnet --version
+
+      - name: Setup NuGet
+        uses: nuget/setup-nuget@v1
+
+      # Set up TileDB.CSharp.Test project to use local NuGet package
+      - name: Setup local test project
+        shell: bash
+        run: |
+          nuget add TileDB.CSharp.*.nupkg -Source ./packages
+          dotnet new mstest -o tests/TileDB.CSharp.Test/ --force
+          dotnet add tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj package TileDB.CSharp -s ./packages
+
+      # Run tests using NuGet release candidate
+      - name: Test TileDB.CSharp
+        run: |
+          dotnet test -c Release tests/TileDB.CSharp.Test
+
   Release:
+    # Only run this job if a tag was provided
     if: startsWith(github.ref, 'refs/tags/')
-    needs: Stage-Release
+    needs: Test-NuGet-Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@master
+      - uses: actions/download-artifact@v3
         with:
           name: TileDB NuGet Package
 

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -16,35 +16,37 @@ jobs:
         # Will be checking following versions
         dotnet: ['5.0']
     steps:
-    # Checks out repository
-    - uses: actions/checkout@v2
+      # Checks out repository
+      - uses: actions/checkout@v2
 
-    # Following action sets up dotnet and uses the strategy matrix to test on
-    # specific versions
-    - name: Set up dotnet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ matrix.dotnet }}
+      # Following action sets up dotnet and uses the strategy matrix to test on
+      # specific versions
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
 
-    - name: Display dotnet version
-      run: dotnet --version
+      - name: Display dotnet version
+        run: dotnet --version
 
-    # Download tiledb
-    - name: Download tiledb
-      run: ./.github/scripts/install_tiledb.sh
+      # Download tiledb
+      - name: Download tiledb
+        run: ./.github/scripts/install_tiledb.sh
 
-    # DotNet build
-    - name: Dotnet build for TileDB.CSharp
-      shell: pwsh
-      run: |
-        $ErrorView = "NormalView"
-        dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-    # DotNet test
-    - name: Test TileDB.CSharp
-      shell: pwsh
-      run: |
-        $ErrorView = "NormalView"
-        dotnet test -c Release tests/TileDB.CSharp.Test
+      # DotNet build
+      - name: Dotnet build for TileDB.CSharp
+        shell: pwsh
+        run: |
+          $ErrorView = "NormalView"
+          dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
+
+      # DotNet test
+      - name: Test TileDB.CSharp
+        shell: pwsh
+        run: |
+          $ErrorView = "NormalView"
+          dotnet test -c Release tests/TileDB.CSharp.Test
+
   MacOS_Test:
     runs-on: macos-latest
     strategy:
@@ -52,35 +54,37 @@ jobs:
         # Will be checking following versions
         dotnet: ['5.0']
     steps:
-    # Checks out repository
-    - uses: actions/checkout@v2
+      # Checks out repository
+      - uses: actions/checkout@v2
 
-    # Following action sets up dotnet and uses the strategy matrix to test on
-    # specific versions
-    - name: Set up dotnet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ matrix.dotnet }}
+      # Following action sets up dotnet and uses the strategy matrix to test on
+      # specific versions
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
 
-    - name: Display dotnet version
-      run: |
-        dotnet --version
-    # Download tiledb
-    - name: Download tiledb
-      run: ./.github/scripts/install_tiledb.sh
+      - name: Display dotnet version
+        run: |
+          dotnet --version
+      # Download tiledb
+      - name: Download tiledb
+        run: ./.github/scripts/install_tiledb.sh
 
-    # DotNet build
-    - name: Dotnet build for TileDB.CSharp
-      shell: pwsh
-      run: |
-        $ErrorView = "NormalView"
-        dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-    # DotNet test
-    - name: Test TileDB.CSharp
-      shell: pwsh
-      run: |
-        $ErrorView = "NormalView"
-        dotnet test -c Release tests/TileDB.CSharp.Test
+      # DotNet build
+      - name: Dotnet build for TileDB.CSharp
+        shell: pwsh
+        run: |
+          $ErrorView = "NormalView"
+          dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
+
+      # DotNet test
+      - name: Test TileDB.CSharp
+        shell: pwsh
+        run: |
+          $ErrorView = "NormalView"
+          dotnet test -c Release tests/TileDB.CSharp.Test
+
   Windows_Test:
     runs-on: windows-latest
     strategy:
@@ -88,40 +92,42 @@ jobs:
         # Will be checking following versions
         dotnet: ['5.0']
     steps:
-    # Checks out repository
-    - uses: actions/checkout@v2
+      # Checks out repository
+      - uses: actions/checkout@v2
 
-    # Following action sets up dotnet and uses the strategy matrix to test on
-    # specific versions
-    - name: Set up dotnet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ matrix.dotnet }}
+      # Following action sets up dotnet and uses the strategy matrix to test on
+      # specific versions
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
 
-    - name: Display dotnet version
-      run: dotnet --version
+      - name: Display dotnet version
+        run: dotnet --version
 
-    # Download tiledb
-    - name: Download tiledb
-      run: |
-        $ErrorView = "NormalView"
-        cd cpp
-        cmake .
-        cmake --build . --target install
-    # DotNet build
-    - name: Dotnet build for TileDB.CSharp
-      shell: pwsh
-      run: |
-        $ErrorView = "NormalView"
-        dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-    # DotNet test
-    - name: Test TileDB.CSharp
-      shell: pwsh
-      run: |
-        $ErrorView = "NormalView"
-        dotnet test -c Release tests/TileDB.CSharp.Test
-  Release:
-    if: startsWith(github.ref, 'refs/tags/')
+      # Download tiledb
+      - name: Download tiledb
+        run: |
+          $ErrorView = "NormalView"
+          cd cpp
+          cmake .
+          cmake --build . --target install
+
+      # DotNet build
+      - name: Dotnet build for TileDB.CSharp
+        shell: pwsh
+        run: |
+          $ErrorView = "NormalView"
+          dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
+
+      # DotNet test
+      - name: Test TileDB.CSharp
+        shell: pwsh
+        run: |
+          $ErrorView = "NormalView"
+          dotnet test -c Release tests/TileDB.CSharp.Test
+
+  Stage-Release:
     needs: [Linux_Test, MacOS_Test, Windows_Test]
     runs-on: ubuntu-latest
     strategy:
@@ -129,51 +135,68 @@ jobs:
         # Will be checking following versions
         dotnet: ['5.0']
     steps:
-    # Checks out repository
-    - uses: actions/checkout@v2
+      # Checks out repository
+      - uses: actions/checkout@v2
 
-    # Following action sets up dotnet and uses the strategy matrix to test on
-    # specific versions
-    - name: Set up dotnet
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: ${{ matrix.dotnet }}
+      # Following action sets up dotnet and uses the strategy matrix to test on
+      # specific versions
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ matrix.dotnet }}
 
-    - name: Display dotnet version
-      run: dotnet --version
+      - name: Display dotnet version
+        run: dotnet --version
 
-    # Download tiledb
-    - name: Download tiledb
-      run: ./.github/scripts/download_tiledb.sh
+      # Download tiledb
+      - name: Download tiledb
+        run: ./.github/scripts/download_tiledb.sh
 
-    # Download tiledb
-    - name: Copy tiledb lib
-      shell: pwsh
-      run: |
-        $ErrorView = "NormalView"
-        cp sources/TileDB.CSharp/runtimes/linux-x64/native/libtiledb.so.2.10 sources/TileDB.CSharp/runtimes/linux-x64/native/libtiledb.so
-    # DotNet build
-    - name: Dotnet build for TileDB.CSharp
-      shell: pwsh
-      run: |
-        $ErrorView = "NormalView"
-        dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
-    # DotNet pack
-    - name: Dotnet pack for TileDB.CSharp
-      shell: pwsh
-      run: |
-        $ErrorView = "NormalView"
-        dotnet pack ./sources/TileDB.CSharp/TileDB.CSharp.csproj /p:NuspecFile=TileDB.CSharp.nuspec -c Release
+      # Download tiledb
+      - name: Copy tiledb lib
+        shell: pwsh
+        run: |
+          $ErrorView = "NormalView"
+          cp sources/TileDB.CSharp/runtimes/linux-x64/native/libtiledb.so.2.10 sources/TileDB.CSharp/runtimes/linux-x64/native/libtiledb.so
 
-    - name: Create Release
-      id: create_release
-      uses: softprops/action-gh-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        files: sources/TileDB.CSharp/lib/*.nupkg
-        tag_name: ${{ github.ref_name }}
-        name: ${{ github.ref_name }}
-        body: ${{ steps.github_release.outputs.changelog }}
-        draft: false
-        prerelease: false
+      # DotNet build
+      - name: Dotnet build for TileDB.CSharp
+        shell: pwsh
+        run: |
+          $ErrorView = "NormalView"
+          dotnet build /p:Platform=x64 -c Release sources/TileDB.CSharp
+
+      # DotNet pack
+      - name: Dotnet pack for TileDB.CSharp
+        shell: pwsh
+        run: |
+          $ErrorView = "NormalView"
+          dotnet pack ./sources/TileDB.CSharp/TileDB.CSharp.csproj /p:NuspecFile=TileDB.CSharp.nuspec -c Release
+
+      - name: Archive nuget artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: TileDB NuGet Package
+          path: sources/TileDB.CSharp/lib/TileDB.CSharp.*.nupkg
+
+  Release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: Stage-Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@master
+        with:
+          name: TileDB NuGet Package
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: ./*.nupkg
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.github_release.outputs.changelog }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
With these CI changes a TileDB-CSharp release can be triggered by pushing a new tag. After passing initial tests and building an updated NuGet package for this release, the workflow will upload `TileDB.CSharp.*.nupkg` as an artifact and later jobs will download this artifact to test the NuGet package locally on Windows, Mac, and Linux.

Any push to `main` will result in this workflow being triggered, but the final `Release` job will not run without a release tag. Always open to thoughts or suggestions on how this could be improved. 

Triggered this workflow manually (with no release tag): https://github.com/TileDB-Inc/TileDB-CSharp/actions/runs/2693214014