### PR TITLE
Change the library's compiled output path to `bin`.

### DIFF
--- a/sources/TileDB.CSharp/TileDB.CSharp.csproj
+++ b/sources/TileDB.CSharp/TileDB.CSharp.csproj
@@ -12,10 +12,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <OutputPath>./lib</OutputPath>
-  </PropertyGroup>
-
   <ItemGroup>
     <None Include="README.md" Pack="True" PackagePath="" />
     <None Include="build/TileDB.CSharp.targets" Pack="True" PackagePath="build" />


### PR DESCRIPTION
There is no reason for it to be different.