### PR TITLE
Fix race condition in `Query.SubmitAsync()`.

### DIFF
--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using TileDB.CSharp.Marshalling.SafeHandles;
@@ -124,9 +125,6 @@ namespace TileDB.CSharp
         private Dictionary<string, BufferHandle> _dataBufferHandles = new Dictionary<string, BufferHandle>();
         private Dictionary<string, BufferHandle> _offsetsBufferHandles = new Dictionary<string, BufferHandle>();
         private Dictionary<string, BufferHandle> _validityBufferHandles = new Dictionary<string, BufferHandle>();
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        private delegate void QueryCallbackDelegate(IntPtr ptr);
 
         public Query(Context ctx, Array array, QueryType queryType)
         {
@@ -379,25 +377,15 @@ namespace TileDB.CSharp
             return QueryStatus.TILEDB_COMPLETED;
         }
 
-        /// <summary>
-        /// Callback function on query completed.
-        /// </summary>
-        /// <param name="ptr"></param>
-        private void QueryCallback(IntPtr ptr)
+        [UnmanagedCallersOnly(CallConvs = new [] {typeof(CallConvCdecl)})]
+        private static void QueryCallback(void* ptr)
         {
+            GCHandle gcHandle = GCHandle.FromIntPtr((IntPtr)ptr);
+            var query = (Query)gcHandle.Target!;
+            gcHandle.Free();
             //fire event
             var args = new QueryEventArgs((int)QueryStatus.TILEDB_COMPLETED, "query completed");
-            OnQueryCompleted(args);
-        }
-
-        private void OnQueryCompleted(QueryEventArgs args)
-        {
-            var handler = QueryCompleted;
-            if (handler != null)
-            {
-                handler(this, args); //fire the event
-            }
-
+            query.QueryCompleted?.Invoke(query, args);
         }
 
         /// <summary>
@@ -405,10 +393,22 @@ namespace TileDB.CSharp
         /// </summary>
         public void SubmitAsync()
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            QueryCallbackDelegate  callback = new QueryCallbackDelegate(QueryCallback);
-            _ctx.handle_error(Methods.tiledb_query_submit_async(ctxHandle, handle, (delegate* unmanaged[Cdecl]< void *, void > )Marshal.GetFunctionPointerForDelegate<QueryCallbackDelegate>(callback), null));
+            GCHandle gcHandle = GCHandle.Alloc(this);
+            bool successful = false;
+            try
+            {
+                using var ctxHandle = _ctx.Handle.Acquire();
+                using var handle = _handle.Acquire();
+                _ctx.handle_error(Methods.tiledb_query_submit_async(ctxHandle, handle, &QueryCallback, (void*)GCHandle.ToIntPtr(gcHandle)));
+                successful = true;
+            }
+            finally
+            {
+                if (!successful)
+                {
+                    gcHandle.Free();
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
The implementation of `Query.SubmitAsync()` had a race condition. According to the documentation of [`Marshal.GetFunctionPointerForDelegate`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.getfunctionpointerfordelegate) _"You must manually keep the delegate from being collected by the garbage collector from managed code. The garbage collector does not track references to unmanaged code."_. We did not that, and if the garbage collector collects the delegate in the middle of an asynchronous query, by the time the native code calls the callback, it will be gone, and (I think) the process will crash.

This PR fixes the problem in two ways. First we mark the C# callback function with [`[UnmanagedCallersOnly]`](https://devblogs.microsoft.com/dotnet/improvements-in-native-code-interop-in-net-5-0/#unmanagedcallersonly), allowing us to directly pass the function's pointer to native code without allocating a delegate. Second we ensure that the `Query` object remains alive during the asynchronous query, by allocating a `GCHandle`, and passing it as the `callback_data` parameter to `tiledb_query_submit_async`.