### PR TITLE
Ensure the default `Context` is created only once and don't dispose it.

### DIFF
--- a/sources/TileDB.CSharp/Context.cs
+++ b/sources/TileDB.CSharp/Context.cs
@@ -9,7 +9,8 @@ namespace TileDB.CSharp
     {
         private readonly ContextHandle _handle;
         private readonly Config _config;
-        private bool _disposed;
+
+        private bool IsDefault { get; init; }
 
         public Context()
         {
@@ -25,35 +26,22 @@ namespace TileDB.CSharp
 
         public void Dispose()
         {
-            Dispose(true);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (_disposed) return;
-            if (disposing && !_handle.IsInvalid)
+            if (IsDefault)
             {
-                _handle.Dispose();
+                return;
             }
 
-            _disposed = true;
+            _handle.Dispose();
         }
 
         internal ContextHandle Handle => _handle;
 
-        private static Context? _default;
+        private static readonly Context _default = new() { IsDefault = true };
+
         /// <summary>
-        /// Get default context.
+        /// Gets the default <see cref="Context"/>.
         /// </summary>
-        /// <returns></returns>
-        public static Context GetDefault()
-        {
-            if (_default == null)
-            {
-                _default = new Context(new Config());
-            }
-            return _default;
-        }
+        public static Context GetDefault() => _default;
 
         /// <summary>
         /// Get statistic string.

--- a/sources/TileDB.CSharp/Context.cs
+++ b/sources/TileDB.CSharp/Context.cs
@@ -5,6 +5,9 @@ using TileDB.Interop;
 
 namespace TileDB.CSharp
 {
+    /// <summary>
+    /// Represents a TileDB context.
+    /// </summary>
     public sealed unsafe class Context : IDisposable
     {
         private readonly ContextHandle _handle;
@@ -12,18 +15,31 @@ namespace TileDB.CSharp
 
         private bool IsDefault { get; init; }
 
+        /// <summary>
+        /// Creates a <see cref="Context"/>.
+        /// </summary>
         public Context()
         {
             _handle = ContextHandle.Create();
             _config = new Config();
         }
 
+        /// <summary>
+        /// Creates a <see cref="Context"/> with an associated <see cref="CSharp.Config"/>.
+        /// </summary>
+        /// <param name="config">The context's config.</param>
         public Context(Config config)
         {
             _handle = ContextHandle.Create(config.Handle);
             _config = config;
         }
 
+        /// <summary>
+        /// Disposes the <see cref="Context"/>.
+        /// </summary>
+        /// <remarks>
+        /// Calling this method on the context returned by <see cref="GetDefault"/> will have no effect.
+        /// </remarks>
         public void Dispose()
         {
             if (IsDefault)
@@ -44,9 +60,8 @@ namespace TileDB.CSharp
         public static Context GetDefault() => _default;
 
         /// <summary>
-        /// Get statistic string.
+        /// Gets the <see cref="Context"/>'s statistics.
         /// </summary>
-        /// <returns></returns>
         public string Stats()
         {
             using var handle = _handle.Acquire();
@@ -57,9 +72,8 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Get config.
+        /// Gets the <see cref="Context"/>'s <see cref="Config"/>.
         /// </summary>
-        /// <returns></returns>
 
         public Config Config()
         {
@@ -67,9 +81,8 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Get last error message.
+        /// Gets the last error message associated with this <see cref="Context"/>.
         /// </summary>
-        /// <returns></returns>
         public string LastError()
         {
             var sb_result = new StringBuilder();
@@ -108,7 +121,7 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Cancel tasks.
+        /// Cancels the asynchronous tasks associated with this <see cref="Context"/>.
         /// </summary>
         public void CancelTasks()
         {
@@ -117,11 +130,12 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Set tag.
+        /// Sets a string key-value “tag” on the given context.
         /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        /// <exception cref="System.ArgumentException"></exception>
+        /// <param name="key">The tag's key.</param>
+        /// <param name="value">The tag's value.</param>
+        /// <exception cref="ArgumentException"><paramref name="key"/> or
+        /// <paramref name="value"/> are <see langword="null"/> or empty.</exception>
         public void SetTag(string key, string value)
         {
             if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(value))
@@ -135,10 +149,12 @@ namespace TileDB.CSharp
             handle_error(Methods.tiledb_ctx_set_tag(handle, ms_key, ms_value));
         }
 
-        #region error
         /// <summary>
-        /// Default event handler is just printing
+        /// An event that gets raised if an operation that used this <see cref="Context"/> failed.
         /// </summary>
+        /// <remarks>
+        /// By default it throws an exception.
+        /// </remarks>
         public event EventHandler<ErrorEventArgs> ErrorHappened = (_, e) =>
         {
             var error_msg = $"Error! Code:{e.Code},Message:{e.Message}";
@@ -193,6 +209,5 @@ namespace TileDB.CSharp
             var handler = ErrorHappened;
             handler(this, e); //fire the event
         }
-        #endregion
     }
 }


### PR DESCRIPTION
Calling `Context.GetDefault()` from multiple threads may create multiple `Context`s. This PR ensures only one will be created. Calling `Dispose()` on this default context will now do nothing (previously it was prone to causing subsequent operations to fail).

I also better documented the `Context` class.