### PR TITLE
Add support for fragment consolidation.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <LanguageVersion>latest</LanguageVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/sources/TileDB.CSharp/Array.cs
+++ b/sources/TileDB.CSharp/Array.cs
@@ -312,7 +312,7 @@ namespace TileDB.CSharp
         /// <param name="uri">The array's URI.</param>
         /// <param name="fragments">The URIs of the fragments to consolidate.</param>
         /// <param name="config">Configuration parameters for the consolidation. Optional.</param>
-        public static void ConsolidateFragments(Context ctx, string uri, IReadOnlyCollection<string> fragments, Config? config = null)
+        public static void ConsolidateFragments(Context ctx, string uri, IReadOnlyList<string> fragments, Config? config = null)
         {
             using var ctxHandle = ctx.Handle.Acquire();
             using var ms_uri = new MarshaledString(uri);

--- a/sources/TileDB.CSharp/Array.cs
+++ b/sources/TileDB.CSharp/Array.cs
@@ -306,11 +306,11 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Consolidates the given fragment URIs of an array into a single fragment.
+        /// Consolidates the given fragments of an array into a single fragment.
         /// </summary>
         /// <param name="ctx">The <see cref="Context"/> to use.</param>
         /// <param name="uri">The array's URI.</param>
-        /// <param name="fragments">The URIs of the fragments to consolidate.</param>
+        /// <param name="fragments">The names of the fragments to consolidate. They can be retrieved using <see cref="FragmentInfo.GetFragmentName"/>.</param>
         /// <param name="config">Configuration parameters for the consolidation. Optional.</param>
         public static void ConsolidateFragments(Context ctx, string uri, IReadOnlyList<string> fragments, Config? config = null)
         {

--- a/sources/TileDB.CSharp/Array.cs
+++ b/sources/TileDB.CSharp/Array.cs
@@ -297,11 +297,11 @@ namespace TileDB.CSharp
         /// <param name="ctx"></param>
         /// <param name="uri"></param>
         /// <param name="config"></param>
-        public static void Consolidate(Context ctx, string uri, Config config)
+        public static void Consolidate(Context ctx, string uri, Config? config = null)
         {
             using var ms_uri = new MarshaledString(uri);
             using var ctxHandle = ctx.Handle.Acquire();
-            using var configHandle = config.Handle.Acquire();
+            using var configHandle = config?.Handle.Acquire() ?? default;
             ctx.handle_error(Methods.tiledb_array_consolidate(ctxHandle, ms_uri, configHandle));
         }
 
@@ -311,11 +311,11 @@ namespace TileDB.CSharp
         /// <param name="ctx"></param>
         /// <param name="uri"></param>
         /// <param name="config"></param>
-        public static void Vacuum(Context ctx, string uri, Config config)
+        public static void Vacuum(Context ctx, string uri, Config? config = null)
         {
             using var ms_uri = new MarshaledString(uri);
             using var ctxHandle = ctx.Handle.Acquire();
-            using var configHandle = config.Handle.Acquire();
+            using var configHandle = config?.Handle.Acquire() ?? default;
             ctx.handle_error(Methods.tiledb_array_vacuum(ctxHandle, ms_uri, configHandle));
         }
 

--- a/sources/TileDB.CSharp/Array.cs
+++ b/sources/TileDB.CSharp/Array.cs
@@ -292,11 +292,11 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Consolidate an array.
+        /// Consolidates an array.
         /// </summary>
-        /// <param name="ctx"></param>
-        /// <param name="uri"></param>
-        /// <param name="config"></param>
+        /// <param name="ctx">The <see cref="Context"/> to use.</param>
+        /// <param name="uri">The array's URI.</param>
+        /// <param name="config">Configuration parameters for the consolidation. Optional.</param>
         public static void Consolidate(Context ctx, string uri, Config? config = null)
         {
             using var ms_uri = new MarshaledString(uri);
@@ -306,11 +306,11 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Vacuum the array.
+        /// Vacuums an array.
         /// </summary>
-        /// <param name="ctx"></param>
-        /// <param name="uri"></param>
-        /// <param name="config"></param>
+        /// <param name="ctx">The <see cref="Context"/> to use.</param>
+        /// <param name="uri">The array's URI.</param>
+        /// <param name="config">Configuration parameters for the consolidation. Optional.</param>
         public static void Vacuum(Context ctx, string uri, Config? config = null)
         {
             using var ms_uri = new MarshaledString(uri);

--- a/sources/TileDB.CSharp/Array.cs
+++ b/sources/TileDB.CSharp/Array.cs
@@ -316,12 +316,9 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx.Handle.Acquire();
             using var ms_uri = new MarshaledString(uri);
-            using var msc_fragments = new MarshaledStringCollection(fragments, stackalloc IntPtr[32]);
+            using var msc_fragments = new MarshaledStringCollection(fragments);
             using var configHandle = config?.Handle.Acquire() ?? default;
-            fixed (IntPtr* fragmentsPtr = msc_fragments.Strings)
-            {
-                ctx.handle_error(Methods.tiledb_array_consolidate_fragments(ctxHandle, ms_uri, (sbyte**)fragmentsPtr, (ulong)msc_fragments.Strings.Length, configHandle));
-            }
+            ctx.handle_error(Methods.tiledb_array_consolidate_fragments(ctxHandle, ms_uri, (sbyte**)msc_fragments.Strings, (ulong)msc_fragments.Count, configHandle));
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -237,6 +237,7 @@ namespace TileDB.CSharp
         /// The maximum value <paramref name="fragmentIndex"/> can take
         /// is determined by the <see cref="FragmentCount"/> property.
         /// </remarks>
+        /// <seealso cref="Array.ConsolidateFragments"/>
         public string GetFragmentName(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();

--- a/sources/TileDB.CSharp/Marshalling/MarshaledStringCollection.cs
+++ b/sources/TileDB.CSharp/Marshalling/MarshaledStringCollection.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using TileDB.Interop;
+
+namespace TileDB.CSharp.Marshalling
+{
+    internal unsafe ref struct MarshaledStringCollection
+    {
+        private ScratchBuffer<IntPtr> _nativeStrings;
+
+        public ReadOnlySpan<IntPtr> Strings => _nativeStrings.Span;
+
+        public MarshaledStringCollection(IReadOnlyCollection<string> strings, Span<IntPtr> preAllocatedSpan)
+        {
+            _nativeStrings = new ScratchBuffer<IntPtr>(strings.Count, preAllocatedSpan);
+            Span<IntPtr> buffer = _nativeStrings.Span;
+            buffer.Clear();
+
+            int i = 0;
+            try
+            {
+                foreach (string s in strings)
+                {
+                    buffer[i++] = MarshaledString.AllocNullTerminated(s).Pointer;
+                }
+                Debug.Assert(i == buffer.Length);
+            }
+            catch
+            {
+                Dispose();
+                throw;
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (ref IntPtr ptr in _nativeStrings.Span)
+            {
+                if (ptr != (IntPtr)0)
+                {
+                    Marshal.FreeHGlobal(ptr);
+                    ptr = (IntPtr)0;
+                }
+            }
+            _nativeStrings.Dispose();
+        }
+    }
+}

--- a/sources/TileDB.CSharp/Marshalling/MarshaledStringCollection.cs
+++ b/sources/TileDB.CSharp/Marshalling/MarshaledStringCollection.cs
@@ -12,20 +12,18 @@ namespace TileDB.CSharp.Marshalling
 
         public ReadOnlySpan<IntPtr> Strings => _nativeStrings.Span;
 
-        public MarshaledStringCollection(IReadOnlyCollection<string> strings, Span<IntPtr> preAllocatedSpan)
+        public MarshaledStringCollection(IReadOnlyList<string> strings, Span<IntPtr> preAllocatedSpan)
         {
             _nativeStrings = new ScratchBuffer<IntPtr>(strings.Count, preAllocatedSpan);
             Span<IntPtr> buffer = _nativeStrings.Span;
             buffer.Clear();
 
-            int i = 0;
             try
             {
-                foreach (string s in strings)
+                for (int i = 0; i < strings.Count; i++)
                 {
-                    buffer[i++] = MarshaledString.AllocNullTerminated(s).Pointer;
+                    buffer[i] = MarshaledString.AllocNullTerminated(strings[i]).Pointer;
                 }
-                Debug.Assert(i == buffer.Length);
             }
             catch
             {

--- a/sources/TileDB.CSharp/Marshalling/SafeHandleHolder.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandleHolder.cs
@@ -5,12 +5,12 @@ namespace TileDB.CSharp.Marshalling
 {
     internal struct SafeHandleHolder<TNativeObject> : IDisposable where TNativeObject : unmanaged
     {
-        private readonly SafeHandle _handle;
+        private readonly SafeHandle? _handle;
         private bool _isHeld;
 
 #pragma warning disable S3869 // "SafeHandle.DangerousGetHandle" should not be called
         public static unsafe implicit operator TNativeObject*(SafeHandleHolder<TNativeObject> holder) =>
-            (TNativeObject*)holder._handle.DangerousGetHandle();
+            (TNativeObject*)(holder._handle?.DangerousGetHandle() ?? (IntPtr)0);
 #pragma warning restore S3869 // "SafeHandle.DangerousGetHandle" should not be called
 
         public SafeHandleHolder(SafeHandle handle)
@@ -28,7 +28,7 @@ namespace TileDB.CSharp.Marshalling
             }
 
             _isHeld = false;
-            _handle.DangerousRelease();
+            _handle?.DangerousRelease();
         }
     }
 }

--- a/tests/TileDB.CSharp.Test/ArrayTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayTest.cs
@@ -167,6 +167,7 @@ namespace TileDB.CSharp.Test
             fragmentInfo.Load();
 
             Assert.AreEqual(1u, fragmentInfo.FragmentCount);
+            Assert.AreEqual(FragmentCount, fragmentInfo.FragmentToVacuumCount);
         }
 
         private ArraySchema BuildDenseArraySchema(Context context)

--- a/tests/TileDB.CSharp.Test/ArrayTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayTest.cs
@@ -160,9 +160,9 @@ namespace TileDB.CSharp.Test
 
             Assert.AreEqual(FragmentCount, fragmentInfo.FragmentCount);
 
-            string[] fragmentUris = Enumerable.Range(0, (int)FragmentCount).Select(x => fragmentInfo.GetFragmentName((uint)x)).ToArray();
+            string[] fragments = Enumerable.Range(0, (int)FragmentCount).Select(x => fragmentInfo.GetFragmentName((uint)x)).ToArray();
 
-            Array.ConsolidateFragments(context, uri, fragmentUris);
+            Array.ConsolidateFragments(context, uri, fragments);
 
             fragmentInfo.Load();
 

--- a/tests/TileDB.CSharp.Test/ArrayTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace TileDB.CSharp.Test
@@ -123,11 +124,54 @@ namespace TileDB.CSharp.Test
             Assert.IsNotNull(array_schema_loaded);
         }
 
+        [TestMethod]
+        public void TestConsolidateFragments()
+        {
+            const uint FragmentCount = 10;
+
+            var context = Context.GetDefault();
+
+            using var uri = new TemporaryDirectory("array_consolidate_fragments");
+
+            using (var schema = BuildDenseArraySchema(context))
+            using (var array = new Array(context, uri))
+            {
+                array.Create(schema);
+            }
+
+            int[] a1Data = Enumerable.Range(1, 10).Select(x => x * x).ToArray();
+            byte[] a2Data = "aabbcccdeffggghhhhijj"u8.ToArray();
+            ulong[] a2Offsets = { 0, 2, 4, 7, 8, 9, 11, 14, 17, 18 };
+            for (uint i = 0; i < FragmentCount; i++)
+            {
+                using var array = new Array(context, uri);
+                array.Open(QueryType.Write);
+
+                using var query = new Query(context, array, QueryType.Write);
+                query.SetDataBuffer("a1", a1Data);
+                query.SetDataBuffer("a2", a2Data);
+                query.SetOffsetsBuffer("a2", a2Offsets);
+
+                query.Submit();
+            }
+
+            using var fragmentInfo = new FragmentInfo(context, uri);
+            fragmentInfo.Load();
+
+            Assert.AreEqual(FragmentCount, fragmentInfo.FragmentCount);
+
+            string[] fragmentUris = Enumerable.Range(0, (int)FragmentCount).Select(x => fragmentInfo.GetFragmentName((uint)x)).ToArray();
+
+            Array.ConsolidateFragments(context, uri, fragmentUris);
+
+            fragmentInfo.Load();
+
+            Assert.AreEqual(1u, fragmentInfo.FragmentCount);
+        }
+
         private ArraySchema BuildDenseArraySchema(Context context)
         {
-            var bound = new short[] { 1, 10 };
-            const short extent = 5;
-            var dimension = Dimension.Create(context, "dim1", bound, extent);
+            var dimension = Dimension.Create<short>(context, "dim1", 1, 10, 5);
             Assert.IsNotNull(dimension);
             var domain = new Domain(context);
             Assert.IsNotNull(domain);


### PR DESCRIPTION
[SC-22323](https://app.shortcut.com/tiledb-inc/story/22323/build-staged-consolidation-example-and-tests)

I also tidied up the `Array.Consolidate` and `Vacuum` methods.

~~TODO: write tests.~~