### PR TITLE
Fix `SonarAnalyzer.CSharp` not running.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,8 @@
   <ItemGroup>
     <PackageReference
       Include="SonarAnalyzer.CSharp"
-      Version="8.35.0.42613"
+      Version="8.46.0.54807"
       PrivateAssets="all"
-      Condition="$(MSBuildProjectExtension) == '.csproj'"
     />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
To be automatically imported by `MSBuild`, the property file has to be named `Directory.Build.props` instead of `Default.Build.props`. I fixed it, and also updated the analyzer to its latest version.