### PR TITLE
Make `Query.SubmitAsync` return `ValueTask`.

### DIFF
--- a/examples/TileDB.CSharp.Example/ExampleIncompleteQuery.cs
+++ b/examples/TileDB.CSharp.Example/ExampleIncompleteQuery.cs
@@ -69,14 +69,14 @@ namespace TileDB.CSharp.Examples
             }
         }
 
-        static void ReadArray()
+        static async Task ReadArrayAsync()
         {
             // Allocate buffers for 10 values per batch read
             var rowsRead = new int[10];
             var colsRead = new int[10];
             var attrRead = new int[10];
 
-            using (var arrayRead = new Array(ctx, arrayName))
+            using (var arrayRead = new Array(Ctx, ArrayPath))
             {
                 arrayRead.Open(QueryType.Read);
                 var queryRead = new Query(Ctx, arrayRead);
@@ -111,9 +111,9 @@ namespace TileDB.CSharp.Examples
 
         public static async Task RunAsync()
         {
-             if (Directory.Exists(arrayName))
+             if (Directory.Exists(ArrayPath))
              {
-                 Directory.Delete(arrayName, true);
+                 Directory.Delete(ArrayPath, true);
              }
 
             CreateArray();

--- a/examples/TileDB.CSharp.Example/ExampleIncompleteQueryStringDimensions.cs
+++ b/examples/TileDB.CSharp.Example/ExampleIncompleteQueryStringDimensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace TileDB.CSharp.Examples
 {
@@ -29,7 +30,7 @@ namespace TileDB.CSharp.Examples
             Array.Create(Ctx, ArrayPath, schema);
         }
 
-        private static void WriteArray()
+        static async Task WriteArrayAsync()
         {
             var rowsData = Encoding.ASCII.GetBytes("abbcccddddeeeee");
             var colsData = Encoding.ASCII.GetBytes("jjjjjiiiihhhggf");
@@ -50,14 +51,14 @@ namespace TileDB.CSharp.Examples
                 queryWrite.SetDataBuffer("cols", colsData);
                 queryWrite.SetOffsetsBuffer("cols", colsOffsets);
                 queryWrite.SetDataBuffer("a1", attrData);
-                queryWrite.Submit();
+                await queryWrite.SubmitAsync();
 
                 Console.WriteLine($"Write query status: {queryWrite.Status()}");
                 arrayWrite.Close();
             }
         }
 
-        private static void ReadArray()
+        static async Task ReadArrayAsync()
         {
             using (var arrayRead = new Array(Ctx, ArrayPath))
             {
@@ -83,7 +84,7 @@ namespace TileDB.CSharp.Examples
                 int batchNum = 1;
                 do
                 {
-                    queryRead.Submit();
+                    await queryRead.SubmitAsync();
                     var resultBufferElements = queryRead.ResultBufferElements();
 
                     var rowDataElements = (int)resultBufferElements["rows"].Item1;
@@ -134,7 +135,7 @@ namespace TileDB.CSharp.Examples
             }
         }
 
-        public static void Run()
+        public static async Task RunAsync()
         {
              if (Directory.Exists(ArrayPath))
              {
@@ -142,8 +143,8 @@ namespace TileDB.CSharp.Examples
              }
 
              CreateArray();
-             WriteArray();
-             ReadArray();
+             await WriteArrayAsync();
+             await ReadArrayAsync();
         }
     }
 }

--- a/examples/TileDB.CSharp.Example/ExampleQuery.cs
+++ b/examples/TileDB.CSharp.Example/ExampleQuery.cs
@@ -32,7 +32,7 @@ namespace TileDB.CSharp.Examples
             Array.Create(Ctx, ArrayPath, array_schema);
         }
 
-        protected static void WriteArray()
+        private static async Task WriteArrayAsync()
         {
             var dim1_data_buffer = new int[3] { 1, 2, 3 };
             var dim2_data_buffer = new int[3] { 1, 3, 4 };
@@ -46,12 +46,12 @@ namespace TileDB.CSharp.Examples
                 query_write.SetDataBuffer("rows", dim1_data_buffer);
                 query_write.SetDataBuffer("cols", dim2_data_buffer);
                 query_write.SetDataBuffer("a", attr_data_buffer);
-                query_write.Submit();
+                await query_write.SubmitAsync();
                 array_write.Close();
             }
         }
 
-        private static void ReadArray()
+        private static async Task ReadArrayAsync()
         {
             var dim1_data_buffer_read = new int[3];
             var dim2_data_buffer_read = new int[3];
@@ -65,29 +65,9 @@ namespace TileDB.CSharp.Examples
                 query_read.SetDataBuffer("rows", dim1_data_buffer_read);
                 query_read.SetDataBuffer("cols", dim2_data_buffer_read);
                 query_read.SetDataBuffer("a", attr_data_buffer_read);
-                query_read.Submit();
+                await query_read.SubmitAsync();
                 array_read.Close();
             }
-
-            Console.WriteLine("dim1:{0},{1},{2}", dim1_data_buffer_read[0], dim1_data_buffer_read[1], dim1_data_buffer_read[2]);
-            Console.WriteLine("dim2:{0},{1},{2}", dim2_data_buffer_read[0], dim2_data_buffer_read[1], dim2_data_buffer_read[2]);
-            Console.WriteLine("attr:{0},{1},{2}", attr_data_buffer_read[0], attr_data_buffer_read[1], attr_data_buffer_read[2]);
-        }
-
-        private static async Task ReadArrayAsync()
-        {
-            var dim1_data_buffer_read = new int[3];
-            var dim2_data_buffer_read = new int[3];
-            var attr_data_buffer_read = new int[3];
-
-            var array_read = new Array(Ctx, ArrayPath);
-            array_read.Open(QueryType.Read);
-            var query_read = new Query(Ctx, array_read);
-            query_read.SetLayout(LayoutType.RowMajor);
-            query_read.SetDataBuffer("rows", dim1_data_buffer_read);
-            query_read.SetDataBuffer("cols", dim2_data_buffer_read);
-            query_read.SetDataBuffer("a", attr_data_buffer_read);
-            await query_read.SubmitAsync();
 
             Console.WriteLine("dim1:{0},{1},{2}", dim1_data_buffer_read[0], dim1_data_buffer_read[1], dim1_data_buffer_read[2]);
             Console.WriteLine("dim2:{0},{1},{2}", dim2_data_buffer_read[0], dim2_data_buffer_read[1], dim2_data_buffer_read[2]);
@@ -102,8 +82,7 @@ namespace TileDB.CSharp.Examples
             }
 
             CreateArray();
-            WriteArray();
-            ReadArray();
+            await WriteArrayAsync();
             await ReadArrayAsync();
         }
     }

--- a/examples/TileDB.CSharp.Example/ExampleWritingDenseGlobal.cs
+++ b/examples/TileDB.CSharp.Example/ExampleWritingDenseGlobal.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace TileDB.CSharp.Examples
 {
@@ -24,7 +25,7 @@ namespace TileDB.CSharp.Examples
             Array.Create(Ctx, ArrayPath, schema);
         }
 
-        private static void WriteArray()
+        private static async Task WriteArrayAsync()
         {
             using var array = new Array(Ctx, ArrayPath);
             array.Open(QueryType.Write);
@@ -37,12 +38,12 @@ namespace TileDB.CSharp.Examples
 
             // Write 4 cells
             queryWrite.SetDataBuffer("a1", new[] { 1, 2, 3, 4 });
-            queryWrite.Submit();
+            await queryWrite.SubmitAsync();
             Console.WriteLine($"Write query #1 status: {queryWrite.Status()}");
 
             // Write 4 more cells before we finalize the query
             queryWrite.SetDataBuffer("a1", new[] { 5, 6, 7, 8});
-            queryWrite.Submit();
+            await queryWrite.SubmitAsync();
             Console.WriteLine($"Write query #2 status: {queryWrite.Status()}");
 
             // Important: Global order writes must call Query.FinalizeQuery()
@@ -50,7 +51,7 @@ namespace TileDB.CSharp.Examples
             array.Close();
         }
 
-        private static void ReadArray()
+        private static async Task ReadArrayAsync()
         {
             using var array = new Array(Ctx, ArrayPath);
             array.Open(QueryType.Read);
@@ -59,14 +60,14 @@ namespace TileDB.CSharp.Examples
 
             var a1Read = new int[16];
             readQuery.SetDataBuffer("a1", a1Read);
-            readQuery.Submit();
+            await readQuery.SubmitAsync();
             Console.WriteLine($"Read query status: {readQuery.Status()}");
             Console.WriteLine($"a1 data: {string.Join(", ", a1Read)}");
 
             array.Close();
         }
 
-        public static void Run()
+        public static async Task RunAsync()
         {
             if (Directory.Exists(ArrayPath))
             {
@@ -74,8 +75,8 @@ namespace TileDB.CSharp.Examples
             }
 
             CreateArray();
-            WriteArray();
-            ReadArray();
+            await WriteArrayAsync();
+            await ReadArrayAsync();
         }
     }
 }

--- a/examples/TileDB.CSharp.Example/ExampleWritingSparseGlobal.cs
+++ b/examples/TileDB.CSharp.Example/ExampleWritingSparseGlobal.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace TileDB.CSharp.Examples
 {
@@ -25,7 +26,7 @@ namespace TileDB.CSharp.Examples
             Array.Create(Ctx, ArrayPath, schema);
         }
 
-        private static void WriteArray()
+        private static async Task WriteArrayAsync()
         {
             using var array = new Array(Ctx, ArrayPath);
             array.Open(QueryType.Write);
@@ -38,14 +39,14 @@ namespace TileDB.CSharp.Examples
             queryWrite.SetDataBuffer("rows", new[] { 1, 2, 2 });
             queryWrite.SetDataBuffer("cols", new[] { 1, 1, 4 });
             queryWrite.SetDataBuffer("a1", new[] { 1, 2, 3 });
-            queryWrite.Submit();
+            await queryWrite.SubmitAsync();
             Console.WriteLine($"Write query #1 status: {queryWrite.Status()}");
 
             // Write 3 more value at coordinates (3, 1), (4, 1), and (4, 4)
             queryWrite.SetDataBuffer("rows", new[] { 3, 4, 4 });
             queryWrite.SetDataBuffer("cols", new[] { 1, 1, 4 });
             queryWrite.SetDataBuffer("a1", new[] { 4, 5, 6 });
-            queryWrite.Submit();
+            await queryWrite.SubmitAsync();
             Console.WriteLine($"Write query #2 status: {queryWrite.Status()}");
 
             // Important: Global order writes must call Query.FinalizeQuery()
@@ -53,7 +54,7 @@ namespace TileDB.CSharp.Examples
             array.Close();
         }
 
-        private static void ReadArray()
+        private static async Task ReadArrayAsync()
         {
             using var array = new Array(Ctx, ArrayPath);
             array.Open(QueryType.Read);
@@ -66,7 +67,7 @@ namespace TileDB.CSharp.Examples
             readQuery.SetDataBuffer("rows", rowsRead);
             readQuery.SetDataBuffer("cols", colsRead);
             readQuery.SetDataBuffer("a1", a1Read);
-            readQuery.Submit();
+            await readQuery.SubmitAsync();
             Console.WriteLine($"Read query status: {readQuery.Status()}");
             var coordsRead = rowsRead.Zip(colsRead);
             var dataRead = coordsRead.Zip(a1Read);
@@ -75,7 +76,7 @@ namespace TileDB.CSharp.Examples
             array.Close();
         }
 
-        public static void Run()
+        public static async Task RunAsync()
         {
             if (Directory.Exists(ArrayPath))
             {
@@ -83,8 +84,8 @@ namespace TileDB.CSharp.Examples
             }
 
             CreateArray();
-            WriteArray();
-            ReadArray();
+            await WriteArrayAsync();
+            await ReadArrayAsync();
         }
     }
 }

--- a/examples/TileDB.CSharp.Example/Program.cs
+++ b/examples/TileDB.CSharp.Example/Program.cs
@@ -12,8 +12,8 @@ namespace TileDB.CSharp.Examples
             await ExampleQuery.RunAsync();
             await ExampleIncompleteQuery.RunAsync();
             await ExampleIncompleteQueryStringDimensions.RunAsync();
-            ExampleWritingDenseGlobal.Run();
-            ExampleWritingSparseGlobal.Run();
+            await ExampleWritingDenseGlobal.RunAsync();
+            await ExampleWritingSparseGlobal.RunAsync();
 
             ExampleFile.RunLocal();
             // ExampleFile.RunCloud("tiledb_api_token", "tiledb_namespace", "new_cloud_array_name", "s3://bucket/prefix/");

--- a/examples/TileDB.CSharp.Example/Program.cs
+++ b/examples/TileDB.CSharp.Example/Program.cs
@@ -5,13 +5,13 @@ namespace TileDB.CSharp.Examples
 {
     static class Program
     {
-        static async Task Main(string[] args)
+        static async Task Main()
         {
             Console.WriteLine("TileDB Core Version: {0}", CoreUtil.GetCoreLibVersion());
 
             await ExampleQuery.RunAsync();
-            ExampleIncompleteQuery.Run();
-            ExampleIncompleteQueryStringDimensions.Run();
+            await ExampleIncompleteQuery.RunAsync();
+            await ExampleIncompleteQueryStringDimensions.RunAsync();
             ExampleWritingDenseGlobal.Run();
             ExampleWritingSparseGlobal.Run();
 

--- a/examples/TileDB.CSharp.Example/Program.cs
+++ b/examples/TileDB.CSharp.Example/Program.cs
@@ -1,15 +1,15 @@
 ﻿using System;
-using System.IO;
-using TileDB.CSharp;
+using System.Threading.Tasks;
+
 namespace TileDB.CSharp.Examples
 {
     static class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             Console.WriteLine("TileDB Core Version: {0}", CoreUtil.GetCoreLibVersion());
 
-            ExampleQuery.Run();
+            await ExampleQuery.RunAsync();
             ExampleIncompleteQuery.Run();
             ExampleIncompleteQueryStringDimensions.Run();
             ExampleWritingDenseGlobal.Run();

--- a/examples/bindings/QuickstartSparseString/Program.cs
+++ b/examples/bindings/QuickstartSparseString/Program.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
-using TileDB.CSharp;
 using TileDB.CSharp.Examples;
 using TileDB.Interop;
 

--- a/sources/TileDB.CSharp/Query.ValueTaskSource.cs
+++ b/sources/TileDB.CSharp/Query.ValueTaskSource.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace TileDB.CSharp
+{
+    unsafe partial class Query
+    {
+        private ValueTaskSource? _reusableValueTaskSource;
+
+        internal ValueTaskSource GetValueTaskSource() =>
+            Interlocked.Exchange(ref _reusableValueTaskSource, null) ?? new(this);
+
+        internal sealed class ValueTaskSource : IValueTaskSource
+        {
+            // .NET uses this environment variable to directly run async I/O callbacks
+            // on dedicated I/O threads instead of the general-purpose thread pool. We
+            // can reuse it and give the option to run the async callback directly on
+            // TileDB Core's thread.
+            private static readonly bool UnsafeInlineIOCompletionCallbacks =
+                Environment.GetEnvironmentVariable("DOTNET_SYSTEM_NET_SOCKETS_INLINE_COMPLETIONS") == "1";
+
+            private ManualResetValueTaskSourceCore<bool> _core;
+            private readonly Query _query;
+
+            public ValueTaskSource(Query query)
+            {
+                _query = query;
+                if (!UnsafeInlineIOCompletionCallbacks)
+                {
+                    _core.RunContinuationsAsynchronously = true;
+                }
+            }
+
+            public ValueTask AsValueTask() => new(this, _core.Version);
+
+            public void GetResult(short token)
+            {
+                try
+                {
+                    _core.GetResult(token);
+                }
+                finally
+                {
+                    _core.Reset();
+                    Volatile.Write(ref _query._reusableValueTaskSource, this);
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token) => _core.GetStatus(token);
+
+            public void OnCompleted(Action<object?> continuation, object? state, short token, ValueTaskSourceOnCompletedFlags flags) =>
+                _core.OnCompleted(continuation, state, token, flags);
+
+            internal void SetResult() => _core.SetResult(false);
+        }
+    }
+}


### PR DESCRIPTION
This PR changes the way queries are submitted asynchronously. `Query.SubmitAsync` was modified to return `ValueTask`, allowing us to use the Task Asynchronous Pattern and the `async`/`await` keywords.

Instead of

```csharp
query.QueryCompleted += OnCompleted;
query.SubmitAsync();

void OnCompleted(object sender, QueryEventArgs args)
{
    // continue
}
```

all we have to write is

```csharp
await query.SubmitAsync();
// continue
```
.

The usability benefits are enormous. Callback hell is avoided, and by making asynchronous queries as easy as synchronous ones, their usage can be popularized. There are also performance -the `ValueTask` is powered by [a reusable state machine object](https://blog.marcgravell.com/2019/08/prefer-valuetask-to-task-always-and.html) which means that calling `await query.SubmitAsync()` on the same query object many times will allocate only once- and correctness benefits -besides the bug #118 would fix which is fixed here as well, the previous implementation did not correctly propagate some ambient state to the callback-.

The old event-based code was entirely removed. This is a breaking change but one that I believe is definitely worth it.

The query tests were updated to use both `Submit` and `SubmitAsync`, and the examples were converted to exclusively use `SubmitAsync`.

[SC-22350](https://app.shortcut.com/tiledb-inc/story/22350/support-the-task-asynchronous-pattern-in-asynchronous-queries)