### PR TITLE
Add CI for .NET 6.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
             HOST: win
             BOOTSTRAP: ../bootstrap.ps1 -EnableS3 -EnableSerialization
         tag: [release-2.10, release-2.11, dev]
-        dotnet: ['5.0']
+        dotnet: ['5.0', '6.0']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -72,7 +72,7 @@ jobs:
       - name: Run examples
         shell: bash
         run: |
-          find tiledb-csharp/examples/ -name *.csproj -execdir dotnet run --framework net${{ matrix.dotnet }} \;
+          find tiledb-csharp/examples/ -name *.csproj -execdir dotnet run \;
 
   Create-Issue:
     needs: Build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,10 +41,19 @@ jobs:
           ref: ${{ matrix.tag }}
           path: tiledb
 
+      # GitHub runners come with several versions of .NET preinstalled; Remove them to target version
+      - name: Remove existing .NET versions
+        shell: bash
+        run: |
+          rm -rf $DOTNET_ROOT
+
       - name: Set up dotnet
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: ${{ matrix.dotnet }}
+
+      - name: Display dotnet versions
+        run: dotnet --info
 
       - name: Build TileDB
         run: |

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -13,13 +13,23 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        dotnet: ['5.0']
+        dotnet: ['5.0', '6.0']
         # Repeat this test for each os
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       # Checks out repository
       - uses: actions/checkout@v3
+
+      # Install tiledb
+      - name: Install tiledb
+        shell: bash
+        run: ./.github/scripts/install_tiledb.sh
+
+      - name: Remove existing .NET versions
+        shell: bash
+        run: |
+          rm -rf $DOTNET_ROOT
 
       # Following action sets up dotnet and uses the strategy matrix to test on
       # specific versions
@@ -28,13 +38,7 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet }}
 
-      - name: Display dotnet version
-        run: dotnet --version
-
-      # Install tiledb
-      - name: Install tiledb
-        shell: bash
-        run: ./.github/scripts/install_tiledb.sh
+      - run: dotnet --info
 
       # DotNet build
       - name: Dotnet build for TileDB.CSharp
@@ -49,7 +53,7 @@ jobs:
       - name: Run examples
         shell: bash
         run: |
-          find examples/ -name *.csproj -execdir dotnet run --framework net${{ matrix.dotnet }} \;
+          find examples/ -name *.csproj -execdir dotnet run \;
 
   Stage-Release-Candidate:
     needs: Run-Tests
@@ -57,7 +61,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        dotnet: ['5.0']
+        dotnet: ['5.0', '6.0']
     steps:
       # Checks out repository
       - uses: actions/checkout@v3
@@ -101,7 +105,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        dotnet: ['5.0']
+        dotnet: ['5.0', '6.0']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout TileDB-CSharp repository

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -38,7 +38,8 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet }}
 
-      - run: dotnet --info
+      - name: Display .NET versions
+        run: dotnet --info
 
       # DotNet build
       - name: Dotnet build for TileDB.CSharp
@@ -61,7 +62,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        dotnet: ['5.0', '6.0']
+        dotnet: ['5.0']
     steps:
       # Checks out repository
       - uses: actions/checkout@v3
@@ -73,8 +74,8 @@ jobs:
         with:
           dotnet-version: ${{ matrix.dotnet }}
 
-      - name: Display dotnet version
-        run: dotnet --version
+      - name: Display dotnet versions
+        run: dotnet --info
 
       # Download tiledb
       - name: Download tiledb
@@ -116,13 +117,19 @@ jobs:
         with:
           name: TileDB NuGet Package
 
+      # GitHub runners come with several versions of .NET preinstalled; Remove them to target version
+      - name: Remove existing .NET versions
+        shell: bash
+        run: |
+          rm -rf $DOTNET_ROOT
+
       - name: Set up dotnet
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: ${{ matrix.dotnet }}
 
-      - name: Display dotnet version
-        run: dotnet --version
+      - name: Display dotnet versions
+        run: dotnet --info
 
       - name: Setup NuGet
         uses: nuget/setup-nuget@v1

--- a/examples/TileDB.CSharp.Example/TileDB.CSharp.Example.csproj
+++ b/examples/TileDB.CSharp.Example/TileDB.CSharp.Example.csproj
@@ -3,7 +3,8 @@
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <RootNamespace>TileDB.CSharp.Examples</RootNamespace>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
+    <RollForward>Major</RollForward>
     <Version>5.1.1</Version>
   </PropertyGroup>
 

--- a/examples/bindings/quickstart_sparse_string/quickstart_sparse_string.csproj
+++ b/examples/bindings/quickstart_sparse_string/quickstart_sparse_string.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <Version>5.1.0</Version>
-    <TargetFramework>net5.0</TargetFramework>
-    <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RollForward>Major</RollForward>
+    <TargetFramework>net5.0</TargetFramework>
+    <Version>5.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sources/TileDB.CSharp/TileDB.CSharp.csproj
+++ b/sources/TileDB.CSharp/TileDB.CSharp.csproj
@@ -3,8 +3,9 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <Nullable>enable</Nullable>
+    <RollForward>Major</RollForward>
     <RootNamespace>TileDB.CSharp</RootNamespace>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>5.1.1</Version>
   </PropertyGroup>
 

--- a/sources/TileDB.Interop/TileDB.Interop.csproj
+++ b/sources/TileDB.Interop/TileDB.Interop.csproj
@@ -2,7 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <RollForward>Major</RollForward>
+    <TargetFramework>net5.0</TargetFramework>
     <Version>5.1.1</Version>
   </PropertyGroup>
 </Project>

--- a/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
+++ b/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
@@ -2,8 +2,9 @@
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+    <RollForward>Major</RollForward>
     <RootNamespace>TileDB.CSharp.Test</RootNamespace>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added `RollForward` tag to msbuild configurations to use .NET 6 if available. If both .NET 5.0 and .NET 6.0 SDKs are available and we use `dotnet run` without an explicit `--framework net5.0` .NET 6.0 will be used. The `--framework` flag should only be set if .NET 5.0 and 6.0 SDKs are both available and we want to target .NET 5.0. 

CI now tests building with both .NET 5.0 and 6.0 using new msbuild configurations. I used docker to test building in environments limited to either .NET 5.0 *or* .NET 6.0.

```bash
# From root of TileDB-CSharp/
docker run -v $(pwd):/app -w /app/examples/TileDB.CSharp.Example mcr.microsoft.com/dotnet/sdk:6.0 dotnet run
docker run -v $(pwd):/app -w /app/examples/TileDB.CSharp.Example mcr.microsoft.com/dotnet/sdk:5.0 dotnet run
```
