### PR TITLE
Always create owned safe handles.

### DIFF
--- a/sources/TileDB.CSharp/ArraySchema.cs
+++ b/sources/TileDB.CSharp/ArraySchema.cs
@@ -18,16 +18,6 @@ namespace TileDB.CSharp
             _handle = ArraySchemaHandle.Create(_ctx, tiledb_array_type);
         }
 
-        private ArraySchema(Context ctx, string uri)
-        {
-            _ctx = ctx;
-            tiledb_array_schema_t* array_schema_p;
-            using var ms_uri = new MarshaledString(uri);
-            using var ctxHandle = ctx.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_load(ctxHandle, ms_uri, &array_schema_p));
-            _handle = ArraySchemaHandle.CreateUnowned(array_schema_p);
-        }
-
         internal ArraySchema(Context ctx, ArraySchemaHandle handle)
         {
             _ctx = ctx;
@@ -231,12 +221,27 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public FilterList CoordsFilterList()
         {
+            var handle = new FilterListHandle();
+            var successful = false;
+            tiledb_filter_list_t* filter_list_p = null;
+            try
+            {
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var schemaHandle = _handle.Acquire())
+                {
+                    _ctx.handle_error(Methods.tiledb_array_schema_get_coords_filter_list(ctxHandle, schemaHandle, &filter_list_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(filter_list_p);
+                }
+            }
 
-            tiledb_filter_list_t* filter_list_p;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_coords_filter_list(ctxHandle, handle, &filter_list_p));
-            return new FilterList(_ctx, FilterListHandle.CreateUnowned(filter_list_p));
+            return new FilterList(_ctx, handle);
         }
 
         /// <summary>
@@ -245,11 +250,27 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public FilterList OffsetsFilterList()
         {
-            tiledb_filter_list_t* filter_list_p;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_offsets_filter_list(ctxHandle, handle, &filter_list_p));
-            return new FilterList(_ctx, FilterListHandle.CreateUnowned(filter_list_p));
+            var handle = new FilterListHandle();
+            var successful = false;
+            tiledb_filter_list_t* filter_list_p = null;
+            try
+            {
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var schemaHandle = _handle.Acquire())
+                {
+                    _ctx.handle_error(Methods.tiledb_array_schema_get_offsets_filter_list(ctxHandle, schemaHandle, &filter_list_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(filter_list_p);
+                }
+            }
+
+            return new FilterList(_ctx, handle);
         }
 
         /// <summary>
@@ -258,12 +279,27 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public Domain Domain()
         {
+            var handle = new DomainHandle();
+            var successful = false;
             tiledb_domain_t* domain_p = null;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_domain(ctxHandle, handle, &domain_p));
+            try
+            {
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var schemaHandle = _handle.Acquire())
+                {
+                    _ctx.handle_error(Methods.tiledb_array_schema_get_domain(ctxHandle, schemaHandle, &domain_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(domain_p);
+                }
+            }
 
-            return new Domain(_ctx, DomainHandle.CreateUnowned(domain_p));
+            return new Domain(_ctx, handle);
         }
 
         /// <summary>
@@ -299,12 +335,27 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public Attribute Attribute(uint i)
         {
-            tiledb_attribute_t* attribute_p;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_attribute_from_index(ctxHandle, handle, i, &attribute_p));
+            var handle = new AttributeHandle();
+            var successful = false;
+            tiledb_attribute_t* attribute_p = null;
+            try
+            {
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var schemaHandle = _handle.Acquire())
+                {
+                    _ctx.handle_error(Methods.tiledb_array_schema_get_attribute_from_index(ctxHandle, schemaHandle, i, &attribute_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(attribute_p);
+                }
+            }
 
-            return new Attribute(_ctx, AttributeHandle.CreateUnowned(attribute_p));
+            return new Attribute(_ctx, handle);
         }
 
         /// <summary>
@@ -314,13 +365,28 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public Attribute Attribute(string name)
         {
-            tiledb_attribute_t* attribute_p;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(name);
-            _ctx.handle_error(Methods.tiledb_array_schema_get_attribute_from_name(ctxHandle, handle, ms_name, &attribute_p));
+            var handle = new AttributeHandle();
+            var successful = false;
+            tiledb_attribute_t* attribute_p = null;
+            try
+            {
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var schemaHandle = _handle.Acquire())
+                using (var ms_name = new MarshaledString(name))
+                {
+                    _ctx.handle_error(Methods.tiledb_array_schema_get_attribute_from_name(ctxHandle, schemaHandle, ms_name, &attribute_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(attribute_p);
+                }
+            }
 
-            return new Attribute(_ctx, AttributeHandle.CreateUnowned(attribute_p));
+            return new Attribute(_ctx, handle);
         }
 
         /// <summary>
@@ -344,13 +410,29 @@ namespace TileDB.CSharp
         /// <param name="ctx"></param>
         /// <param name="uri"></param>
         /// <returns></returns>
-
         public static ArraySchema Load(Context ctx, string uri)
         {
-            return new ArraySchema(ctx, uri);
+            var handle = new ArraySchemaHandle();
+            var successful = false;
+            tiledb_array_schema_t* array_schema_p = null;
+            try
+            {
+                using (var ms_uri = new MarshaledString(uri))
+                using (var ctxHandle = ctx.Handle.Acquire())
+                {
+                    ctx.handle_error(Methods.tiledb_array_schema_load(ctxHandle, ms_uri, &array_schema_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(array_schema_p);
+                }
+            }
+            return new ArraySchema(ctx, handle);
         }
-
-
         #endregion capi functions
 
         /// <summary>

--- a/sources/TileDB.CSharp/Attribute.cs
+++ b/sources/TileDB.CSharp/Attribute.cs
@@ -130,13 +130,28 @@ namespace TileDB.CSharp
         /// </summary>
         public FilterList FilterList()
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_filter_list_t* filter_list_p;
-            _ctx.handle_error(Methods.tiledb_attribute_get_filter_list(ctxHandle, handle, &filter_list_p));
-            return new FilterList(_ctx, FilterListHandle.CreateUnowned(filter_list_p));
-        }
+            var handle = new FilterListHandle();
+            var successful = false;
+            tiledb_filter_list_t* filter_list_p = null;
+            try
+            {
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var attributeHandle = _handle.Acquire())
+                {
+                    _ctx.handle_error(Methods.tiledb_attribute_get_filter_list(ctxHandle, attributeHandle, &filter_list_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(filter_list_p);
+                }
+            }
 
+            return new FilterList(_ctx, handle);
+        }
 
         /// <summary>
         /// Get cell value number.

--- a/sources/TileDB.CSharp/Dimension.cs
+++ b/sources/TileDB.CSharp/Dimension.cs
@@ -68,11 +68,27 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public FilterList FilterList()
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_filter_list_t* filter_list_p;
-            _ctx.handle_error(Methods.tiledb_dimension_get_filter_list(ctxHandle, handle, &filter_list_p));
-            return new FilterList(_ctx, FilterListHandle.CreateUnowned(filter_list_p));
+            var handle = new FilterListHandle();
+            var successful = false;
+            tiledb_filter_list_t* filter_list_p = null;
+            try
+            {
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var dimensionHandle = _handle.Acquire())
+                {
+                    _ctx.handle_error(Methods.tiledb_dimension_get_filter_list(ctxHandle, dimensionHandle, &filter_list_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(filter_list_p);
+                }
+            }
+
+            return new FilterList(_ctx, handle);
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/Domain.cs
+++ b/sources/TileDB.CSharp/Domain.cs
@@ -98,17 +98,27 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public Dimension Dimension(uint index)
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_dimension_t* dimension_p;
-            _ctx.handle_error(Methods.tiledb_domain_get_dimension_from_index(ctxHandle, handle, index, &dimension_p));
-
-            if (dimension_p == null)
+            var handle = new DimensionHandle();
+            var successful = false;
+            tiledb_dimension_t* dimension_p = null;
+            try
             {
-                throw new ErrorException("Dimension.dimension_from_index, dimension pointer is null");
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var domainHandle = _handle.Acquire())
+                {
+                    _ctx.handle_error(Methods.tiledb_domain_get_dimension_from_index(ctxHandle, domainHandle, index, &dimension_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(dimension_p);
+                }
             }
 
-            return new Dimension(_ctx, DimensionHandle.CreateUnowned(dimension_p));
+            return new Dimension(_ctx, handle);
         }
 
         /// <summary>
@@ -118,18 +128,28 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public Dimension Dimension(string name)
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_dimension_t* dimension_p;
-            using var ms_name = new MarshaledString(name);
-            _ctx.handle_error(Methods.tiledb_domain_get_dimension_from_name(ctxHandle, handle, ms_name, &dimension_p));
-
-            if (dimension_p == null)
+            var handle = new DimensionHandle();
+            var successful = false;
+            tiledb_dimension_t* dimension_p = null;
+            try
             {
-                throw new ErrorException("Dimension.dimension_from_name, dimension pointer is null");
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var domainHandle = _handle.Acquire())
+                using (var ms_name = new MarshaledString(name))
+                {
+                    _ctx.handle_error(Methods.tiledb_domain_get_dimension_from_name(ctxHandle, domainHandle, ms_name, &dimension_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(dimension_p);
+                }
             }
 
-            return new Dimension(_ctx, DimensionHandle.CreateUnowned(dimension_p));
+            return new Dimension(_ctx, handle);
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/File.cs
+++ b/sources/TileDB.CSharp/File.cs
@@ -20,15 +20,26 @@ namespace TileDB.CSharp
 
         public ArraySchema SchemaCreate(string uri)
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            tiledb_array_schema_t* array_schema_p;
-            _ctx.handle_error(Methods.tiledb_filestore_schema_create(ctxHandle, ms_uri, &array_schema_p));
-            if (array_schema_p == null)
+            var handle = new ArraySchemaHandle();
+            var successful = false;
+            tiledb_array_schema_t* array_schema_p = null;
+            try
             {
-                throw new ErrorException("Array.schema, schema pointer is null");
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var ms_uri = new MarshaledString(uri))
+                {
+                    _ctx.handle_error(Methods.tiledb_filestore_schema_create(ctxHandle, ms_uri, &array_schema_p));
+                }
+                successful = true;
             }
-            return new ArraySchema(_ctx, ArraySchemaHandle.CreateUnowned(array_schema_p));
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(array_schema_p);
+                }
+            }
+            return new ArraySchema(_ctx, handle);
         }
 
         public void URIImport(string arrayURI, string fileURI, MIMEType mimeType)

--- a/sources/TileDB.CSharp/FilterList.cs
+++ b/sources/TileDB.CSharp/FilterList.cs
@@ -95,20 +95,29 @@ namespace TileDB.CSharp
         /// <param name="filterIndex"></param>
         /// <returns></returns>
         /// <exception cref="ErrorException"></exception>
-        public Filter Filter(uint filterIndex) 
+        public Filter Filter(uint filterIndex)
         {
+            var handle = new FilterHandle();
+            var successful = false;
             tiledb_filter_t* filter_p = null;
-            using (var ctxHandle = _ctx.Handle.Acquire())
-            using (var handle = _handle.Acquire())
+            try
             {
-                _ctx.handle_error(Methods.tiledb_filter_list_get_filter_from_index(ctxHandle, handle, filterIndex, &filter_p));
+                using (var ctxHandle = _ctx.Handle.Acquire())
+                using (var filterListHandle = _handle.Acquire())
+                {
+                    _ctx.handle_error(Methods.tiledb_filter_list_get_filter_from_index(ctxHandle, filterListHandle, filterIndex, &filter_p));
+                }
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(filter_p);
+                }
             }
 
-            if (filter_p == null) {
-                throw new ErrorException("FilterList.filter, filter pointer is null");
-            }
-
-            return new Filter(_ctx, FilterHandle.CreateUnowned(filter_p));
+            return new Filter(_ctx, handle);
         }
 
     }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ArrayHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ArrayHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public ArrayHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static ArrayHandle CreateUnowned(tiledb_array_t* array) => new((IntPtr)array, ownsHandle: false);
-
         public static ArrayHandle Create(Context context, sbyte* uri)
         {
             var handle = new ArrayHandle();
@@ -45,7 +43,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_array_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_array_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_array_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaEvolutionHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaEvolutionHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public ArraySchemaEvolutionHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static ArraySchemaEvolutionHandle CreateUnowned(tiledb_array_schema_t* array) => new((IntPtr)array, ownsHandle: false);
-
         public static ArraySchemaEvolutionHandle Create(Context context)
         {
             var handle = new ArraySchemaEvolutionHandle();
@@ -45,7 +43,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_array_schema_evolution_t* h) => SetHandle((IntPtr)h);
+        internal void InitHandle(tiledb_array_schema_evolution_t* h) => SetHandle((IntPtr)h);
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_array_schema_evolution_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public ArraySchemaHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static ArraySchemaHandle CreateUnowned(tiledb_array_schema_t* schema) => new((IntPtr)schema, ownsHandle: false);
-
         public static ArraySchemaHandle Create(Context context, tiledb_array_type_t arrayType)
         {
             var handle = new ArraySchemaHandle();
@@ -45,7 +43,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_array_schema_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_array_schema_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_array_schema_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/AttributeHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/AttributeHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public AttributeHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static AttributeHandle CreateUnowned(tiledb_attribute_t* schema) => new((IntPtr)schema, ownsHandle: false);
-
         public static AttributeHandle Create(Context context, string name, tiledb_datatype_t datatype)
         {
             var handle = new AttributeHandle();
@@ -44,7 +42,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_attribute_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_attribute_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_attribute_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public ConfigHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static ConfigHandle CreateUnowned(tiledb_config_t* schema) => new((IntPtr)schema, ownsHandle: false);
-
         public static ConfigHandle Create()
         {
             var handle = new ConfigHandle();
@@ -43,7 +41,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_config_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_config_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_config_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigIteratorHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigIteratorHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public ConfigIteratorHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static ConfigIteratorHandle CreateUnowned(tiledb_config_iter_t* schema) => new((IntPtr)schema, ownsHandle: false);
-
         public static ConfigIteratorHandle Create(ConfigHandle hconfig, string prefix)
         {
             var handle = new ConfigIteratorHandle();
@@ -45,7 +43,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_config_iter_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_config_iter_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_config_iter_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ContextHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ContextHandle.cs
@@ -11,8 +11,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public ContextHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static ContextHandle CreateUnowned(tiledb_ctx_t* context) => new((IntPtr)context, ownsHandle: false);
-
         public static ContextHandle Create()
         {
             var handle = new ContextHandle();
@@ -67,7 +65,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_ctx_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_ctx_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_ctx_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/DimensionHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/DimensionHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public DimensionHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static DimensionHandle CreateUnowned(tiledb_dimension_t* schema) => new((IntPtr)schema, ownsHandle: false);
-
         public static DimensionHandle Create(Context context, string name, tiledb_datatype_t datatype, void* dimDomain, void* tileExtent)
         {
             var handle = new DimensionHandle();
@@ -44,7 +42,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_dimension_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_dimension_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_dimension_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/DomainHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/DomainHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public DomainHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static DomainHandle CreateUnowned(tiledb_domain_t* schema) => new((IntPtr)schema, ownsHandle: false);
-
         public static DomainHandle Create(Context context)
         {
             var handle = new DomainHandle();
@@ -43,7 +41,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_domain_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_domain_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_domain_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public FilterHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static FilterHandle CreateUnowned(tiledb_filter_t* array) => new((IntPtr)array, ownsHandle: false);
-
         public static FilterHandle Create(Context context, tiledb_filter_type_t filterType)
         {
             var handle = new FilterHandle();
@@ -43,7 +41,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_filter_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_filter_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_filter_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterListHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterListHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public FilterListHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static FilterListHandle CreateUnowned(tiledb_filter_list_t* filterList) => new((IntPtr)filterList, ownsHandle: false);
-
         public static FilterListHandle Create(Context context)
         {
             var handle = new FilterListHandle();
@@ -43,7 +41,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_filter_list_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_filter_list_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_filter_list_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/GroupHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/GroupHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public GroupHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static GroupHandle CreateUnowned(tiledb_group_t* filterList) => new((IntPtr)filterList, ownsHandle: false);
-
         public static GroupHandle Create(Context context, sbyte* uri)
         {
             var handle = new GroupHandle();
@@ -43,7 +41,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_group_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_group_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_group_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryConditionHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryConditionHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public QueryConditionHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static QueryConditionHandle CreateUnowned(tiledb_query_condition_t* filterList) => new((IntPtr)filterList, ownsHandle: false);
-
         public static QueryConditionHandle Create(Context context)
         {
             var handle = new QueryConditionHandle();
@@ -43,7 +41,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_query_condition_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_query_condition_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_query_condition_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public QueryHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static QueryHandle CreateUnowned(tiledb_query_t* filterList) => new((IntPtr)filterList, ownsHandle: false);
-
         public static QueryHandle Create(Context context, ArrayHandle arrayHandle, tiledb_query_type_t queryType)
         {
             var handle = new QueryHandle();
@@ -44,7 +42,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private void InitHandle(tiledb_query_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_query_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_query_t> Acquire() => new(this);

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSHandle.cs
@@ -10,8 +10,6 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public VFSHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static VFSHandle CreateUnowned(tiledb_vfs_t* filterList) => new((IntPtr)filterList, ownsHandle: false);
-
         public static VFSHandle Create(Context context, ConfigHandle configHandle)
         {
             var handle = new VFSHandle();
@@ -44,7 +42,7 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
             return true;
         }
 
-        private protected void InitHandle(tiledb_vfs_t* h) { SetHandle((IntPtr)h); }
+        internal void InitHandle(tiledb_vfs_t* h) { SetHandle((IntPtr)h); }
         public override bool IsInvalid => handle == IntPtr.Zero;
 
         public SafeHandleHolder<tiledb_vfs_t> Acquire() => new(this);


### PR DESCRIPTION
A continuation of #106, this PR removes the `CreateUnowned` function from the safe handles and creates them as owned, according to the usual pattern. Unowned handles were never released from native code, even if we call `Dispose()`, resulting in leaks. These leaks should be patched.