### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/nightly-issue-template.md
+++ b/.github/workflows/nightly-issue-template.md
@@ -1,6 +1,6 @@
 ---
 title: Nightly GitHub Actions Build Fail on {{ date | date('ddd, MMMM Do YYYY') }}
-assignees: shaunrd0
+assignees: teo-tsirpanis
 labels: bug
 ---
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
           - os: windows-latest
             HOST: win
             BOOTSTRAP: ../bootstrap.ps1 -EnableS3 -EnableSerialization
-        tag: [release-2.10, release-2.11, dev]
+        tag: [release-2.11, release-2.12, dev]
         dotnet: ['5.0', '6.0']
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Run examples
         shell: bash
         run: |
-          find examples/ -name *.csproj -execdir dotnet run \;
+          find examples/ -name *.csproj | xargs -I{} dotnet run --project {}
 
   Stage-Release-Candidate:
     needs: Run-Tests


### PR DESCRIPTION
Bumps nightly builds to test against 2.11 and later versions. Used xargs to run examples since `find --exec-dir` [will not fail CI](https://github.com/TileDB-Inc/TileDB-CSharp/actions/runs/3228846664/jobs/5285461303#step:9:874) if an example produces errors. Updated nightly build issue template to assign to @teo-tsirpanis

Passing manual run for [nightly CI](https://github.com/TileDB-Inc/TileDB-CSharp/actions/runs/3330919709/jobs/5510034556). Closes #107 
