### PR TITLE
Update to TileDB 2.11.1

### DIFF
--- a/.github/scripts/download_tiledb.sh
+++ b/.github/scripts/download_tiledb.sh
@@ -1,6 +1,6 @@
 set -e -x
-TAG=2.11.0
-ID=34e5dbc
+TAG=2.11.1
+ID=15a1161
 
 RELEASE=x86_64-$TAG-$ID
 wget https://github.com/TileDB-Inc/TileDB/releases/download/$TAG/tiledb-windows-$RELEASE.zip

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -5,7 +5,7 @@
 # setup
 cmake_minimum_required(VERSION 3.16)
 
-set(TILEDB_VERSION "2.11.0" CACHE STRING "TileDB version")
+set(TILEDB_VERSION "2.11.1" CACHE STRING "TileDB version")
 set(TILEDB_GIT_TAG "dev" CACHE STRING "git branch")
 
 project(TileDB-CSharp)

--- a/cpp/cmake/TileDB.cmake
+++ b/cpp/cmake/TileDB.cmake
@@ -9,7 +9,18 @@ message(STATUS "start to set tiledb for version:${TILEDB_VERSION}")
 if(${TILEDB_VERSION} MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$")
 message(STATUS "start to set TILEDB_DOWNLOAD_URL and TILEDB_DOWNLOAD_SHA1")
 
-if(${TILEDB_VERSION} STREQUAL "2.11.0")
+if(${TILEDB_VERSION} STREQUAL "2.11.1")
+  if (WIN32) # Windows
+    SET(TILEDB_DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.1/tiledb-windows-x86_64-2.11.1-15a1161.zip")
+    SET(TILEDB_DOWNLOAD_SHA1 "f88420f4269aaac69a1dfb53e20f4848c407fa3f")
+  elseif(APPLE) # OSX
+    SET(TILEDB_DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.1/tiledb-macos-x86_64-2.11.1-15a1161.tar.gz")
+    SET(TILEDB_DOWNLOAD_SHA1 "95439b79e6f27cd9441403429161b8fc962e03ea")
+  else() # Linux
+    SET(TILEDB_DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.1/tiledb-linux-x86_64-2.11.1-15a1161.tar.gz")
+    SET(TILEDB_DOWNLOAD_SHA1 "909a579420abcd490c54b486f10a1791499f30d8")
+  endif()
+elseif(${TILEDB_VERSION} STREQUAL "2.11.0")
   if (WIN32) # Windows
     SET(TILEDB_DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-windows-x86_64-2.11.0-34e5dbc.zip")
     SET(TILEDB_DOWNLOAD_SHA1 "ae60d7bea72472716cb85631c27f8d2ddc7d7dd7")
@@ -385,14 +396,14 @@ elseif(${TILEDB_VERSION} STREQUAL "2.0.7")
   endif()
 else()
   if (WIN32) # Windows
-    SET(TILEDB_DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-windows-x86_64-2.11.0-34e5dbc.zip")
-    SET(TILEDB_DOWNLOAD_SHA1 "ae60d7bea72472716cb85631c27f8d2ddc7d7dd7")
+    SET(TILEDB_DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.1/tiledb-windows-x86_64-2.11.1-15a1161.zip")
+    SET(TILEDB_DOWNLOAD_SHA1 "f88420f4269aaac69a1dfb53e20f4848c407fa3f")
   elseif(APPLE) # OSX
-    SET(TILEDB_DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-macos-x86_64-2.11.0-34e5dbc.tar.gz")
-    SET(TILEDB_DOWNLOAD_SHA1 "56e865574404cb11cbd631c7c25ab0cfd413f9b3")
+    SET(TILEDB_DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.1/tiledb-macos-x86_64-2.11.1-15a1161.tar.gz")
+    SET(TILEDB_DOWNLOAD_SHA1 "95439b79e6f27cd9441403429161b8fc962e03ea")
   else() # Linux
-    SET(TILEDB_DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.0/tiledb-linux-x86_64-2.11.0-34e5dbc.tar.gz")
-    SET(TILEDB_DOWNLOAD_SHA1 "c2eb91e352905728edfeb8dc0a6fbfd7bc69ef66")
+    SET(TILEDB_DOWNLOAD_URL "https://github.com/TileDB-Inc/TileDB/releases/download/2.11.1/tiledb-linux-x86_64-2.11.1-15a1161.tar.gz")
+    SET(TILEDB_DOWNLOAD_SHA1 "909a579420abcd490c54b486f10a1791499f30d8")
   endif()
 endif()
 

--- a/scripts/generate/README.md
+++ b/scripts/generate/README.md
@@ -81,9 +81,9 @@ source ~/.zshrc
 Install specific version of TileDB in `/usr/local`
 
 ```bash
-git clone https://github.com/TileDB-Inc/TileDB.git -b 2.11.0
-mv TileDB TileDB_2.11.0
-cd TileDB_2.11.0
+git clone https://github.com/TileDB-Inc/TileDB.git -b 2.11.1
+mv TileDB TileDB_2.11.1
+cd TileDB_2.11.1
 mkdir build && cd build
 #cmake 3.22.2
 cmake -DTILEDB_VERBOSE=OFF -DTILEDB_S3=ON -DTILEDB_SERIALIZATION=ON -DTILEDB_AZURE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/usr/local ..

--- a/sources/TileDB.CSharp/TileDB.CSharp.nuspec
+++ b/sources/TileDB.CSharp/TileDB.CSharp.nuspec
@@ -9,7 +9,7 @@
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/TileDB-Inc/TileDB-CSharp</projectUrl>
     <description>CSharp wrapper of TileDB universal data engine</description>
-    <releaseNotes>This package is the csharp wrapper of TileDB 2.11.0.</releaseNotes>
+    <releaseNotes>This package is the csharp wrapper of TileDB 2.11.1.</releaseNotes>
     <copyright>$copyright$</copyright>
     <tags>tiledb</tags>
     <dependencies>


### PR DESCRIPTION
I did a version bump to 5.2.1 in #94 so we could release an updated NuGet package to support a question on AOD and didn't have a chance to do a release before TileDB 2.11.1 was tagged this morning. If needed I can bump to 5.2.2 - I left it out for now with the intention to release 5.2.1 with TileDB 2.11.1 when this is merged.