### PR TITLE
Run examples using CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run examples
         shell: bash
         run: |
-          find examples/ -name *.csproj -execdir dotnet run --framework net5.0 \;
+          find examples/ -name *.csproj -execdir dotnet run --framework net${{ matrix.dotnet }} \;
 
   Create-Issue:
     needs: Build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,6 +69,11 @@ jobs:
         run: |
           dotnet test tiledb-csharp/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj -c Release
 
+      - name: Run examples
+        shell: bash
+        run: |
+          find examples/ -name *.csproj -execdir dotnet run --framework net5.0 \;
+
   Create-Issue:
     needs: Build
     if: failure()

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Run examples
         shell: bash
         run: |
-          find examples/ -name *.csproj -execdir dotnet run --framework net${{ matrix.dotnet }} \;
+          find tiledb-csharp/examples/ -name *.csproj -execdir dotnet run --framework net${{ matrix.dotnet }} \;
 
   Create-Issue:
     needs: Build

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run examples
         shell: bash
         run: |
-          find examples/ -name *.csproj -execdir dotnet run --framework net5.0 \;
+          find examples/ -name *.csproj -execdir dotnet run --framework net${{ matrix.dotnet }} \;
 
   Stage-Release-Candidate:
     needs: Run-Tests

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -46,6 +46,11 @@ jobs:
         run: |
           dotnet test -c Release tests/TileDB.CSharp.Test
 
+      - name: Run examples
+        shell: bash
+        run: |
+          find examples/ -name *.csproj -execdir dotnet run --framework net5.0 \;
+
   Stage-Release-Candidate:
     needs: Run-Tests
     runs-on: ubuntu-latest

--- a/examples/bindings/quickstart_sparse_string/quickstart_sparse_string.csproj
+++ b/examples/bindings/quickstart_sparse_string/quickstart_sparse_string.csproj
@@ -6,21 +6,7 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
-  <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
-    <Content Include="..\..\..\sources\TileDB.CSharp\runtimes\win-x64\native\tiledb.dll" Link="tiledb.dll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(OS)' == 'Unix' and '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' ">
-    <Content Include="..\..\..\sources\TileDB.CSharp\runtimes\linux-x64\native\libtiledb.so.2.10" Link="libtiledb.so.2.10">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
-  <ItemGroup Condition=" '$(OS)' == 'Unix' and '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::OSX)))' ">
-    <Content Include="..\..\..\sources\TileDB.CSharp\runtimes\osx-x64\native\libtiledb.dylib" Link="libtiledb.dylib">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\sources\TileDB.CSharp\TileDB.CSharp.csproj" />
   </ItemGroup>


### PR DESCRIPTION
This will run all current and future example projects stored under the `examples/` subdirectory. Alternatively we could itemize them, just thought it might be nice if the CI could pick up new examples without needing updated.