### PR TITLE
Add a Release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run tests
+        uses: ./tiledb-csharp.yml
+      - uses: actions/checkout@v3
+      - name: Remove existing .NET versions
+        shell: bash
+        run: |
+          rm -rf $DOTNET_ROOT
+      - name: Set up .NET SDK from global.json
+        uses: actions/setup-dotnet@v3
+      - name: Display .NET versions
+        run: dotnet --info
+      - name: Pack TileDB.CSharp
+        run: dotnet pack -c Release ./sources/TileDB.CSharp/TileDB.CSharp.csproj
+      - name: Publish TileDB.CSharp
+        run: dotnet nuget push ./*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.TILEDB_CSHARP_NUGET_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,12 @@ on:
       - published
 
 jobs:
+  Run-Tests:
+    uses: ./.github/workflows/tiledb-csharp.yml
   Release:
     runs-on: ubuntu-latest
+    needs: Run-Tests
     steps:
-      - name: Run tests
-        uses: ./tiledb-csharp.yml
       - uses: actions/checkout@v3
       - name: Remove existing .NET versions
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Display .NET versions
         run: dotnet --info
       - name: Pack TileDB.CSharp
-        run: dotnet pack -c Release ./sources/TileDB.CSharp/TileDB.CSharp.csproj
+        run: dotnet pack -c Release ./sources/TileDB.CSharp/TileDB.CSharp.csproj -o pack
       - name: Publish TileDB.CSharp
         shell: bash
-        run: dotnet nuget push "*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.TILEDB_CSHARP_NUGET_KEY }}
+        run: |
+          cd pack
+          dotnet nuget push "*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.TILEDB_CSHARP_NUGET_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags: ['*']
 
 jobs:
   Run-Tests:
@@ -23,7 +22,7 @@ jobs:
         run: dotnet --info
       - name: Pack TileDB.CSharp
         run: dotnet pack -c Release ./sources/TileDB.CSharp/TileDB.CSharp.csproj -o pack
-      - name: Publish TileDB.CSharp
+      - name: Push packages to NuGet
         shell: bash
         run: |
           cd pack

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,4 +24,5 @@ jobs:
       - name: Pack TileDB.CSharp
         run: dotnet pack -c Release ./sources/TileDB.CSharp/TileDB.CSharp.csproj
       - name: Publish TileDB.CSharp
-        run: dotnet nuget push ./*.nupkg -s https://api.nuget.org/v3/index.json -k ${{ secrets.TILEDB_CSHARP_NUGET_KEY }}
+        shell: bash
+        run: dotnet nuget push "*.nupkg" -s https://api.nuget.org/v3/index.json -k ${{ secrets.TILEDB_CSHARP_NUGET_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,13 @@ jobs:
         run: dotnet --info
       - name: Pack TileDB.CSharp
         run: dotnet pack -c Release ./sources/TileDB.CSharp/TileDB.CSharp.csproj -o pack
+      # In case pushing to NuGet fails we upload the packages as artifacts to push them ourselves.
+      # We must push these packages GitHub Actions generated because they are marked as deterministic.
+      - name: Upload packages as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: nuget-release
+          path: pack/
       - name: Push packages to NuGet
         shell: bash
         run: |

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -1,4 +1,4 @@
-name: TileDB-CSharp
+name: CI
 
 on:
   push:
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   Run-Tests:


### PR DESCRIPTION
This PR adds a workflow that runs when a tag gets pushed, packs `TileDB.CSharp` and pushes it to nuget.org. With that the release process gets fully automated, and produces [deterministic NuGet packages compatible with SourceLink](https://mitchelsellers.com/blog/article/net-5-deterministic-builds-source-linking).

Before merging it you have to create a [NuGet API key](https://www.nuget.org/account/apikeys) that can push new versions of `TileDB.CSharp` and add it as a [secret](https://github.com/TileDB-Inc/TileDB-CSharp/settings/secrets/actions) with the name `TILEDB_CSHARP_NUGET_KEY`.

![image](https://user-images.githubusercontent.com/12659251/205638673-bc850d1e-dd84-4d8b-a57e-a74bcebdeb8d.png)