### PR TITLE
Add `FragmentInfo`.

### DIFF
--- a/sources/TileDB.CSharp/Enums.cs
+++ b/sources/TileDB.CSharp/Enums.cs
@@ -1105,6 +1105,11 @@ namespace TileDB.CSharp
         public static tiledb_datatype_t to_tiledb_datatype(Type t) =>
             (tiledb_datatype_t)TypeToDataType(t);
 
+        /// <summary>
+        /// Converts a <see cref="Type"/> to a <see cref="DataType"/> enum value.
+        /// </summary>
+        /// <param name="t">The type to convert.</param>
+        /// <exception cref="NotSupportedException"><paramref name="t"/> is unsupported.</exception>
         public static DataType TypeToDataType(Type t)
         {
             if (t == typeof(int))
@@ -1157,15 +1162,10 @@ namespace TileDB.CSharp
             }
             else
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                return DataType.Any;
-#pragma warning restore CS0618 // Type or member is obsolete
+                ThrowHelpers.ThrowTypeNotSupported();
+                return default; // unreachable
             }
         }
-
-        [Obsolete("This method will be removed in a future version of the library. Use DataTypeToType and the DataType enum instead.")]
-        private static Type TileDBDataTypeToType(tiledb_datatype_t tiledbDatatype) =>
-            DataTypeToType((DataType)tiledbDatatype);
 
         public static Type DataTypeToType(DataType datatype)
         {

--- a/sources/TileDB.CSharp/Enums.cs
+++ b/sources/TileDB.CSharp/Enums.cs
@@ -282,12 +282,6 @@ namespace TileDB.CSharp
         // https://github.com/TileDB-Inc/TileDB/pull/2812
         StringUcs4 = tiledb_datatype_t.TILEDB_STRING_UCS4,
         /// <summary>
-        /// Any value. Deprecated.
-        /// </summary>
-        [Obsolete("This data type is deprecated.")]
-        // https://github.com/TileDB-Inc/TileDB/pull/2807
-        Any = tiledb_datatype_t.TILEDB_ANY,
-        /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// years since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
@@ -439,8 +433,8 @@ namespace TileDB.CSharp
         TILEDB_STRING_UCS2 = StringUcs2,
         [Obsolete("Use StringUcs4 instead."), EditorBrowsable(EditorBrowsableState.Never)]
         TILEDB_STRING_UCS4 = StringUcs4,
-        [Obsolete("Use Any instead."), EditorBrowsable(EditorBrowsableState.Never)]
-        TILEDB_ANY = Any,
+        [Obsolete("This data type is deprecated."), EditorBrowsable(EditorBrowsableState.Never)]
+        TILEDB_ANY = tiledb_datatype_t.TILEDB_ANY,
         [Obsolete("Use DateTimeYear instead."), EditorBrowsable(EditorBrowsableState.Never)]
         TILEDB_DATETIME_YEAR = DateTimeYear,
         [Obsolete("Use DateTimeMonth instead."), EditorBrowsable(EditorBrowsableState.Never)]
@@ -1172,8 +1166,6 @@ namespace TileDB.CSharp
 #pragma warning disable CS0618 // Type or member is obsolete
             switch (datatype)
             {
-                case DataType.Any:
-                    return typeof(sbyte);
                 case DataType.Char:
                     return typeof(sbyte);
                 case DataType.DateTimeAttosecond:

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -411,12 +411,14 @@ namespace TileDB.CSharp
         /// with the dimension's data type.</exception>
         public (T Start, T End) GetMinimumBoundedRectangle<T>(uint fragmentIndex, uint minimumBoundedRectangleIndex, uint dimensionIndex)
         {
-            ValidateDomainType<T>(GetDimensionType(fragmentIndex, dimensionIndex));
+            DataType dataType = GetDimensionType(fragmentIndex, dimensionIndex);
+            ValidateDomainType<T>(dataType);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 if (typeof(T) == typeof(string))
                 {
-                    (string startStr, string endStr) = GetStringMinimumBoundedRectangle(fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex);
+                    (string startStr, string endStr) =
+                        GetStringMinimumBoundedRectangle(fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, dataType);
                     return ((T)(object)startStr, (T)(object)endStr);
                 }
                 ThrowHelpers.ThrowTypeNotSupported();
@@ -448,12 +450,14 @@ namespace TileDB.CSharp
         /// with the dimension's data type.</exception>
         public (T Start, T End) GetMinimumBoundedRectangle<T>(uint fragmentIndex, uint minimumBoundedRectangleIndex, string dimensionName)
         {
-            ValidateDomainType<T>(GetDimensionType(fragmentIndex, dimensionName));
+            DataType dataType = GetDimensionType(fragmentIndex, dimensionName);
+            ValidateDomainType<T>(dataType);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 if (typeof(T) == typeof(string))
                 {
-                    (string startStr, string endStr) = GetStringMinimumBoundedRectangle(fragmentIndex, minimumBoundedRectangleIndex, dimensionName);
+                    (string startStr, string endStr) =
+                        GetStringMinimumBoundedRectangle(fragmentIndex, minimumBoundedRectangleIndex, dimensionName, dataType);
                     return ((T)(object)startStr, (T)(object)endStr);
                 }
                 ThrowHelpers.ThrowTypeNotSupported();
@@ -474,7 +478,7 @@ namespace TileDB.CSharp
             return (start, end);
         }
 
-        private (string Start, string End) GetStringMinimumBoundedRectangle(uint fragmentIndex, uint minimumBoundedRectangleIndex, uint dimensionIndex)
+        private (string Start, string End) GetStringMinimumBoundedRectangle(uint fragmentIndex, uint minimumBoundedRectangleIndex, uint dimensionIndex, DataType dataType)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -491,12 +495,12 @@ namespace TileDB.CSharp
                     handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, startBufPtr, endBufPtr));
             }
 
-            string startStr = MarshaledStringOut.GetString(startBuf.Span[0..startSize]);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span[0..endSize]);
+            string startStr = MarshaledStringOut.GetString(startBuf.Span[0..startSize], dataType);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span[0..endSize], dataType);
             return (startStr, endStr);
         }
 
-        private (string Start, string End) GetStringMinimumBoundedRectangle(uint fragmentIndex, uint minimumBoundedRectangleIndex, string dimensionName)
+        private (string Start, string End) GetStringMinimumBoundedRectangle(uint fragmentIndex, uint minimumBoundedRectangleIndex, string dimensionName, DataType dataType)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -514,8 +518,8 @@ namespace TileDB.CSharp
                     fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, startBufPtr, endBufPtr));
             }
 
-            string startStr = MarshaledStringOut.GetString(startBuf.Span[0..startSize]);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span[0..endSize]);
+            string startStr = MarshaledStringOut.GetString(startBuf.Span[0..startSize], dataType);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span[0..endSize], dataType);
             return (startStr, endStr);
         }
 
@@ -532,12 +536,13 @@ namespace TileDB.CSharp
         /// with the dimension's data type.</exception>
         public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, uint dimensionIndex)
         {
-            ValidateDomainType<T>(GetDimensionType(fragmentIndex, dimensionIndex));
+            DataType dataType = GetDimensionType(fragmentIndex, dimensionIndex);
+            ValidateDomainType<T>(dataType);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 if (typeof(T) == typeof(string))
                 {
-                    (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionIndex);
+                    (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionIndex, dataType);
                     return ((T)(object)startStr, (T)(object)endStr);
                 }
                 ThrowHelpers.ThrowTypeNotSupported();
@@ -569,12 +574,13 @@ namespace TileDB.CSharp
         /// with the dimension's data type.</exception>
         public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, string dimensionName)
         {
-            ValidateDomainType<T>(GetDimensionType(fragmentIndex, dimensionName));
+            DataType dataType = GetDimensionType(fragmentIndex, dimensionName);
+            ValidateDomainType<T>(dataType);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 if (typeof(T) == typeof(string))
                 {
-                    (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionName);
+                    (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionName, dataType);
                     return ((T)(object)startStr, (T)(object)endStr);
                 }
                 ThrowHelpers.ThrowTypeNotSupported();
@@ -595,7 +601,7 @@ namespace TileDB.CSharp
             return (start, end);
         }
 
-        private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, uint dimensionIndex)
+        private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, uint dimensionIndex, DataType dataType)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -612,12 +618,12 @@ namespace TileDB.CSharp
                     handle, fragmentIndex, dimensionIndex, startBufPtr, endBufPtr));
             }
 
-            string startStr = MarshaledStringOut.GetString(startBuf.Span);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span);
+            string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
             return (startStr, endStr);
         }
 
-        private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, string dimensionName)
+        private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, string dimensionName, DataType dataType)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -635,8 +641,8 @@ namespace TileDB.CSharp
                     handle, fragmentIndex, ms_dimensionName, startBufPtr, endBufPtr));
             }
 
-            string startStr = MarshaledStringOut.GetString(startBuf.Span);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span);
+            string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
             return (startStr, endStr);
         }
 

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -170,7 +170,7 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Gets the <see cref="ArraySchema"/> of a fragment.
+        /// Gets the number of cells written in a fragment.
         /// </summary>
         /// <param name="fragmentIndex">The index of the fragment of interest.</param>
         /// <remarks>

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -7,6 +7,9 @@ using TileDB.Interop;
 
 namespace TileDB.CSharp
 {
+    /// <summary>
+    /// Represents a TileDB fragment info object.
+    /// </summary>
     public unsafe sealed class FragmentInfo : IDisposable
     {
         private readonly Context _ctx;
@@ -14,6 +17,11 @@ namespace TileDB.CSharp
 
         internal FragmentInfoHandle Handle => _handle;
 
+        /// <summary>
+        /// Creates a <see cref="FragmentInfo"/> object.
+        /// </summary>
+        /// <param name="ctx">The <see cref="Context"/> associated with this object.</param>
+        /// <param name="uri">The URI of the array to load the fragment info for.</param>
         public FragmentInfo(Context ctx, string uri)
         {
             _ctx = ctx;
@@ -21,11 +29,17 @@ namespace TileDB.CSharp
             _handle = FragmentInfoHandle.Create(ctx, uri_ms);
         }
 
+        /// <summary>
+        /// Disposes this <see cref="FragmentInfo"/> object.
+        /// </summary>
         public void Dispose()
         {
             _handle.Dispose();
         }
 
+        /// <summary>
+        /// Loads the fragment info.
+        /// </summary>
         public void Load()
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -33,6 +47,11 @@ namespace TileDB.CSharp
             _ctx.handle_error(Methods.tiledb_fragment_info_load(ctxHandle, handle));
         }
 
+        /// <summary>
+        /// Loads the fragment info from an encrypted array.
+        /// </summary>
+        /// <param name="encryptionType">The encryption type to use.</param>
+        /// <param name="key">The encryption key to use.</param>
         public void LoadWithKey(EncryptionType encryptionType, ReadOnlySpan<byte> key)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -43,6 +62,10 @@ namespace TileDB.CSharp
             }
         }
 
+        /// <summary>
+        /// Set the fragment info object's <see cref="Config"/>.
+        /// </summary>
+        /// <param name="config">The <see cref="Config"/> object to set.</param>
         public void SetConfig(Config config)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -51,6 +74,9 @@ namespace TileDB.CSharp
             _ctx.handle_error(Methods.tiledb_fragment_info_set_config(ctxHandle, handle, configHandle));
         }
 
+        /// <summary>
+        /// The number of fragments in the array.
+        /// </summary>
         public uint FragmentCount
         {
             get
@@ -63,6 +89,9 @@ namespace TileDB.CSharp
             }
         }
 
+        /// <summary>
+        /// The number of fragments to vacuum in the array.
+        /// </summary>
         public uint FragmentToVacuumCount
         {
             get
@@ -75,6 +104,9 @@ namespace TileDB.CSharp
             }
         }
 
+        /// <summary>
+        /// The number of fragments with unconsolidated metadata in the array.
+        /// </summary>
         public uint FragmentWithUnconsolidatedMetadataCount
         {
             get
@@ -87,6 +119,14 @@ namespace TileDB.CSharp
             }
         }
 
+        /// <summary>
+        /// Gets the <see cref="ArraySchema"/> of a fragment.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public ArraySchema GetSchema(uint fragmentIndex)
         {
             var ctx = _ctx;
@@ -97,6 +137,14 @@ namespace TileDB.CSharp
             return new ArraySchema(ctx, ArraySchemaHandle.CreateUnowned(schema));
         }
 
+        /// <summary>
+        /// Gets the schema name of a fragment.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public string GetSchemaName(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -109,6 +157,14 @@ namespace TileDB.CSharp
             return name;
         }
 
+        /// <summary>
+        /// Gets the <see cref="ArraySchema"/> of a fragment.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public ulong GetCellsWritten(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -118,6 +174,13 @@ namespace TileDB.CSharp
             return result;
         }
 
+        /// <summary>
+        /// Gets the URI of a fragment to vacuum.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.<remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentToVacuumCount"/> property.
+        /// </remarks>
         public string GetFragmentToVacuumUri(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -130,6 +193,14 @@ namespace TileDB.CSharp
             return uri;
         }
 
+        /// <summary>
+        /// Gets the name of a fragment.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public string GetFragmentName(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -142,6 +213,14 @@ namespace TileDB.CSharp
             return uri;
         }
 
+        /// <summary>
+        /// Gets the URI of a fragment.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public string GetFragmentUri(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -154,6 +233,14 @@ namespace TileDB.CSharp
             return uri;
         }
 
+        /// <summary>
+        /// Gets the format version of a fragment.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public uint GetFormatVersion(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -163,6 +250,14 @@ namespace TileDB.CSharp
             return result;
         }
 
+        /// <summary>
+        /// Gets the size in bytes of a fragment.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public ulong GetFragmentSize(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -172,6 +267,14 @@ namespace TileDB.CSharp
             return result;
         }
 
+        /// <summary>
+        /// Checks whether a fragment has consolidated metadata.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public bool HasConsolidatedMetadata(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -181,6 +284,14 @@ namespace TileDB.CSharp
             return result == 1;
         }
 
+        /// <summary>
+        /// Checks whether a fragment is dense.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public bool IsDense(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -190,6 +301,14 @@ namespace TileDB.CSharp
             return result == 1;
         }
 
+        /// <summary>
+        /// Checks whether a fragment is sparse.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public bool IsSparse(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -199,6 +318,15 @@ namespace TileDB.CSharp
             return result == 1;
         }
 
+        /// <summary>
+        /// Gets the timestamp range of a fragment.
+        /// </summary>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <returns>The start and end timestamps of the fragment.</returns>
+        /// <remarks>
+        /// The maximum value <paramref name="fragmentIndex"/> can take
+        /// is determined by the <see cref="FragmentCount"/> property.
+        /// </remarks>
         public (ulong Start, ulong End) GetTimestampRange(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -208,6 +336,16 @@ namespace TileDB.CSharp
             return (start, end);
         }
 
+        /// <summary>
+        /// Gets the non-empty domain from one of a fragment's dimensions, identified by its index.
+        /// </summary>
+        /// <typeparam name="T">The dimension's data type.</typeparam>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <param name="dimensionIndex">The index of the dimension of interest, following
+        /// the order as it was defined in the domain of the array schema.</param>
+        /// <returns>The start and end values of the domain, inclusive.</returns>
+        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is a managed type
+        /// other than <see cref="string"/>.</exception>
         public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, uint dimensionIndex)
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
@@ -231,6 +369,16 @@ namespace TileDB.CSharp
             return (start, end);
         }
 
+        /// <summary>
+        /// Gets the non-empty domain from one of a fragment's dimensions, identified by its index.
+        /// </summary>
+        /// <typeparam name="T">The dimension's data type.</typeparam>
+        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <param name="dimensionIndex">The index of the dimension of interest, following
+        /// the order as it was defined in the domain of the array schema.</param>
+        /// <returns>The start and end values of the domain, inclusive.</returns>
+        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is a managed type
+        /// other than <see cref="string"/>.</exception>
         public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, string dimensionName)
         {
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -144,12 +144,26 @@ namespace TileDB.CSharp
         /// </remarks>
         public ArraySchema GetSchema(uint fragmentIndex)
         {
+            var handle = new ArraySchemaHandle();
+            var successful = false;
+            tiledb_array_schema_t* schema = null;
             var ctx = _ctx;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_array_schema_t* schema;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_array_schema(ctxHandle, handle, fragmentIndex, &schema));
-            return new ArraySchema(ctx, ArraySchemaHandle.CreateUnowned(schema));
+            try
+            {
+                using var ctxHandle = ctx.Handle.Acquire();
+                using var fragmentInfoHandle = _handle.Acquire();
+                ctx.handle_error(Methods.tiledb_fragment_info_get_array_schema(ctxHandle, fragmentInfoHandle, fragmentIndex, &schema));
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(schema);
+                }
+            }
+
+            return new ArraySchema(ctx, handle);
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -120,6 +120,21 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
+        /// The number of cells written to the fragments by the user.
+        /// </summary>
+        public ulong TotalCellCount
+        {
+            get
+            {
+                using var ctxHandle = _ctx.Handle.Acquire();
+                using var handle = _handle.Acquire();
+                ulong result;
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_total_cell_num(ctxHandle, handle, &result));
+                return result;
+            }
+        }
+
+        /// <summary>
         /// Gets the <see cref="ArraySchema"/> of a fragment.
         /// </summary>
         /// <param name="fragmentIndex">The index of the fragment of interest.</param>

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -164,12 +164,9 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            var name = new MarshaledStringOut();
-            fixed (sbyte** name_ptr = &name.Value)
-            {
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_array_schema_name(ctxHandle, handle, fragmentIndex, name_ptr));
-            }
-            return name;
+            sbyte* name;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_array_schema_name(ctxHandle, handle, fragmentIndex, &name));
+            return MarshaledStringOut.GetStringFromNullTerminated(name);
         }
 
         /// <summary>
@@ -200,12 +197,9 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            var uri = new MarshaledStringOut();
-            fixed (sbyte** uri_ptr = &uri.Value)
-            {
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_to_vacuum_uri(ctxHandle, handle, fragmentIndex, uri_ptr));
-            }
-            return uri;
+            sbyte* uri;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_to_vacuum_uri(ctxHandle, handle, fragmentIndex, &uri));
+            return MarshaledStringOut.GetStringFromNullTerminated(uri);
         }
 
         /// <summary>
@@ -220,12 +214,9 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            var uri = new MarshaledStringOut();
-            fixed (sbyte** uri_ptr = &uri.Value)
-            {
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_name(ctxHandle, handle, fragmentIndex, uri_ptr));
-            }
-            return uri;
+            sbyte* name;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_name(ctxHandle, handle, fragmentIndex, &name));
+            return MarshaledStringOut.GetStringFromNullTerminated(name);
         }
 
         /// <summary>
@@ -240,12 +231,9 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            var uri = new MarshaledStringOut();
-            fixed (sbyte** uri_ptr = &uri.Value)
-            {
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_uri(ctxHandle, handle, fragmentIndex, uri_ptr));
-            }
-            return uri;
+            sbyte* uri;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_uri(ctxHandle, handle, fragmentIndex, &uri));
+            return MarshaledStringOut.GetStringFromNullTerminated(uri);
         }
 
         /// <summary>
@@ -460,7 +448,9 @@ namespace TileDB.CSharp
                     handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, startBufPtr, endBufPtr));
             }
 
-            return (startBuf.Span.AsString(), endBuf.Span.AsString());
+            string startStr = MarshaledStringOut.GetString(startBuf.Span);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span);
+            return (startStr, endStr);
         }
 
         private (string Start, string End) GetStringMinimumBoundedRectangle(uint fragmentIndex, uint minimumBoundedRectangleIndex, string dimensionName)
@@ -481,7 +471,9 @@ namespace TileDB.CSharp
                     fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, startBufPtr, endBufPtr));
             }
 
-            return (startBuf.Span.AsString(), endBuf.Span.AsString());
+            string startStr = MarshaledStringOut.GetString(startBuf.Span);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span);
+            return (startStr, endStr);
         }
 
         /// <summary>
@@ -575,7 +567,9 @@ namespace TileDB.CSharp
                     handle, fragmentIndex, dimensionIndex, startBufPtr, endBufPtr));
             }
 
-            return (startBuf.Span.AsString(), endBuf.Span.AsString());
+            string startStr = MarshaledStringOut.GetString(startBuf.Span);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span);
+            return (startStr, endStr);
         }
 
         private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, string dimensionName)
@@ -596,7 +590,9 @@ namespace TileDB.CSharp
                     handle, fragmentIndex, ms_dimensionName, startBufPtr, endBufPtr));
             }
 
-            return (startBuf.Span.AsString(), endBuf.Span.AsString());
+            string startStr = MarshaledStringOut.GetString(startBuf.Span);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span);
+            return (startStr, endStr);
         }
 
         private static void ValidateDomainType<T>()

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -448,8 +448,8 @@ namespace TileDB.CSharp
                     handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, startBufPtr, endBufPtr));
             }
 
-            string startStr = MarshaledStringOut.GetString(startBuf.Span);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span);
+            string startStr = MarshaledStringOut.GetString(startBuf.Span[0..startSize]);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span[0..endSize]);
             return (startStr, endStr);
         }
 
@@ -471,8 +471,8 @@ namespace TileDB.CSharp
                     fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, startBufPtr, endBufPtr));
             }
 
-            string startStr = MarshaledStringOut.GetString(startBuf.Span);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span);
+            string startStr = MarshaledStringOut.GetString(startBuf.Span[0..startSize]);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span[0..endSize]);
             return (startStr, endStr);
         }
 

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -208,20 +208,42 @@ namespace TileDB.CSharp
             return (start, end);
         }
 
-        public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, uint dimensionIndex) where T : struct
+        public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, uint dimensionIndex)
         {
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                if (typeof(T) == typeof(string))
+                {
+                    (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionIndex);
+                    return ((T)(object)startStr, (T)(object)endStr);
+                }
+                ThrowHelpers.ThrowTypeNotSupported();
+                return default;
+            }
+
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             byte* domain = stackalloc byte[Unsafe.SizeOf<T>() * 2];
             _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_index(ctxHandle, handle, fragmentIndex, dimensionIndex, domain));
 
-            var beginning = Unsafe.ReadUnaligned<T>(domain);
+            var start = Unsafe.ReadUnaligned<T>(domain);
             var end = Unsafe.ReadUnaligned<T>(domain + Unsafe.SizeOf<T>());
-            return (beginning, end);
+            return (start, end);
         }
 
-        public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, string dimensionName) where T : struct
+        public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, string dimensionName)
         {
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                if (typeof(T) == typeof(string))
+                {
+                    (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionName);
+                    return ((T)(object)startStr, (T)(object)endStr);
+                }
+                ThrowHelpers.ThrowTypeNotSupported();
+                return default;
+            }
+
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             using var ms_dimensionName = new MarshaledString(dimensionName);
@@ -233,7 +255,7 @@ namespace TileDB.CSharp
             return (start, end);
         }
 
-        public (string Start, string End) GetNonEmptyDomain(uint fragmentIndex, uint dimensionIndex)
+        private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, uint dimensionIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -253,7 +275,7 @@ namespace TileDB.CSharp
             return (start, end);
         }
 
-        public (string Start, string End) GetNonEmptyDomain(uint fragmentIndex, string dimensionName)
+        private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, string dimensionName)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -63,6 +63,34 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
+        /// Creates a <see cref="Config"/> object that contains this <see cref="FragmentInfo"/>'s configuration.
+        /// </summary>
+        public Config GetConfig()
+        {
+            var handle = new ConfigHandle();
+            bool successful = false;
+            tiledb_config_t* config = null;
+            try
+            {
+                using (var ctx = _ctx.Handle.Acquire())
+                using (var fragmentInfoHandle = _handle.Acquire())
+                {
+                    _ctx.handle_error(Methods.tiledb_fragment_info_get_config(ctx, fragmentInfoHandle, &config));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(config);
+                }
+            }
+
+            return new Config(handle);
+        }
+
+        /// <summary>
         /// Set the fragment info object's <see cref="Config"/>.
         /// </summary>
         /// <param name="config">The <see cref="Config"/> object to set.</param>

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -1,0 +1,277 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Text;
+using TileDB.CSharp.Marshalling;
+using TileDB.CSharp.Marshalling.SafeHandles;
+using TileDB.Interop;
+
+namespace TileDB.CSharp
+{
+    public unsafe sealed class FragmentInfo : IDisposable
+    {
+        private readonly Context _ctx;
+        private readonly FragmentInfoHandle _handle;
+
+        internal FragmentInfoHandle Handle => _handle;
+
+        public FragmentInfo(Context ctx, string uri)
+        {
+            _ctx = ctx;
+            using var uri_ms = new MarshaledString(uri);
+            _handle = FragmentInfoHandle.Create(ctx, uri_ms);
+        }
+
+        public void Dispose()
+        {
+            _handle.Dispose();
+        }
+
+        public void Load()
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            _ctx.handle_error(Methods.tiledb_fragment_info_load(ctxHandle, handle));
+        }
+
+        public void LoadWithKey(EncryptionType encryptionType, ReadOnlySpan<byte> key)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            fixed (byte* keyPtr = key)
+            {
+                _ctx.handle_error(Methods.tiledb_fragment_info_load_with_key(ctxHandle, handle, (tiledb_encryption_type_t)encryptionType, keyPtr, (uint)key.Length));
+            }
+        }
+
+        public void SetConfig(Config config)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            using var configHandle = config.Handle.Acquire();
+            _ctx.handle_error(Methods.tiledb_fragment_info_set_config(ctxHandle, handle, configHandle));
+        }
+
+        public uint FragmentCount
+        {
+            get
+            {
+                using var ctxHandle = _ctx.Handle.Acquire();
+                using var handle = _handle.Acquire();
+                uint result;
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_num(ctxHandle, handle, &result));
+                return result;
+            }
+        }
+
+        public uint FragmentToVacuumCount
+        {
+            get
+            {
+                using var ctxHandle = _ctx.Handle.Acquire();
+                using var handle = _handle.Acquire();
+                uint result;
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_to_vacuum_num(ctxHandle, handle, &result));
+                return result;
+            }
+        }
+
+        public uint FragmentWithUnconsolidatedMetadataCount
+        {
+            get
+            {
+                using var ctxHandle = _ctx.Handle.Acquire();
+                using var handle = _handle.Acquire();
+                uint result;
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_unconsolidated_metadata_num(ctxHandle, handle, &result));
+                return result;
+            }
+        }
+
+        public ArraySchema GetSchema(uint fragmentIndex)
+        {
+            var ctx = _ctx;
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            tiledb_array_schema_t* schema;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_array_schema(ctxHandle, handle, fragmentIndex, &schema));
+            return new ArraySchema(ctx, ArraySchemaHandle.CreateUnowned(schema));
+        }
+
+        public string GetSchemaName(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            var name = new MarshaledStringOut();
+            fixed (sbyte** name_ptr = &name.Value)
+            {
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_array_schema_name(ctxHandle, handle, fragmentIndex, name_ptr));
+            }
+            return name;
+        }
+
+        public ulong GetCellsWritten(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            ulong result;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_cell_num(ctxHandle, handle, fragmentIndex, &result));
+            return result;
+        }
+
+        public string GetFragmentToVacuumUri(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            var uri = new MarshaledStringOut();
+            fixed (sbyte** uri_ptr = &uri.Value)
+            {
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_to_vacuum_uri(ctxHandle, handle, fragmentIndex, uri_ptr));
+            }
+            return uri;
+        }
+
+        public string GetFragmentName(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            var uri = new MarshaledStringOut();
+            fixed (sbyte** uri_ptr = &uri.Value)
+            {
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_name(ctxHandle, handle, fragmentIndex, uri_ptr));
+            }
+            return uri;
+        }
+
+        public string GetFragmentUri(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            var uri = new MarshaledStringOut();
+            fixed (sbyte** uri_ptr = &uri.Value)
+            {
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_uri(ctxHandle, handle, fragmentIndex, uri_ptr));
+            }
+            return uri;
+        }
+
+        public uint GetFormatVersion(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            uint result;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_version(ctxHandle, handle, fragmentIndex, &result));
+            return result;
+        }
+
+        public ulong GetFragmentSize(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            ulong result;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_size(ctxHandle, handle, fragmentIndex, &result));
+            return result;
+        }
+
+        public bool HasConsolidatedMetadata(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            int result;
+            _ctx.handle_error(Methods.tiledb_fragment_info_has_consolidated_metadata(ctxHandle, handle, fragmentIndex, &result));
+            return result == 1;
+        }
+
+        public bool IsDense(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            int result;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_dense(ctxHandle, handle, fragmentIndex, &result));
+            return result == 1;
+        }
+
+        public bool IsSparse(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            int result;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_sparse(ctxHandle, handle, fragmentIndex, &result));
+            return result == 1;
+        }
+
+        public (ulong Start, ulong End) GetTimestampRange(uint fragmentIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            ulong start, end;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_timestamp_range(ctxHandle, handle, fragmentIndex, &start, &end));
+            return (start, end);
+        }
+
+        public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, uint dimensionIndex) where T : struct
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            byte* domain = stackalloc byte[Unsafe.SizeOf<T>() * 2];
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_index(ctxHandle, handle, fragmentIndex, dimensionIndex, domain));
+
+            var beginning = Unsafe.ReadUnaligned<T>(domain);
+            var end = Unsafe.ReadUnaligned<T>(domain + Unsafe.SizeOf<T>());
+            return (beginning, end);
+        }
+
+        public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, string dimensionName) where T : struct
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            using var ms_dimensionName = new MarshaledString(dimensionName);
+            byte* domain = stackalloc byte[Unsafe.SizeOf<T>() * 2];
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_name(ctxHandle, handle, fragmentIndex, ms_dimensionName, domain));
+
+            var start = Unsafe.ReadUnaligned<T>(domain);
+            var end = Unsafe.ReadUnaligned<T>(domain + Unsafe.SizeOf<T>());
+            return (start, end);
+        }
+
+        public (string Start, string End) GetNonEmptyDomain(uint fragmentIndex, uint dimensionIndex)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            ulong startSize64, endSize64;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(ctxHandle, handle, fragmentIndex, dimensionIndex, &startSize64, &endSize64));
+            int startSize = checked((int)startSize64);
+            int endSize = checked((int)endSize64);
+            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128]);
+            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128]);
+            fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
+            {
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_index(ctxHandle, handle, fragmentIndex, dimensionIndex, startBufPtr, endBufPtr));
+            }
+
+            var start = Encoding.ASCII.GetString(startBuf.Span);
+            var end = Encoding.ASCII.GetString(endBuf.Span);
+            return (start, end);
+        }
+
+        public (string Start, string End) GetNonEmptyDomain(uint fragmentIndex, string dimensionName)
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            using var ms_dimensionName = new MarshaledString(dimensionName);
+            ulong startSize64, endSize64;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(ctxHandle, handle, fragmentIndex, ms_dimensionName, &startSize64, &endSize64));
+            int startSize = checked((int)startSize64);
+            int endSize = checked((int)endSize64);
+            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128]);
+            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128]);
+            fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
+            {
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_name(ctxHandle, handle, fragmentIndex, ms_dimensionName, startBufPtr, endBufPtr));
+            }
+
+            var start = Encoding.ASCII.GetString(startBuf.Span);
+            var end = Encoding.ASCII.GetString(endBuf.Span);
+            return (start, end);
+        }
+    }
+}

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -377,7 +377,8 @@ namespace TileDB.CSharp
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             byte* domain = stackalloc byte[Unsafe.SizeOf<T>() * 2];
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_index(ctxHandle, handle, fragmentIndex, dimensionIndex, domain));
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_index(ctxHandle,
+                handle, fragmentIndex, dimensionIndex, domain));
 
             var start = Unsafe.ReadUnaligned<T>(domain);
             var end = Unsafe.ReadUnaligned<T>(domain + Unsafe.SizeOf<T>());
@@ -389,8 +390,7 @@ namespace TileDB.CSharp
         /// </summary>
         /// <typeparam name="T">The dimension's data type.</typeparam>
         /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <param name="dimensionIndex">The index of the dimension of interest, following
-        /// the order as it was defined in the domain of the array schema.</param>
+        /// <param name="dimensionName">The name of the dimension of interest.</param>
         /// <returns>The start and end values of the domain, inclusive.</returns>
         /// <exception cref="NotSupportedException"><typeparamref name="T"/> is a managed type
         /// other than <see cref="string"/>.</exception>
@@ -411,7 +411,8 @@ namespace TileDB.CSharp
             using var handle = _handle.Acquire();
             using var ms_dimensionName = new MarshaledString(dimensionName);
             byte* domain = stackalloc byte[Unsafe.SizeOf<T>() * 2];
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_name(ctxHandle, handle, fragmentIndex, ms_dimensionName, domain));
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_name(ctxHandle,
+                handle, fragmentIndex, ms_dimensionName, domain));
 
             var start = Unsafe.ReadUnaligned<T>(domain);
             var end = Unsafe.ReadUnaligned<T>(domain + Unsafe.SizeOf<T>());
@@ -423,14 +424,16 @@ namespace TileDB.CSharp
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             ulong startSize64, endSize64;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(ctxHandle, handle, fragmentIndex, dimensionIndex, &startSize64, &endSize64));
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(ctxHandle,
+                handle, fragmentIndex, dimensionIndex, &startSize64, &endSize64));
             int startSize = checked((int)startSize64);
             int endSize = checked((int)endSize64);
             using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128]);
             using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128]);
             fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
             {
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_index(ctxHandle, handle, fragmentIndex, dimensionIndex, startBufPtr, endBufPtr));
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_index(ctxHandle,
+                    handle, fragmentIndex, dimensionIndex, startBufPtr, endBufPtr));
             }
 
             var start = Encoding.ASCII.GetString(startBuf.Span);
@@ -444,14 +447,16 @@ namespace TileDB.CSharp
             using var handle = _handle.Acquire();
             using var ms_dimensionName = new MarshaledString(dimensionName);
             ulong startSize64, endSize64;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(ctxHandle, handle, fragmentIndex, ms_dimensionName, &startSize64, &endSize64));
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(ctxHandle,
+                handle, fragmentIndex, ms_dimensionName, &startSize64, &endSize64));
             int startSize = checked((int)startSize64);
             int endSize = checked((int)endSize64);
             using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128]);
             using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128]);
             fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
             {
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_name(ctxHandle, handle, fragmentIndex, ms_dimensionName, startBufPtr, endBufPtr));
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_name(ctxHandle,
+                    handle, fragmentIndex, ms_dimensionName, startBufPtr, endBufPtr));
             }
 
             var start = Encoding.ASCII.GetString(startBuf.Span);

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -47,21 +47,6 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Loads the fragment info from an encrypted array.
-        /// </summary>
-        /// <param name="encryptionType">The encryption type to use.</param>
-        /// <param name="key">The encryption key to use.</param>
-        public void LoadWithKey(EncryptionType encryptionType, ReadOnlySpan<byte> key)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            fixed (byte* keyPtr = key)
-            {
-                _ctx.handle_error(Methods.tiledb_fragment_info_load_with_key(ctxHandle, handle, (tiledb_encryption_type_t)encryptionType, keyPtr, (uint)key.Length));
-            }
-        }
-
-        /// <summary>
         /// Creates a <see cref="Config"/> object that contains this <see cref="FragmentInfo"/>'s configuration.
         /// </summary>
         public Config GetConfig()

--- a/sources/TileDB.CSharp/Marshalling/MarshaledStringOut.cs
+++ b/sources/TileDB.CSharp/Marshalling/MarshaledStringOut.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Text;
+using TileDB.CSharp;
 
 namespace TileDB.Interop
 {
@@ -10,6 +11,16 @@ namespace TileDB.Interop
         /// </summary>
         public static string GetString(ReadOnlySpan<byte> span) =>
             Encoding.ASCII.GetString(span);
+
+        public static string GetString(ReadOnlySpan<byte> span, DataType dataType) =>
+            dataType switch
+            {
+                DataType.StringAscii => Encoding.ASCII.GetString(span),
+                DataType.StringUtf8 => Encoding.UTF8.GetString(span),
+                DataType.StringUtf16 => Encoding.Unicode.GetString(span),
+                DataType.StringUtf32=> Encoding.UTF32.GetString(span),
+                _ => throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Unsupported string data type.")
+            };
 
         /// <summary>
         /// Encodes a null-terminated pointer of bytes into a string, using the default encoding.

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/FragmentInfoHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/FragmentInfoHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public FragmentInfoHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static FragmentInfoHandle CreateUnowned(tiledb_fragment_info_t* fragmentInfo) => new((IntPtr)fragmentInfo, ownsHandle: false);
-
         public static FragmentInfoHandle Create(Context context, sbyte* array_uri)
         {
             var handle = new FragmentInfoHandle();

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/FragmentInfoHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/FragmentInfoHandle.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using TileDB.Interop;
+
+namespace TileDB.CSharp.Marshalling.SafeHandles
+{
+    internal unsafe sealed class FragmentInfoHandle : SafeHandle
+    {
+        public FragmentInfoHandle() : base(IntPtr.Zero, true) { }
+
+        public FragmentInfoHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+        public static FragmentInfoHandle CreateUnowned(tiledb_fragment_info_t* fragmentInfo) => new((IntPtr)fragmentInfo, ownsHandle: false);
+
+        public static FragmentInfoHandle Create(Context context, sbyte* array_uri)
+        {
+            var handle = new FragmentInfoHandle();
+            bool successful = false;
+            tiledb_fragment_info_t* fragmentInfo = null;
+            try
+            {
+                using (var ctx = context.Handle.Acquire())
+                {
+                    context.handle_error(Methods.tiledb_fragment_info_alloc(ctx, array_uri, &fragmentInfo));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(fragmentInfo);
+                }
+            }
+
+            return handle;
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            fixed (IntPtr* h = &handle)
+            {
+                Methods.tiledb_fragment_info_free((tiledb_fragment_info_t**)h);
+            }
+            return true;
+        }
+
+        private void InitHandle(tiledb_fragment_info_t* h) { SetHandle((IntPtr)h); }
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        public SafeHandleHolder<tiledb_fragment_info_t> Acquire() => new(this);
+    }
+}

--- a/sources/TileDB.CSharp/Marshalling/ScratchBuffer.cs
+++ b/sources/TileDB.CSharp/Marshalling/ScratchBuffer.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.InteropServices;
+
+#nullable enable
+
+namespace TileDB.CSharp.Marshalling
+{
+    /// <summary>
+    /// Manages temporary buffers with low GC pressure.
+    /// </summary>
+    /// <remarks>
+    /// Objects of this type should not be passed around; instead pass their <see cref="Span"/> property.
+    /// </remarks>
+    /// <typeparam name="T">The type of items this scratch buffer stores.</typeparam>
+    internal ref struct ScratchBuffer<T>
+    {
+        public Span<T> Span { get; private set; }
+        private T[]? _arrayToReturn;
+
+        /// <summary>
+        /// Creates a <see cref="ScratchBuffer{T}"/> of length at least <paramref name="minimumLength"/>.
+        /// </summary>
+        /// <param name="minimumLength">The buffer's minimum length.</param>
+        /// <param name="preAllocatedSpan">A pre-allocated <see cref="Span{T}"/> that will
+        /// be preferred if it has at least <paramref name="minimumLength"/> elements.</param>
+        /// <remarks>
+        /// <paramref name="preAllocatedSpan"/> could be allocated from the stack using
+        /// the <see langword="stackalloc"/> keyword. If it is too small, <see cref="Span"/>
+        /// will come from the array pool.</remarks>
+        /// <seealso cref="ScratchBuffer{T}(Int32)"/>
+        public ScratchBuffer(int minimumLength, Span<T> preAllocatedSpan)
+        {
+            if (preAllocatedSpan.Length >= minimumLength)
+            {
+                Span = preAllocatedSpan;
+                _arrayToReturn = null;
+            }
+            else
+                this = new ScratchBuffer<T>(minimumLength);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="ScratchBuffer{T}"/> of length at least <paramref name="minimumLength"/>.
+        /// </summary>
+        /// <param name="minimumLength">The buffer's minimum length.</param>
+        /// <remarks>The created instance's <see cref="Span"/>
+        /// will always come from the array pool.</remarks>
+        public ScratchBuffer(int minimumLength)
+        {
+            Span = _arrayToReturn = ArrayPool<T>.Shared.Rent(minimumLength);
+        }
+
+        /// <summary>
+        /// Allows directly using this <see cref="ScratchBuffer{T}"/> in a <see langword="fixed"/> statement.
+        /// </summary>
+        public ref T GetPinnableReference() => ref MemoryMarshal.GetReference(Span);
+
+        /// <summary>
+        /// Disposes the <see cref="ScratchBuffer{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// This function must be always called after using a <see cref="ScratchBuffer{T}"/>
+        /// to release any pooled arrays that might have been used. You can use <see langword="using"/>
+        /// keyword to do it more intuitively. After disposal, the spans returned by the <see cref="Span"/>
+        /// property must not be used, and accessing it will return an empty span.</remarks>
+        public void Dispose()
+        {
+            if (_arrayToReturn == null) return;
+
+            Span = default;
+            ArrayPool<T>.Shared.Return(_arrayToReturn);
+            _arrayToReturn = null;
+        }
+    }
+}

--- a/sources/TileDB.CSharp/ThrowHelpers.cs
+++ b/sources/TileDB.CSharp/ThrowHelpers.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace TileDB.CSharp
+{
+    internal static class ThrowHelpers
+    {
+        [DoesNotReturn]
+        public static void ThrowTypeNotSupported() =>
+            throw new NotSupportedException("Type not supported");
+    }
+}

--- a/sources/TileDB.CSharp/ThrowHelpers.cs
+++ b/sources/TileDB.CSharp/ThrowHelpers.cs
@@ -7,6 +7,15 @@ namespace TileDB.CSharp
     {
         [DoesNotReturn]
         public static void ThrowTypeNotSupported() =>
-            throw new NotSupportedException("Type not supported");
+            throw new NotSupportedException("Type is not supported");
+
+        // We don't have to specify the type in the type argument, it can be seen from the stacktrace.
+        [DoesNotReturn]
+        public static void ThrowTypeMismatch(DataType type) =>
+            throw new InvalidOperationException($"Type is not compatible with data type {type}");
+
+        [DoesNotReturn]
+        public static void ThrowStringTypeMismatch(DataType type) =>
+            throw new InvalidOperationException($"Cannot encode data type {type} into strings");
     }
 }

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Text;
+
+namespace TileDB.CSharp.Test
+{
+    [TestClass]
+    public class FragmentInfoTest
+    {
+        private Context _ctx = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _ctx = new Context();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _ctx.Dispose();
+        }
+
+        [TestMethod]
+        public void TestMbrVarDim()
+        {
+            using var uri = new TemporaryDirectory("fragment_info_mbr");
+            CreateSparseVarDimArrayForMbrTesting(uri);
+            WriteSparseVarDimArrayForMbrTesting(uri);
+
+            using FragmentInfo info = new FragmentInfo(_ctx, uri);
+            info.Load();
+
+            Assert.AreEqual(1u, info.FragmentCount);
+
+            Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(0));
+
+            Assert.AreEqual(("a", "bb"), info.GetMinimumBoundedRectangle<string>(0, 0, 0));
+            Assert.AreEqual(("c", "ddd"), info.GetMinimumBoundedRectangle<string>(0, 1, "d"));
+        }
+
+        private void CreateSparseVarDimArrayForMbrTesting(string arrayUri)
+        {
+            using Dimension d = Dimension.CreateString(_ctx, "d");
+            using Domain domain = new Domain(_ctx);
+            domain.AddDimension(d);
+
+            using Attribute a = new Attribute(_ctx, "a", DataType.TILEDB_INT32);
+            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.TILEDB_SPARSE);
+            schema.SetTileOrder(LayoutType.TILEDB_ROW_MAJOR);
+            schema.SetCellOrder(LayoutType.TILEDB_ROW_MAJOR);
+            schema.SetDomain(domain);
+            schema.SetCapacity(2);
+            schema.AddAttribute(a);
+
+            Array.Create(_ctx, arrayUri, schema);
+        }
+
+        private void WriteSparseVarDimArrayForMbrTesting(string arrayUri)
+        {
+            byte[] dData = Encoding.ASCII.GetBytes("abbcddd");
+            ulong[] dOffsets = {0, 1, 3, 4};
+
+            int[] a = {11, 12, 13, 14};
+
+            using Array array = new Array(_ctx, arrayUri);
+            array.Open(QueryType.TILEDB_WRITE);
+            using Query query = new Query(_ctx, array, QueryType.TILEDB_WRITE);
+            query.SetLayout(LayoutType.TILEDB_UNORDERED);
+
+            query.SetDataBuffer("d", dData);
+            query.SetOffsetsBuffer("d", dOffsets);
+            query.SetDataBuffer("a", a);
+
+            query.Submit();
+
+            query.FinalizeQuery();
+        }
+    }
+}

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -194,6 +194,26 @@ namespace TileDB.CSharp.Test
         }
 
         [TestMethod]
+        public void TestMinimumBoundedRectanglesInt32()
+        {
+            using var uri = new TemporaryDirectory("fragment_info_mbr_int32");
+            CreateSparseArrayNoVarDimInt32(uri);
+            WriteSparseArrayNoVarDim3FragsInt32(uri);
+
+            using FragmentInfo info = new FragmentInfo(_ctx, uri);
+            info.Load();
+
+            Assert.AreEqual(3u, info.FragmentCount);
+
+            Assert.AreEqual(1ul, info.GetMinimumBoundedRectangleCount(0));
+            Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(1));
+            Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(2));
+
+            Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<int>(0, 0, 0));
+            Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
+        }
+
+        [TestMethod]
         public void TestNonEmptyDomain()
         {
             using var uri = new TemporaryDirectory("fragment_info_non_empty_domain");
@@ -448,6 +468,28 @@ namespace TileDB.CSharp.Test
             Array.Create(_ctx, arrayUri, schema);
         }
 
+        private void CreateSparseArrayNoVarDimInt32(string arrayUri)
+        {
+            using Dimension d1 = Dimension.Create<int>(_ctx, nameof(d1), 1, 10, 5);
+            using Dimension d2 = Dimension.Create<int>(_ctx, nameof(d2), 1, 10, 5);
+
+            using Domain domain = new Domain(_ctx);
+            domain.AddDimension(d1);
+            domain.AddDimension(d2);
+
+            using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.Int32);
+
+            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
+            schema.SetTileOrder(LayoutType.RowMajor);
+            schema.SetCellOrder(LayoutType.RowMajor);
+            schema.SetCapacity(2);
+            schema.SetDomain(domain);
+            schema.AddAttribute(a1);
+
+            schema.Check();
+            Array.Create(_ctx, arrayUri, schema);
+        }
+
         private void WriteSparseArrayNoVarDim3Frags(string arrayUri)
         {
             using Array a = new Array(_ctx, arrayUri);
@@ -458,6 +500,28 @@ namespace TileDB.CSharp.Test
             WriteImpl(new long[] { 1, 2, 7, 1 }, new long[] { 1, 2, 7, 8 }, new int[] { 5, 6, 7, 8 });
 
             void WriteImpl(long[] d1, long[] d2, int[] a1)
+            {
+                using Query query = new Query(_ctx, a);
+                query.SetLayout(LayoutType.Unordered);
+                query.SetDataBuffer("d1", d1);
+                query.SetDataBuffer("d2", d2);
+                query.SetDataBuffer("a1", a1);
+
+                query.Submit();
+                query.FinalizeQuery();
+            }
+        }
+
+        private void WriteSparseArrayNoVarDim3FragsInt32(string arrayUri)
+        {
+            using Array a = new Array(_ctx, arrayUri);
+            a.Open(QueryType.Write);
+
+            WriteImpl(new int[] { 1, 2 }, new int[] { 1, 2 }, new int[] { 1, 2 });
+            WriteImpl(new int[] { 1, 2, 7, 8 }, new int[] { 1, 2, 7, 8 }, new int[] { 9, 10, 11, 12 });
+            WriteImpl(new int[] { 1, 2, 7, 1 }, new int[] { 1, 2, 7, 8 }, new int[] { 5, 6, 7, 8 });
+
+            void WriteImpl(int[] d1, int[] d2, int[] a1)
             {
                 using Query query = new Query(_ctx, a);
                 query.SetLayout(LayoutType.Unordered);

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -24,14 +24,16 @@ namespace TileDB.CSharp.Test
             _ctx.Dispose();
         }
 
-        [TestMethod]
-        public void TestFragmentCount()
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Dense")]
+        [DataRow(false, DisplayName = "Sparse")]
+        public void TestFragmentCount(bool isDense)
         {
             using var uri = new TemporaryDirectory("fragment_info_fragment_num");
-            CreateDenseArray(uri);
+            CreateArray(uri, isDense);
             for (uint i = 0; i < FragmentCount; i++)
             {
-                WriteDenseArray(uri);
+                WriteArray(uri, isDense);
             }
 
             using FragmentInfo info = new FragmentInfo(_ctx, uri);
@@ -40,14 +42,16 @@ namespace TileDB.CSharp.Test
             Assert.AreEqual(FragmentCount, info.FragmentCount);
         }
 
-        [TestMethod]
-        public void TestArraySchemaName()
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Dense")]
+        [DataRow(false, DisplayName = "Sparse")]
+        public void TestArraySchemaName(bool isDense)
         {
             using var uri = new TemporaryDirectory("fragment_info_array_schema_name");
-            CreateDenseArray(uri);
+            CreateArray(uri, isDense);
             for (uint i = 0; i < FragmentCount; i++)
             {
-                WriteDenseArray(uri);
+                WriteArray(uri, isDense);
             }
 
             using FragmentInfo info = new FragmentInfo(_ctx, uri);
@@ -63,16 +67,18 @@ namespace TileDB.CSharp.Test
             Assert.AreEqual(FragmentCount, fragmentCount);
         }
 
-        [TestMethod]
-        public void TestGetFragmentSize()
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Dense")]
+        [DataRow(false, DisplayName = "Sparse")]
+        public void TestGetFragmentSize(bool isDense)
         {
             using var uri = new TemporaryDirectory("fragment_info_fragment_size");
 
-            CreateDenseArray(uri);
+            CreateArray(uri, isDense);
 
             for (uint i = 0; i < FragmentCount; i++)
             {
-                WriteDenseArray(uri);
+                WriteArray(uri, isDense);
             }
 
             using FragmentInfo info = new FragmentInfo(_ctx, uri);
@@ -90,15 +96,17 @@ namespace TileDB.CSharp.Test
             }
         }
 
-        [TestMethod]
-        public void TestIsDenseSparse()
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Dense")]
+        [DataRow(false, DisplayName = "Sparse")]
+        public void TestIsDenseSparse(bool isDense)
         {
             using var uri = new TemporaryDirectory("fragment_info_is_dense_sparse");
 
-            CreateDenseArray(uri);
+            CreateArray(uri, isDense);
             for (uint i = 0; i < FragmentCount; i++)
             {
-                WriteDenseArray(uri);
+                WriteArray(uri, isDense);
             }
 
             using FragmentInfo info = new FragmentInfo(_ctx, uri);
@@ -108,21 +116,23 @@ namespace TileDB.CSharp.Test
 
             for (uint i = 0; i < fragmentCount; i++)
             {
-                Assert.IsTrue(info.IsDense(i));
-                Assert.IsFalse(info.IsSparse(i));
+                Assert.AreEqual(isDense, info.IsDense(i));
+                Assert.AreEqual(!isDense, info.IsSparse(i));
             }
         }
 
-        [TestMethod]
-        public void TestGetTimestampRange()
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Dense")]
+        [DataRow(false, DisplayName = "Sparse")]
+        public void TestGetTimestampRange(bool isDense)
         {
             using var uri = new TemporaryDirectory("fragment_info_timestamp_range");
 
-            CreateDenseArray(uri);
+            CreateArray(uri, isDense);
 
             for (uint i = 0; i < FragmentCount; i++)
             {
-                WriteDenseArray(uri);
+                WriteArray(uri, isDense);
             }
 
             using FragmentInfo info = new FragmentInfo(_ctx, uri);
@@ -204,6 +214,7 @@ namespace TileDB.CSharp.Test
                 arr.Open(QueryType.TILEDB_READ);
                 using ArraySchema schema = arr.Schema();
                 using Domain domain = schema.Domain();
+
                 uint ndim = domain.NDim();
 
                 for (uint dim = 0; dim < ndim; dim++)
@@ -228,14 +239,16 @@ namespace TileDB.CSharp.Test
             }
         }
 
-        [TestMethod]
-        public void TestGetCellCount()
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Dense")]
+        [DataRow(false, DisplayName = "Sparse")]
+        public void TestGetCellCount(bool isDense)
         {
             using var uri = new TemporaryDirectory("fragment_info_cell_num");
-            CreateDenseArray(uri);
+            CreateArray(uri, isDense);
             for (uint i = 0; i < FragmentCount; i++)
             {
-                WriteDenseArray(uri);
+                WriteArray(uri, isDense);
             }
 
             using FragmentInfo info = new FragmentInfo(_ctx, uri);
@@ -245,18 +258,20 @@ namespace TileDB.CSharp.Test
 
             for (uint i = 0; i < fragmentCount; i++)
             {
-                Assert.AreEqual(8u, info.GetCellsWritten(i));
+                Assert.AreEqual(isDense ? 8u : 5u, info.GetCellsWritten(i));
             }
         }
 
-        [TestMethod]
-        public void TestGetFormatVersion()
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Dense")]
+        [DataRow(false, DisplayName = "Sparse")]
+        public void TestGetFormatVersion(bool isDense)
         {
             using var uri = new TemporaryDirectory("fragment_info_version");
-            CreateDenseArray(uri);
+            CreateArray(uri, isDense);
             for (uint i = 0; i < FragmentCount; i++)
             {
-                WriteDenseArray(uri);
+                WriteArray(uri, isDense);
             }
 
             using FragmentInfo info = new FragmentInfo(_ctx, uri);
@@ -274,14 +289,16 @@ namespace TileDB.CSharp.Test
             }
         }
 
-        [TestMethod]
-        public void TestHasConsolidatedMetadata()
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Dense")]
+        [DataRow(false, DisplayName = "Sparse")]
+        public void TestHasConsolidatedMetadata(bool isDense)
         {
             using var uri = new TemporaryDirectory("fragment_info_has_consolidated_metadata");
-            CreateDenseArray(uri);
+            CreateArray(uri, isDense);
             for (uint i = 0; i < FragmentCount; i++)
             {
-                WriteDenseArray(uri);
+                WriteArray(uri, isDense);
             }
 
             using FragmentInfo info = new FragmentInfo(_ctx, uri);
@@ -295,20 +312,46 @@ namespace TileDB.CSharp.Test
             }
         }
 
-        [TestMethod]
-        public void TestHasUnconsolidatedMetadata()
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Dense")]
+        [DataRow(false, DisplayName = "Sparse")]
+        public void TestHasUnconsolidatedMetadata(bool isDense)
         {
             using var uri = new TemporaryDirectory("fragment_info_has_unconsolidated_metadata");
-            CreateDenseArray(uri);
+            CreateArray(uri, isDense);
             for (uint i = 0; i < FragmentCount; i++)
             {
-                WriteDenseArray(uri);
+                WriteArray(uri, isDense);
             }
 
             using FragmentInfo info = new FragmentInfo(_ctx, uri);
             info.Load();
 
             Assert.AreEqual(FragmentCount, info.FragmentWithUnconsolidatedMetadataCount);
+        }
+
+        private void CreateArray(string arrayUri, bool isDense)
+        {
+            if (isDense)
+            {
+                CreateDenseArray(arrayUri);
+            }
+            else
+            {
+                CreateSparseVarDimArray(arrayUri);
+            }
+        }
+
+        private void WriteArray(string arrayUri, bool isDense)
+        {
+            if (isDense)
+            {
+                WriteDenseArray(arrayUri);
+            }
+            else
+            {
+                WriteSparseVarDimArray(arrayUri);
+            }
         }
 
         private void CreateDenseArray(string arrayUri)

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -211,7 +211,7 @@ namespace TileDB.CSharp.Test
             for (uint i = 0; i < fragmentCount; i++)
             {
                 using Array arr = new Array(_ctx, uri);
-                arr.Open(QueryType.TILEDB_READ);
+                arr.Open(QueryType.Read);
                 using ArraySchema schema = arr.Schema();
                 using Domain domain = schema.Domain();
 
@@ -363,11 +363,11 @@ namespace TileDB.CSharp.Test
             domain.AddDimension(rows);
             domain.AddDimension(columns);
 
-            using Attribute a = new Attribute(_ctx, nameof(a), DataType.TILEDB_INT32);
+            using Attribute a = new Attribute(_ctx, nameof(a), DataType.Int32);
 
-            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.TILEDB_DENSE);
-            schema.SetTileOrder(LayoutType.TILEDB_ROW_MAJOR);
-            schema.SetCellOrder(LayoutType.TILEDB_ROW_MAJOR);
+            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Dense);
+            schema.SetTileOrder(LayoutType.RowMajor);
+            schema.SetCellOrder(LayoutType.RowMajor);
             schema.SetDomain(domain);
             schema.AddAttribute(a);
 
@@ -380,7 +380,7 @@ namespace TileDB.CSharp.Test
             int[] subarray = { 1, 2, 1, 4 };
 
             using Array array = new Array(_ctx, arrayUri);
-            array.Open(QueryType.TILEDB_WRITE);
+            array.Open(QueryType.Write);
             using Query query = new Query(_ctx, array);
             query.SetDataBuffer("a", data);
             query.SetSubarray(subarray);
@@ -395,11 +395,11 @@ namespace TileDB.CSharp.Test
             using Domain domain = new Domain(_ctx);
             domain.AddDimension(d1);
 
-            using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.TILEDB_INT32);
+            using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.Int32);
 
-            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.TILEDB_SPARSE);
-            schema.SetTileOrder(LayoutType.TILEDB_ROW_MAJOR);
-            schema.SetCellOrder(LayoutType.TILEDB_ROW_MAJOR);
+            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
+            schema.SetTileOrder(LayoutType.RowMajor);
+            schema.SetCellOrder(LayoutType.RowMajor);
             schema.SetDomain(domain);
             schema.AddAttribute(a1);
 
@@ -414,9 +414,9 @@ namespace TileDB.CSharp.Test
             int[] a1 = { 1, 2, 3, 4, 5 };
 
             using Array array = new Array(_ctx, arrayUri);
-            array.Open(QueryType.TILEDB_WRITE);
+            array.Open(QueryType.Write);
             using Query query = new Query(_ctx, array);
-            query.SetLayout(LayoutType.TILEDB_GLOBAL_ORDER);
+            query.SetLayout(LayoutType.GlobalOrder);
 
             query.SetDataBuffer("d1", dData);
             query.SetOffsetsBuffer("d1", dOffsets);
@@ -435,11 +435,11 @@ namespace TileDB.CSharp.Test
             domain.AddDimension(d1);
             domain.AddDimension(d2);
 
-            using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.TILEDB_INT32);
+            using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.Int32);
 
-            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.TILEDB_SPARSE);
-            schema.SetTileOrder(LayoutType.TILEDB_ROW_MAJOR);
-            schema.SetCellOrder(LayoutType.TILEDB_ROW_MAJOR);
+            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
+            schema.SetTileOrder(LayoutType.RowMajor);
+            schema.SetCellOrder(LayoutType.RowMajor);
             schema.SetCapacity(2);
             schema.SetDomain(domain);
             schema.AddAttribute(a1);
@@ -451,7 +451,7 @@ namespace TileDB.CSharp.Test
         private void WriteSparseArrayNoVarDim3Frags(string arrayUri)
         {
             using Array a = new Array(_ctx, arrayUri);
-            a.Open(QueryType.TILEDB_WRITE);
+            a.Open(QueryType.Write);
 
             WriteImpl(new long[] { 1, 2 }, new long[] { 1, 2 }, new int[] { 1, 2 });
             WriteImpl(new long[] { 1, 2, 7, 8 }, new long[] { 1, 2, 7, 8 }, new int[] { 9, 10, 11, 12 });
@@ -460,7 +460,7 @@ namespace TileDB.CSharp.Test
             void WriteImpl(long[] d1, long[] d2, int[] a1)
             {
                 using Query query = new Query(_ctx, a);
-                query.SetLayout(LayoutType.TILEDB_UNORDERED);
+                query.SetLayout(LayoutType.Unordered);
                 query.SetDataBuffer("d1", d1);
                 query.SetDataBuffer("d2", d2);
                 query.SetDataBuffer("a1", a1);
@@ -476,10 +476,10 @@ namespace TileDB.CSharp.Test
             using Domain domain = new Domain(_ctx);
             domain.AddDimension(d);
 
-            using Attribute a = new Attribute(_ctx, nameof(a), DataType.TILEDB_INT32);
-            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.TILEDB_SPARSE);
-            schema.SetTileOrder(LayoutType.TILEDB_ROW_MAJOR);
-            schema.SetCellOrder(LayoutType.TILEDB_ROW_MAJOR);
+            using Attribute a = new Attribute(_ctx, nameof(a), DataType.Int32);
+            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
+            schema.SetTileOrder(LayoutType.RowMajor);
+            schema.SetCellOrder(LayoutType.RowMajor);
             schema.SetDomain(domain);
             schema.SetCapacity(2);
             schema.AddAttribute(a);
@@ -495,9 +495,9 @@ namespace TileDB.CSharp.Test
             int[] a = { 11, 12, 13, 14 };
 
             using Array array = new Array(_ctx, arrayUri);
-            array.Open(QueryType.TILEDB_WRITE);
+            array.Open(QueryType.Write);
             using Query query = new Query(_ctx, array);
-            query.SetLayout(LayoutType.TILEDB_UNORDERED);
+            query.SetLayout(LayoutType.Unordered);
 
             query.SetDataBuffer("d", dData);
             query.SetOffsetsBuffer("d", dOffsets);

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -171,6 +171,13 @@ namespace TileDB.CSharp.Test
 
             Assert.AreEqual(("a", "bb"), info.GetMinimumBoundedRectangle<string>(0, 0, 0));
             Assert.AreEqual(("c", "ddd"), info.GetMinimumBoundedRectangle<string>(0, 1, "d"));
+
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<int>(0, 0, 0));
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<long>(0, 0, 0));
+            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<int>(0, 1, "d"));
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<long>(0, 1, "d"));
+            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 1, "d"));
         }
 
         [TestMethod]
@@ -191,6 +198,13 @@ namespace TileDB.CSharp.Test
 
             Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<long>(0, 0, 0));
             Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<long>(1, 1, "d1"));
+
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<int>(0, 0, 0));
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<string>(0, 0, 0));
+            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<string>(1, 1, "d1"));
+            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(1, 1, "d1"));
         }
 
         [TestMethod]
@@ -211,6 +225,13 @@ namespace TileDB.CSharp.Test
 
             Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<int>(0, 0, 0));
             Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
+
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<long>(0, 0, 0));
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<string>(0, 0, 0));
+            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<long>(1, 1, "d1"));
+            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<string>(1, 1, "d1"));
+            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(1, 1, "d1"));
         }
 
         [TestMethod]
@@ -247,6 +268,9 @@ namespace TileDB.CSharp.Test
                         (int Start, int End, _) => (Start, End)
                     };
                     Assert.AreEqual(expectedNonEmptyDomain, actualNonEmptyDomain);
+                    Assert.ThrowsException<InvalidOperationException>(() => info.GetNonEmptyDomain<long>(i, dim));
+                    Assert.ThrowsException<InvalidOperationException>(() => info.GetNonEmptyDomain<string>(i, dim));
+                    Assert.ThrowsException<NotSupportedException>(() => info.GetNonEmptyDomain<Guid>(i, dim));
 
                     string name = d.Name();
                     expectedNonEmptyDomain = info.GetNonEmptyDomain<int>(i, name);
@@ -255,6 +279,9 @@ namespace TileDB.CSharp.Test
                         (int Start, int End, _) => (Start, End)
                     };
                     Assert.AreEqual(expectedNonEmptyDomain, actualNonEmptyDomain);
+                    Assert.ThrowsException<InvalidOperationException>(() => info.GetNonEmptyDomain<long>(i, name));
+                    Assert.ThrowsException<InvalidOperationException>(() => info.GetNonEmptyDomain<string>(i, name));
+                    Assert.ThrowsException<NotSupportedException>(() => info.GetNonEmptyDomain<Guid>(i, name));
                 }
             }
         }

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -21,9 +21,9 @@ namespace TileDB.CSharp.Test
         }
 
         [TestMethod]
-        public void TestMbrVarDim()
+        public void TestMinimumBoundedRectanglesString()
         {
-            using var uri = new TemporaryDirectory("fragment_info_mbr");
+            using var uri = new TemporaryDirectory("fragment_info_mbr_var");
             CreateSparseVarDimArrayForMbrTesting(uri);
             WriteSparseVarDimArrayForMbrTesting(uri);
 
@@ -38,13 +38,77 @@ namespace TileDB.CSharp.Test
             Assert.AreEqual(("c", "ddd"), info.GetMinimumBoundedRectangle<string>(0, 1, "d"));
         }
 
+        [TestMethod]
+        public void TestMinimumBoundedRectangles()
+        {
+            using var uri = new TemporaryDirectory("fragment_info_mbr");
+            CreateSparseArrayNoVarDim(uri);
+            WriteSparseArrayNoVarDim3Frags(uri);
+
+            using FragmentInfo info = new FragmentInfo(_ctx, uri);
+            info.Load();
+
+            Assert.AreEqual(3u, info.FragmentCount);
+
+            Assert.AreEqual(1ul, info.GetMinimumBoundedRectangleCount(0));
+            Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(1));
+            Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(2));
+
+            Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<int>(0, 0, 0));
+            Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
+        }
+
+        private void CreateSparseArrayNoVarDim(string arrayUri)
+        {
+            using Dimension d1 = Dimension.Create<long>(_ctx, nameof(d1), 1, 10, 5);
+            using Dimension d2 = Dimension.Create<long>(_ctx, nameof(d2), 1, 10, 5);
+
+            using Domain domain = new Domain(_ctx);
+            domain.AddDimension(d1);
+            domain.AddDimension(d2);
+
+            using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.TILEDB_INT32);
+
+            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.TILEDB_SPARSE);
+            schema.SetTileOrder(LayoutType.TILEDB_ROW_MAJOR);
+            schema.SetCellOrder(LayoutType.TILEDB_ROW_MAJOR);
+            schema.SetCapacity(2);
+            schema.SetDomain(domain);
+            schema.AddAttribute(a1);
+
+            schema.Check();
+            Array.Create(_ctx, arrayUri, schema);
+        }
+
+        private void WriteSparseArrayNoVarDim3Frags(string arrayUri)
+        {
+            using Array a = new Array(_ctx, arrayUri);
+            a.Open(QueryType.TILEDB_WRITE);
+
+            WriteImpl(new long[] {1, 2}, new long[] {1, 2}, new int[] {1, 2});
+            WriteImpl(new long[] {1, 2, 7, 8}, new long[] {1, 2, 7, 8}, new int[] {9, 10, 11, 12});
+            WriteImpl(new long[] {1, 2, 7, 1}, new long[] {1, 2, 7, 8}, new int[] {5, 6, 7, 8});
+
+            void WriteImpl(long[] d1, long[] d2, int[] a1)
+            {
+                using Query query = new Query(_ctx, a, QueryType.TILEDB_WRITE);
+                query.SetLayout(LayoutType.TILEDB_UNORDERED);
+                query.SetDataBuffer("d1", d1);
+                query.SetDataBuffer("d2", d2);
+                query.SetDataBuffer("a1", a1);
+
+                query.Submit();
+                query.FinalizeQuery();
+            }
+        }
+
         private void CreateSparseVarDimArrayForMbrTesting(string arrayUri)
         {
-            using Dimension d = Dimension.CreateString(_ctx, "d");
+            using Dimension d = Dimension.CreateString(_ctx, nameof(d));
             using Domain domain = new Domain(_ctx);
             domain.AddDimension(d);
 
-            using Attribute a = new Attribute(_ctx, "a", DataType.TILEDB_INT32);
+            using Attribute a = new Attribute(_ctx, nameof(a), DataType.TILEDB_INT32);
             using ArraySchema schema = new ArraySchema(_ctx, ArrayType.TILEDB_SPARSE);
             schema.SetTileOrder(LayoutType.TILEDB_ROW_MAJOR);
             schema.SetCellOrder(LayoutType.TILEDB_ROW_MAJOR);

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -179,8 +179,8 @@ namespace TileDB.CSharp.Test
             Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(1));
             Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(2));
 
-            Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<int>(0, 0, 0));
-            Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
+            Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<long>(0, 0, 0));
+            Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<long>(1, 1, "d1"));
         }
 
         [TestMethod]

--- a/tests/TileDB.CSharp.Test/TestUtil.cs
+++ b/tests/TileDB.CSharp.Test/TestUtil.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.IO.Enumeration;
+using System.Linq;
 
 namespace TileDB.CSharp.Test
 {
@@ -12,6 +14,18 @@ namespace TileDB.CSharp.Test
                 Directory.CreateDirectory(MakeTestPath(""));
             }
         }
+
+        public static long GetDirectorySize(string directory)
+        {
+            var enumeration = new FileSystemEnumerable<long>(
+                directory,
+                (ref FileSystemEntry entry) => entry.Length,
+                new() { RecurseSubdirectories = true }
+            );
+
+            return enumeration.Sum();
+        }
+
         /// <summary>
         /// Guard running new test cases against previous versions
         /// Returns false if TileDB core version predates `major.minor.rev`


### PR DESCRIPTION
This PR implements TileDB's fragment info API, and adds tests to it, ported from Java.

[SC-22321](https://app.shortcut.com/tiledb-inc/story/22321/add-high-level-wrapper-for-fragmentinfo-api)