### PR TITLE
Improve the bindings generation process and regenerate them.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "clangsharppinvokegenerator": {
+      "version": "15.0.1",
+      "commands": [
+        "ClangSharpPInvokeGenerator"
+      ]
+    }
+  }
+}

--- a/scripts/generate/README.md
+++ b/scripts/generate/README.md
@@ -6,15 +6,16 @@ Note: prerequisite installation instructions below if needed.
 export DYLD_LIBRARY_PATH=/path/to/libclang/runtimes/osx-x64/native/
 export TILEDB_DIR=/path/to/TileDB/dist
 
-ClangSharpPInvokeGenerator -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include  -I $TILEDB_DIR/include/ --file $TILEDB_DIR/include/tiledb/tiledb.h $TILEDB_DIR/include/tiledb/tiledb_experimental.h @scripts/generate/generate.rsp -l tiledb
+dotnet tool restore
+dotnet ClangSharpPInvokeGenerator -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include  -I $TILEDB_DIR/include/ --file $TILEDB_DIR/include/tiledb/tiledb.h $TILEDB_DIR/include/tiledb/tiledb_experimental.h @scripts/generate/generate.rsp -l tiledb
 ```
 
 ## Generated on windows (copy tiledb_export.h to tiledb/sm/c_api):
 
 ```
-dotnet tool install --global ClangSharpPInvokeGenerator --version 13.0.0-beta1
+dotnet tool restore
 cd tildb/sm/c_api
-ClangSharpPInvokeGenerator -n TileDB.Interop  -f tiledb.h tiledb_experimental.h -c latest-codegen unix-types multi-file generate-helper-types --methodClassName Methods  -l tiledb   --output sources/TileDB.Interop
+dotnet ClangSharpPInvokeGenerator -n TileDB.Interop  -f tiledb.h tiledb_experimental.h -c latest-codegen unix-types multi-file generate-helper-types --methodClassName Methods -l tiledb --output sources/TileDB.Interop
 ```
 
 ## Replacements in LibTileDB.cs

--- a/scripts/generate/README.md
+++ b/scripts/generate/README.md
@@ -7,7 +7,7 @@ export DYLD_LIBRARY_PATH=/path/to/libclang/runtimes/osx-x64/native/
 export TILEDB_DIR=/path/to/TileDB/dist
 
 dotnet tool restore
-dotnet ClangSharpPInvokeGenerator -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include  -I $TILEDB_DIR/include/ --file $TILEDB_DIR/include/tiledb/tiledb.h $TILEDB_DIR/include/tiledb/tiledb_experimental.h @scripts/generate/generate.rsp -l tiledb
+dotnet ClangSharpPInvokeGenerator -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I $TILEDB_DIR/include/ --file $TILEDB_DIR/include/tiledb/tiledb.h $TILEDB_DIR/include/tiledb/tiledb_experimental.h @scripts/generate/generate.rsp
 ```
 
 ## Generated on windows (copy tiledb_export.h to tiledb/sm/c_api):
@@ -15,12 +15,8 @@ dotnet ClangSharpPInvokeGenerator -I /Library/Developer/CommandLineTools/SDKs/Ma
 ```
 dotnet tool restore
 cd tildb/sm/c_api
-dotnet ClangSharpPInvokeGenerator -n TileDB.Interop  -f tiledb.h tiledb_experimental.h -c latest-codegen unix-types multi-file generate-helper-types --methodClassName Methods -l tiledb --output sources/TileDB.Interop
+dotnet ClangSharpPInvokeGenerator -n TileDB.Interop -f tiledb.h tiledb_experimental.h @scripts/generate/generate.rsp
 ```
-
-## Replacements in LibTileDB.cs
-
-1. Comment all  *_dump functions,
 
 # Generator Installation
 

--- a/scripts/generate/README.md
+++ b/scripts/generate/README.md
@@ -2,7 +2,7 @@
 
 Note: prerequisite installation instructions below if needed.
 
-```
+```sh
 export DYLD_LIBRARY_PATH=/path/to/libclang/runtimes/osx-x64/native/
 export TILEDB_DIR=/path/to/TileDB/dist
 
@@ -10,12 +10,15 @@ dotnet tool restore
 dotnet ClangSharpPInvokeGenerator -I /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include -I $TILEDB_DIR/include/ --file $TILEDB_DIR/include/tiledb/tiledb.h $TILEDB_DIR/include/tiledb/tiledb_experimental.h @scripts/generate/generate.rsp
 ```
 
-## Generated on windows (copy tiledb_export.h to tiledb/sm/c_api):
+## Generating on Windows (PowerShell):
 
-```
+We assume that the TileDB Core repository is in the same folder with the C# repository's folder, and has been installed.
+
+```powershell
+$TILEDB_DIR=..\TileDB\dist\
+
 dotnet tool restore
-cd tildb/sm/c_api
-dotnet ClangSharpPInvokeGenerator -n TileDB.Interop -f tiledb.h tiledb_experimental.h @scripts/generate/generate.rsp
+dotnet ClangSharpPInvokeGenerator -f $TILEDB_DIR\include\tiledb\tiledb.h $TILEDB_DIR\include\tiledb\tiledb_experimental.h -I $TILEDB_DIR\include\ "@.\scripts\generate\generate.rsp"
 ```
 
 # Generator Installation

--- a/scripts/generate/generate.rsp
+++ b/scripts/generate/generate.rsp
@@ -9,3 +9,15 @@ Methods
 TileDB.Interop
 --output
 sources/TileDB.Interop
+--exclude
+tiledb_attribute_dump
+tiledb_domain_dump
+tiledb_dimension_dump
+tiledb_array_schema_dump
+tiledb_stats_dump
+tiledb_stats_raw_dump
+tiledb_fragment_info_dump
+tiledb_status
+--remap
+tiledb_experimental_query_status_details_t=tiledb_query_status_details_t
+-ltiledb

--- a/sources/TileDB.CSharp/File.cs
+++ b/sources/TileDB.CSharp/File.cs
@@ -11,12 +11,12 @@ namespace TileDB.CSharp
     public sealed unsafe class File
     {
         private readonly Context _ctx;
-        
+
         public File(Context ctx)
         {
             _ctx = ctx;
         }
-        
+
         public ArraySchema SchemaCreate(string uri)
         {
             var ms_uri = new MarshaledString(uri);
@@ -28,7 +28,7 @@ namespace TileDB.CSharp
             }
             return new ArraySchema(_ctx,array_schema_p);
         }
-        
+
         public void URIImport(string arrayURI, string fileURI, MIMEType mimeType)
         {
             var ms_arrayURI = new MarshaledString(arrayURI);
@@ -36,7 +36,7 @@ namespace TileDB.CSharp
             var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
             _ctx.handle_error(Methods.tiledb_filestore_uri_import(_ctx.Handle, ms_arrayURI, ms_fileURI, tiledb_mime_type));
         }
-        
+
         public void URIExport(string fileURI, string arrayURI)
         {
             var ms_fileURI = new MarshaledString(fileURI);
@@ -44,50 +44,50 @@ namespace TileDB.CSharp
             _ctx.handle_error(Methods.tiledb_filestore_uri_export(_ctx.Handle, ms_fileURI, ms_arrayURI));
         }
 
-        public void BufferImport<T>(string arrayURI, T value, ulong size, MIMEType mimeType) where T: struct
+        public void BufferImport<T>(string arrayURI, T value, nuint size, MIMEType mimeType) where T: struct
         {
             var ms_arrayURI = new MarshaledString(arrayURI);
             var data = new[] { value };
             var dataGcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
             _ctx.handle_error(Methods.tiledb_filestore_buffer_import(
-                _ctx.Handle, 
-                ms_arrayURI, 
+                _ctx.Handle,
+                ms_arrayURI,
                 (void*)dataGcHandle.AddrOfPinnedObject(),
                 size,
                 tiledb_mime_type));
         }
-        
-        public T BufferExport<T>(string arrayURI, ulong offset, ulong size) where T: struct
+
+        public T BufferExport<T>(string arrayURI, nuint offset, nuint size) where T: struct
         {
             var ms_arrayURI = new MarshaledString(arrayURI);
             var data = new T[1];
             var dataGcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             _ctx.handle_error(Methods.tiledb_filestore_buffer_export(
-                _ctx.Handle, 
-                ms_arrayURI, 
+                _ctx.Handle,
+                ms_arrayURI,
                 offset,
                 (void*)dataGcHandle.AddrOfPinnedObject(),
                 size));
-            
+
             var result = data[0];
             dataGcHandle.Free();
 
             return result;
         }
-        
+
         public ulong Size(string arrayURI)
         {
             var ms_arrayURI = new MarshaledString(arrayURI);
-            ulong size;
+            nuint size;
             _ctx.handle_error(Methods.tiledb_filestore_size(
-                _ctx.Handle, 
+                _ctx.Handle,
                 ms_arrayURI,
                 &size));
 
             return size;
         }
-        
+
         public string MIMETypeToStr(MIMEType mimeType)
         {
             var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
@@ -96,18 +96,18 @@ namespace TileDB.CSharp
             {
                 Methods.tiledb_mime_type_to_str(tiledb_mime_type, p_result);
             }
-            
+
             return ms_result;
         }
-        
+
         public MIMEType MIMETypeFromStr(string str)
         {
             tiledb_mime_type_t mimeType;
             var ms_str = new MarshaledString(str);
-            
+
             unsafe
             {
-                int status = TileDB.Interop.Methods.tiledb_mime_type_from_str(ms_str, &mimeType); 
+                int status = TileDB.Interop.Methods.tiledb_mime_type_from_str(ms_str, &mimeType);
                 if (status != (int)Status.TILEDB_OK)
                 {
                     throw new System.ArgumentException("MIMETypeFromStr, Invalid string:" + str);

--- a/sources/TileDB.Interop/InteropAux.cs
+++ b/sources/TileDB.Interop/InteropAux.cs
@@ -1,7 +1,0 @@
-namespace TileDB.Interop
-{
-    // placeholder struct to avoid errors loading generated code
-    public partial struct __sFILE
-    {
-    }
-}

--- a/sources/TileDB.Interop/Methods.cs
+++ b/sources/TileDB.Interop/Methods.cs
@@ -1,13 +1,10 @@
+using System;
 using System.Runtime.InteropServices;
 
 namespace TileDB.Interop
 {
     public static unsafe partial class Methods
     {
-        [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, EntryPoint = "_Z13tiledb_statusi", ExactSpelling = true)]
-        [return: NativeTypeName("capi_status_t")]
-        public static extern int tiledb_status([NativeTypeName("capi_return_t")] int x);
-
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_query_type_to_str(tiledb_query_type_t query_type, [NativeTypeName("const char **")] sbyte** str);
@@ -106,6 +103,7 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("const char *")]
+        [Obsolete]
         public static extern sbyte* tiledb_coords();
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -275,6 +273,7 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_group_create(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* group_uri);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -366,10 +365,6 @@ namespace TileDB.Interop
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_attribute_get_cell_size(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_attribute_t *")] tiledb_attribute_t* attr, [NativeTypeName("uint64_t *")] ulong* cell_size);
 
-        // [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        // [return: NativeTypeName("int32_t")]
-        // public static extern int tiledb_attribute_dump(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_attribute_t *")] tiledb_attribute_t* attr, [NativeTypeName("FILE *")] _IO_FILE* @out);
-
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_attribute_set_fill_value(tiledb_ctx_t* ctx, tiledb_attribute_t* attr, [NativeTypeName("const void *")] void* value, [NativeTypeName("uint64_t")] ulong size);
@@ -417,10 +412,6 @@ namespace TileDB.Interop
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_domain_has_dimension(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_domain_t *")] tiledb_domain_t* domain, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("int32_t *")] int* has_dim);
 
-        // [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        // [return: NativeTypeName("int32_t")]
-        // public static extern int tiledb_domain_dump(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_domain_t *")] tiledb_domain_t* domain, [NativeTypeName("FILE *")] _IO_FILE* @out);
-
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_dimension_alloc(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* name, tiledb_datatype_t type, [NativeTypeName("const void *")] void* dim_domain, [NativeTypeName("const void *")] void* tile_extent, tiledb_dimension_t** dim);
@@ -459,10 +450,6 @@ namespace TileDB.Interop
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_dimension_get_tile_extent(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_dimension_t *")] tiledb_dimension_t* dim, [NativeTypeName("const void **")] void** tile_extent);
-
-        // [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        // [return: NativeTypeName("int32_t")]
-        // public static extern int tiledb_dimension_dump(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_dimension_t *")] tiledb_dimension_t* dim, [NativeTypeName("FILE *")] _IO_FILE* @out);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
@@ -525,6 +512,7 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_array_schema_load_with_key(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* array_uri, tiledb_encryption_type_t encryption_type, [NativeTypeName("const void *")] void* encryption_key, [NativeTypeName("uint32_t")] uint key_length, tiledb_array_schema_t** array_schema);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -575,10 +563,6 @@ namespace TileDB.Interop
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_array_schema_has_attribute(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_array_schema_t *")] tiledb_array_schema_t* array_schema, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("int32_t *")] int* has_attr);
 
-        // [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        // [return: NativeTypeName("int32_t")]
-        // public static extern int tiledb_array_schema_dump(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_array_schema_t *")] tiledb_array_schema_t* array_schema, [NativeTypeName("FILE *")] _IO_FILE* @out);
-
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_query_alloc(tiledb_ctx_t* ctx, tiledb_array_t* array, tiledb_query_type_t query_type, tiledb_query_t** query);
@@ -597,6 +581,7 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_set_subarray(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const void *")] void* subarray);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -605,18 +590,22 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_set_buffer(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* name, void* buffer, [NativeTypeName("uint64_t *")] ulong* buffer_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_set_buffer_var(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("uint64_t *")] ulong* buffer_off, [NativeTypeName("uint64_t *")] ulong* buffer_off_size, void* buffer_val, [NativeTypeName("uint64_t *")] ulong* buffer_val_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_set_buffer_nullable(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* name, void* buffer, [NativeTypeName("uint64_t *")] ulong* buffer_size, [NativeTypeName("uint8_t *")] byte* buffer_validity_bytemap, [NativeTypeName("uint64_t *")] ulong* buffer_validity_bytemap_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_set_buffer_var_nullable(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("uint64_t *")] ulong* buffer_off, [NativeTypeName("uint64_t *")] ulong* buffer_off_size, void* buffer_val, [NativeTypeName("uint64_t *")] ulong* buffer_val_size, [NativeTypeName("uint8_t *")] byte* buffer_validity_bytemap, [NativeTypeName("uint64_t *")] ulong* buffer_validity_bytemap_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -633,18 +622,22 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_buffer(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* name, void** buffer, [NativeTypeName("uint64_t **")] ulong** buffer_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_buffer_var(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("uint64_t **")] ulong** buffer_off, [NativeTypeName("uint64_t **")] ulong** buffer_off_size, void** buffer_val, [NativeTypeName("uint64_t **")] ulong** buffer_val_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_buffer_nullable(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* name, void** buffer, [NativeTypeName("uint64_t **")] ulong** buffer_size, [NativeTypeName("uint8_t **")] byte** buffer_validity_bytemap, [NativeTypeName("uint64_t **")] ulong** buffer_validity_bytemap_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_buffer_var_nullable(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* name, [NativeTypeName("uint64_t **")] ulong** buffer_off, [NativeTypeName("uint64_t **")] ulong** buffer_off_size, void** buffer_val, [NativeTypeName("uint64_t **")] ulong** buffer_val_size, [NativeTypeName("uint8_t **")] byte** buffer_validity_bytemap, [NativeTypeName("uint64_t **")] ulong** buffer_validity_bytemap_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -704,50 +697,62 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_add_range(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("uint32_t")] uint dim_idx, [NativeTypeName("const void *")] void* start, [NativeTypeName("const void *")] void* end, [NativeTypeName("const void *")] void* stride);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_add_range_by_name(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* dim_name, [NativeTypeName("const void *")] void* start, [NativeTypeName("const void *")] void* end, [NativeTypeName("const void *")] void* stride);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_add_range_var(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("uint32_t")] uint dim_idx, [NativeTypeName("const void *")] void* start, [NativeTypeName("uint64_t")] ulong start_size, [NativeTypeName("const void *")] void* end, [NativeTypeName("uint64_t")] ulong end_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_add_range_var_by_name(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* dim_name, [NativeTypeName("const void *")] void* start, [NativeTypeName("uint64_t")] ulong start_size, [NativeTypeName("const void *")] void* end, [NativeTypeName("uint64_t")] ulong end_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_range_num(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_query_t *")] tiledb_query_t* query, [NativeTypeName("uint32_t")] uint dim_idx, [NativeTypeName("uint64_t *")] ulong* range_num);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_range_num_from_name(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_query_t *")] tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* dim_name, [NativeTypeName("uint64_t *")] ulong* range_num);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_range(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_query_t *")] tiledb_query_t* query, [NativeTypeName("uint32_t")] uint dim_idx, [NativeTypeName("uint64_t")] ulong range_idx, [NativeTypeName("const void **")] void** start, [NativeTypeName("const void **")] void** end, [NativeTypeName("const void **")] void** stride);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_range_from_name(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_query_t *")] tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* dim_name, [NativeTypeName("uint64_t")] ulong range_idx, [NativeTypeName("const void **")] void** start, [NativeTypeName("const void **")] void** end, [NativeTypeName("const void **")] void** stride);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_range_var_size(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_query_t *")] tiledb_query_t* query, [NativeTypeName("uint32_t")] uint dim_idx, [NativeTypeName("uint64_t")] ulong range_idx, [NativeTypeName("uint64_t *")] ulong* start_size, [NativeTypeName("uint64_t *")] ulong* end_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_range_var_size_from_name(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_query_t *")] tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* dim_name, [NativeTypeName("uint64_t")] ulong range_idx, [NativeTypeName("uint64_t *")] ulong* start_size, [NativeTypeName("uint64_t *")] ulong* end_size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_range_var(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_query_t *")] tiledb_query_t* query, [NativeTypeName("uint32_t")] uint dim_idx, [NativeTypeName("uint64_t")] ulong range_idx, void* start, void* end);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_get_range_var_from_name(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_query_t *")] tiledb_query_t* query, [NativeTypeName("const char *")] sbyte* dim_name, [NativeTypeName("uint64_t")] ulong range_idx, void* start, void* end);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -890,14 +895,17 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_array_open_at(tiledb_ctx_t* ctx, tiledb_array_t* array, tiledb_query_type_t query_type, [NativeTypeName("uint64_t")] ulong timestamp);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_array_open_with_key(tiledb_ctx_t* ctx, tiledb_array_t* array, tiledb_query_type_t query_type, tiledb_encryption_type_t encryption_type, [NativeTypeName("const void *")] void* encryption_key, [NativeTypeName("uint32_t")] uint key_length);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_array_open_at_with_key(tiledb_ctx_t* ctx, tiledb_array_t* array, tiledb_query_type_t query_type, tiledb_encryption_type_t encryption_type, [NativeTypeName("const void *")] void* encryption_key, [NativeTypeName("uint32_t")] uint key_length, [NativeTypeName("uint64_t")] ulong timestamp);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -910,10 +918,12 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_array_reopen_at(tiledb_ctx_t* ctx, tiledb_array_t* array, [NativeTypeName("uint64_t")] ulong timestamp);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_array_get_timestamp(tiledb_ctx_t* ctx, tiledb_array_t* array, [NativeTypeName("uint64_t *")] ulong* timestamp);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -945,6 +955,7 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_array_create_with_key(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* array_uri, [NativeTypeName("const tiledb_array_schema_t *")] tiledb_array_schema_t* array_schema, tiledb_encryption_type_t encryption_type, [NativeTypeName("const void *")] void* encryption_key, [NativeTypeName("uint32_t")] uint key_length);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -953,6 +964,7 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_array_consolidate_with_key(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* array_uri, tiledb_encryption_type_t encryption_type, [NativeTypeName("const void *")] void* encryption_key, [NativeTypeName("uint32_t")] uint key_length, tiledb_config_t* config);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -1021,10 +1033,12 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_array_consolidate_metadata(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* array_uri, tiledb_config_t* config);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_array_consolidate_metadata_with_key(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* array_uri, tiledb_encryption_type_t encryption_type, [NativeTypeName("const void *")] void* encryption_key, [NativeTypeName("uint32_t")] uint key_length, tiledb_config_t* config);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -1173,17 +1187,9 @@ namespace TileDB.Interop
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_stats_reset();
 
-        // [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        // [return: NativeTypeName("int32_t")]
-        // public static extern int tiledb_stats_dump([NativeTypeName("FILE *")] _IO_FILE* @out);
-
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_stats_dump_str([NativeTypeName("char **")] sbyte** @out);
-
-        // [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        // [return: NativeTypeName("int32_t")]
-        // public static extern int tiledb_stats_raw_dump([NativeTypeName("FILE *")] _IO_FILE* @out);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
@@ -1214,6 +1220,7 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_fragment_info_load_with_key(tiledb_ctx_t* ctx, tiledb_fragment_info_t* fragment_info, tiledb_encryption_type_t encryption_type, [NativeTypeName("const void *")] void* encryption_key, [NativeTypeName("uint32_t")] uint key_length);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -1328,10 +1335,6 @@ namespace TileDB.Interop
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_fragment_info_get_array_schema_name(tiledb_ctx_t* ctx, tiledb_fragment_info_t* fragment_info, [NativeTypeName("uint32_t")] uint fid, [NativeTypeName("const char **")] sbyte** schema_name);
 
-        // [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
-        // [return: NativeTypeName("int32_t")]
-        // public static extern int tiledb_fragment_info_dump(tiledb_ctx_t* ctx, [NativeTypeName("const tiledb_fragment_info_t *")] tiledb_fragment_info_t* fragment_info, [NativeTypeName("FILE *")] _IO_FILE* @out);
-
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
         public static extern int tiledb_array_schema_evolution_alloc(tiledb_ctx_t* ctx, tiledb_array_schema_evolution_t** array_schema_evolution);
@@ -1369,6 +1372,7 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
+        [Obsolete]
         public static extern int tiledb_query_add_point_ranges(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("uint32_t")] uint dim_idx, [NativeTypeName("const void *")] void* start, [NativeTypeName("uint64_t")] ulong count);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
@@ -1377,7 +1381,7 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
-        public static extern int tiledb_query_get_status_details(tiledb_ctx_t* ctx, tiledb_query_t* query, [NativeTypeName("tiledb_query_status_details_t *")] tiledb_experimental_query_status_details_t* status);
+        public static extern int tiledb_query_get_status_details(tiledb_ctx_t* ctx, tiledb_query_t* query, tiledb_query_status_details_t* status);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
@@ -1492,15 +1496,15 @@ namespace TileDB.Interop
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
-        public static extern int tiledb_filestore_buffer_import(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* filestore_array_uri, void* buf, [NativeTypeName("size_t")] ulong size, tiledb_mime_type_t mime_type);
+        public static extern int tiledb_filestore_buffer_import(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* filestore_array_uri, void* buf, [NativeTypeName("size_t")] nuint size, tiledb_mime_type_t mime_type);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
-        public static extern int tiledb_filestore_buffer_export(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* filestore_array_uri, [NativeTypeName("size_t")] ulong offset, void* buf, [NativeTypeName("size_t")] ulong size);
+        public static extern int tiledb_filestore_buffer_export(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* filestore_array_uri, [NativeTypeName("size_t")] nuint offset, void* buf, [NativeTypeName("size_t")] nuint size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]
-        public static extern int tiledb_filestore_size(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* filestore_array_uri, [NativeTypeName("size_t *")] ulong* size);
+        public static extern int tiledb_filestore_size(tiledb_ctx_t* ctx, [NativeTypeName("const char *")] sbyte* filestore_array_uri, [NativeTypeName("size_t *")] nuint* size);
 
         [DllImport("tiledb", CallingConvention = CallingConvention.Cdecl, ExactSpelling = true)]
         [return: NativeTypeName("int32_t")]

--- a/sources/TileDB.Interop/MethodsExperimental.cs
+++ b/sources/TileDB.Interop/MethodsExperimental.cs
@@ -1,8 +1,0 @@
-using System.Runtime.InteropServices;
-
-namespace TileDB.Interop
-{
-    public static unsafe partial class Methods
-    {
-    }
-}

--- a/sources/TileDB.Interop/tiledb_array_type_t.cs
+++ b/sources/TileDB.Interop/tiledb_array_type_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_array_type_t : uint
+    public enum tiledb_array_type_t
     {
         TILEDB_DENSE = 0,
         TILEDB_SPARSE = 1,

--- a/sources/TileDB.Interop/tiledb_datatype_t.cs
+++ b/sources/TileDB.Interop/tiledb_datatype_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_datatype_t : uint
+    public enum tiledb_datatype_t
     {
         TILEDB_INT32 = 0,
         TILEDB_INT64 = 1,

--- a/sources/TileDB.Interop/tiledb_encryption_type_t.cs
+++ b/sources/TileDB.Interop/tiledb_encryption_type_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_encryption_type_t : uint
+    public enum tiledb_encryption_type_t
     {
         TILEDB_NO_ENCRYPTION = 0,
         TILEDB_AES_256_GCM = 1,

--- a/sources/TileDB.Interop/tiledb_experimental_query_status_details_t.cs
+++ b/sources/TileDB.Interop/tiledb_experimental_query_status_details_t.cs
@@ -1,7 +1,0 @@
-namespace TileDB.Interop
-{
-    public partial struct tiledb_experimental_query_status_details_t
-    {
-        public tiledb_query_status_details_reason_t incomplete_reason;
-    }
-}

--- a/sources/TileDB.Interop/tiledb_filesystem_t.cs
+++ b/sources/TileDB.Interop/tiledb_filesystem_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_filesystem_t : uint
+    public enum tiledb_filesystem_t
     {
         TILEDB_HDFS = 0,
         TILEDB_S3 = 1,

--- a/sources/TileDB.Interop/tiledb_filter_option_t.cs
+++ b/sources/TileDB.Interop/tiledb_filter_option_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_filter_option_t : uint
+    public enum tiledb_filter_option_t
     {
         TILEDB_COMPRESSION_LEVEL = 0,
         TILEDB_BIT_WIDTH_MAX_WINDOW = 1,

--- a/sources/TileDB.Interop/tiledb_filter_type_t.cs
+++ b/sources/TileDB.Interop/tiledb_filter_type_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_filter_type_t : uint
+    public enum tiledb_filter_type_t
     {
         TILEDB_FILTER_NONE = 0,
         TILEDB_FILTER_GZIP = 1,

--- a/sources/TileDB.Interop/tiledb_layout_t.cs
+++ b/sources/TileDB.Interop/tiledb_layout_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_layout_t : uint
+    public enum tiledb_layout_t
     {
         TILEDB_ROW_MAJOR = 0,
         TILEDB_COL_MAJOR = 1,

--- a/sources/TileDB.Interop/tiledb_mime_type_t.cs
+++ b/sources/TileDB.Interop/tiledb_mime_type_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_mime_type_t : uint
+    public enum tiledb_mime_type_t
     {
         TILEDB_MIME_AUTODETECT = 0,
         TILEDB_MIME_TIFF = 1,

--- a/sources/TileDB.Interop/tiledb_object_t.cs
+++ b/sources/TileDB.Interop/tiledb_object_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_object_t : uint
+    public enum tiledb_object_t
     {
         TILEDB_INVALID = 0,
         TILEDB_GROUP = 1,

--- a/sources/TileDB.Interop/tiledb_query_condition_combination_op_t.cs
+++ b/sources/TileDB.Interop/tiledb_query_condition_combination_op_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_query_condition_combination_op_t : uint
+    public enum tiledb_query_condition_combination_op_t
     {
         TILEDB_AND = 0,
         TILEDB_OR = 1,

--- a/sources/TileDB.Interop/tiledb_query_condition_op_t.cs
+++ b/sources/TileDB.Interop/tiledb_query_condition_op_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_query_condition_op_t : uint
+    public enum tiledb_query_condition_op_t
     {
         TILEDB_LT = 0,
         TILEDB_LE = 1,

--- a/sources/TileDB.Interop/tiledb_query_status_details_reason_t.cs
+++ b/sources/TileDB.Interop/tiledb_query_status_details_reason_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_query_status_details_reason_t : uint
+    public enum tiledb_query_status_details_reason_t
     {
         TILEDB_REASON_NONE = 0,
         TILEDB_REASON_USER_BUFFER_SIZE = 1,

--- a/sources/TileDB.Interop/tiledb_query_status_t.cs
+++ b/sources/TileDB.Interop/tiledb_query_status_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_query_status_t : uint
+    public enum tiledb_query_status_t
     {
         TILEDB_FAILED = 0,
         TILEDB_COMPLETED = 1,

--- a/sources/TileDB.Interop/tiledb_query_type_t.cs
+++ b/sources/TileDB.Interop/tiledb_query_type_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_query_type_t : uint
+    public enum tiledb_query_type_t
     {
         TILEDB_READ = 0,
         TILEDB_WRITE = 1,

--- a/sources/TileDB.Interop/tiledb_vfs_mode_t.cs
+++ b/sources/TileDB.Interop/tiledb_vfs_mode_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_vfs_mode_t : uint
+    public enum tiledb_vfs_mode_t
     {
         TILEDB_VFS_READ = 0,
         TILEDB_VFS_WRITE = 1,

--- a/sources/TileDB.Interop/tiledb_walk_order_t.cs
+++ b/sources/TileDB.Interop/tiledb_walk_order_t.cs
@@ -1,7 +1,6 @@
 namespace TileDB.Interop
 {
-    [NativeTypeName("unsigned int")]
-    public enum tiledb_walk_order_t : uint
+    public enum tiledb_walk_order_t
     {
         TILEDB_PREORDER = 0,
         TILEDB_POSTORDER = 1,


### PR DESCRIPTION
The bindings generation process has been streamlined in the following ways:

* `ClangSharpPInvokeGenerator` is installed as a local tool, ensuring we are in a common version. It was also updated to its latest one.
* Additional arguments have been passed to the generator such that we no longer need to manually edit `Methods.cs` afterwards. These arguments were also placed in `generate.rsp`.
* After these changes, the bindings were regenerated, with some breaking changes. I can't explain them, they also manifested with version 13.0.0-beta1 of the generator. But the previous versions were wrong. `size_t` maps to `nuint` in C# and not `ulong`, and nothing implied that enums are unsigned.