### PR TITLE
Stop testing 2.11 on nightly builds.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
           - os: windows-latest
             HOST: win
             BOOTSTRAP: ../bootstrap.ps1 -EnableS3 -EnableSerialization
-        tag: [release-2.11, release-2.12, dev]
+        tag: [release-2.12, dev]
         dotnet: ['net5.0', 'net6.0']
     runs-on: ${{ matrix.os }}
 

--- a/tests/TileDB.CSharp.Test/FilterTest.cs
+++ b/tests/TileDB.CSharp.Test/FilterTest.cs
@@ -64,11 +64,6 @@ namespace TileDB.CSharp.Test
         [TestMethod]
         public void NewFloatScalingFilterIsValid()
         {
-            if (!TestUtil.VersionMinimum(2, 11))
-            {
-                return;
-            }
-
             var ctx = Context.GetDefault();
             using var filter = new Filter(ctx, FilterType.ScaleFloat);
             Assert.AreEqual(FilterType.ScaleFloat, filter.FilterType());


### PR DESCRIPTION
Nightly builds on 2.11 are failing because the `tiledb_status_code` function does not exist. This PR modifies `nightly.yml` to stop testing on 2.11.

Fixes #134 #135 #136 #140 #142. See [SC-23174](https://app.shortcut.com/tiledb-inc/story/23174/reconsider-testing-with-older-core-versions).