### PR TITLE
Stop running tests in .NET 5 and retarget projects to .NET 6.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
             HOST: win
             BOOTSTRAP: ../bootstrap.ps1 -EnableS3 -EnableSerialization
         tag: [release-2.10, release-2.11, dev]
-        dotnet: ['5.0', '6.0']
+        dotnet: ['6.0']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        dotnet: ['5.0', '6.0']
+        dotnet: ['6.0']
         # Repeat this test for each os
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         # Will be checking following versions
-        dotnet: ['5.0']
+        dotnet: ['6.0']
     steps:
       # Checks out repository
       - uses: actions/checkout@v3
@@ -102,7 +102,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        dotnet: ['5.0', '6.0']
+        dotnet: ['6.0']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout TileDB-CSharp repository

--- a/examples/TileDB.CSharp.Example/TileDB.CSharp.Example.csproj
+++ b/examples/TileDB.CSharp.Example/TileDB.CSharp.Example.csproj
@@ -5,7 +5,7 @@
     <RollForward>Major</RollForward>
     <RollForward>Major</RollForward>
     <RootNamespace>TileDB.CSharp.Examples</RootNamespace>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>5.2.4</Version>
   </PropertyGroup>
 

--- a/examples/bindings/quickstart_sparse_string/quickstart_sparse_string.csproj
+++ b/examples/bindings/quickstart_sparse_string/quickstart_sparse_string.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
     <RollForward>Major</RollForward>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Version>5.2.4</Version>
   </PropertyGroup>
 

--- a/scripts/GenerateBindings/GenerateBindings.csproj
+++ b/scripts/GenerateBindings/GenerateBindings.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
+++ b/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <RollForward>Major</RollForward>
     <RootNamespace>TileDB.CSharp.Test</RootNamespace>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET 5 has been unsupported since May 2022. This PR stops running CI in it, and retargets test and sample projects to .NET 6 instead.

I did not immediately retarget the main library projects but can do so as well.