### PR TITLE
Clean-up the `VFS` class and expose the remaining VFS APIs.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,11 @@ csharp_style_var_for_built_in_types=true:silent
 csharp_style_var_when_type_is_apparent=true:silent
 csharp_style_var_elsewhere=true:silent
 
+# This takes the address of, gets the size of, or declares a pointer to a managed type.
+# We check at runtime that generic types are not managed, and either way we can't take
+# a pointer to the heap by accident without using fixed or Unsafe.AsPointer.
+dotnet_diagnostic.CS8500.severity = None
+
 ##
 ## SonarAnalyzers.CSharp
 ##

--- a/sources/TileDB.CSharp/Context.cs
+++ b/sources/TileDB.CSharp/Context.cs
@@ -130,6 +130,18 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
+        /// Checks whether the given <see cref="FileSystemType"/> is supported.
+        /// </summary>
+        /// <param name="fileSystem">The file system type to check.</param>
+        public bool IsFileSystemSupported(FileSystemType fileSystem)
+        {
+            using var handle = _handle.Acquire();
+            int result;
+            handle_error(Methods.tiledb_ctx_is_supported_fs(handle, (tiledb_filesystem_t)fileSystem, &result));
+            return result != 0;
+        }
+
+        /// <summary>
         /// Sets a string key-value “tag” on the given context.
         /// </summary>
         /// <param name="key">The tag's key.</param>

--- a/sources/TileDB.CSharp/Enums.cs
+++ b/sources/TileDB.CSharp/Enums.cs
@@ -759,21 +759,29 @@ namespace TileDB.CSharp
     }
 
     /// <summary>
-    /// Specifies the VFS mode.
+    /// Specifies the mode in which a <see cref="VFSFile"/> is opened.
     /// </summary>
+    /// <seealso cref="VFS.Open"/>
     public enum VfsMode : uint
     {
         /// <summary>
-        /// Read mode.
+        /// The file is opened for reading.
+        /// An exception will be thrown if it does not exist.
         /// </summary>
         Read = tiledb_vfs_mode_t.TILEDB_VFS_READ,
         /// <summary>
-        /// Write mode.
+        /// The file is opened for writing.
+        /// If it exists, it will be overwritten.
         /// </summary>
         Write = tiledb_vfs_mode_t.TILEDB_VFS_WRITE,
         /// <summary>
-        /// Append mode.
+        /// The file is opened for writing.
+        /// If it exists, the write will start from its end.
         /// </summary>
+        /// <remarks>
+        /// <see cref="FileSystemType.S3"/> does not support this
+        /// operation and, thus, an exception will be thrown in that case.
+        /// </remarks>
         Append = tiledb_vfs_mode_t.TILEDB_VFS_APPEND,
         [Obsolete(Obsoletions.LegacyEnumNamesMessage + " Use Read instead.", DiagnosticId = Obsoletions.LegacyEnumNamesDiagId, UrlFormat = Obsoletions.SharedUrlFormat), EditorBrowsable(EditorBrowsableState.Never)]
         TILEDB_VFS_READ = Read,

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSFileHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSFileHandle.cs
@@ -29,6 +29,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(vfsFh);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSFileHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSFileHandle.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Runtime.InteropServices;
+using TileDB.Interop;
+
+namespace TileDB.CSharp.Marshalling.SafeHandles
+{
+    internal unsafe sealed class VFSFileHandle : SafeHandle
+    {
+        public VFSFileHandle() : base(IntPtr.Zero, true) { }
+
+        public VFSFileHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+        public static VFSFileHandle Open(Context context, VFSHandle vfsHandle, string uri, tiledb_vfs_mode_t mode)
+        {
+            var handle = new VFSFileHandle();
+            var successful = false;
+            tiledb_vfs_fh_t* vfsFh = null;
+            try
+            {
+                using var contextHandle = context.Handle.Acquire();
+                using var vfsHandleHolder = vfsHandle.Acquire();
+                using var ms_uri = new MarshaledString(uri);
+                context.handle_error(Methods.tiledb_vfs_open(contextHandle, vfsHandleHolder, ms_uri, mode, &vfsFh));
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(vfsFh);
+                }
+            }
+
+            return handle;
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            fixed (IntPtr* p = &handle)
+            {
+                Methods.tiledb_vfs_fh_free((tiledb_vfs_fh_t**)p);
+            }
+            return true;
+        }
+
+        internal void InitHandle(tiledb_vfs_fh_t* h) { SetHandle((IntPtr)h); }
+        public override bool IsInvalid => handle == IntPtr.Zero;
+
+        public SafeHandleHolder<tiledb_vfs_fh_t> Acquire() => new(this);
+    }
+}

--- a/sources/TileDB.CSharp/VFS.cs
+++ b/sources/TileDB.CSharp/VFS.cs
@@ -4,14 +4,24 @@ using TileDB.Interop;
 
 namespace TileDB.CSharp
 {
+    /// <summary>
+    /// Represents a TileDB VFS (Virtual File System) object.
+    /// </summary>
     public unsafe class VFS : IDisposable
     {
         private readonly VFSHandle handle_;
         private readonly Context ctx_;
         private bool disposed_ = false;
 
+        /// <summary>
+        /// Creates a <see cref="VFS"/>.
+        /// </summary>
         public VFS() : this(Context.GetDefault()) { }
 
+        /// <summary>
+        /// Creates a <see cref="VFS"/> associated with the given <see cref="Context"/>.
+        /// </summary>
+        /// <param name="ctx">The context to associate the VFS.</param>
         public VFS(Context ctx) 
         {
             ctx_ = ctx;
@@ -24,6 +34,9 @@ namespace TileDB.CSharp
             handle_ = handle;
         }
 
+        /// <summary>
+        /// Disposes this <see cref="VFS"/>.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -44,17 +57,16 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Get config.
+        /// Gets the <see cref="Config"/> associated with this <see cref="VFS"/>.
         /// </summary>
-        /// <returns></returns>
         public Config Config() {
             return ctx_.Config();
         }
 
         /// <summary>
-        /// Create bucket.
+        /// Creates an object-store bucket.
         /// </summary>
-        /// <param name="uri"></param>
+        /// <param name="uri">The URI of the bucket to be created.</param>
         public void CreateBucket(string uri) {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
@@ -63,9 +75,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Remove bucket.
+        /// Removes an object-store bucket.
         /// </summary>
-        /// <param name="uri"></param>
+        /// <param name="uri">The URI of the bucket to be removed.</param>
         public void RemoveBucket(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -75,9 +87,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Empty bucket.
+        /// Deletes the contents of an object-store bucket.
         /// </summary>
-        /// <param name="uri"></param>
+        /// <param name="uri">The URI of the bucket to be emptied.</param>
         public void EmptyBucket(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -87,10 +99,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Test if a bucket is empty or not.
+        /// Checks whether a bucket is empty or not.
         /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
+        /// <param name="uri">The URI of the bucket to be checked.</param>
         public bool IsEmptyBucket(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -102,10 +113,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Test if it is bucket or not.
+        /// Checks whether a URI points to a bucket.
         /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
+        /// <param name="uri">The URI to check.</param>
         public bool IsBucket(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -117,9 +127,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Create directory.
+        /// Creates a directory.
         /// </summary>
-        /// <param name="uri"></param>
+        /// <param name="uri">The directory's URI.</param>
         public void CreateDir(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -129,10 +139,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Test if it is directory or not.
+        /// Checks whether a URI points to a directory.
         /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
+        /// <param name="uri">The URI to check.</param>
         public bool IsDir(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -144,9 +153,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Remove a directory.
+        /// Removes a directory.
         /// </summary>
-        /// <param name="uri"></param>
+        /// <param name="uri">The directory's URI.</param>
         public void RemoveDir(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -156,10 +165,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Test if it is file or not.
+        /// Checks whether a URI points to a file.
         /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
+        /// <param name="uri">The URI to check.</param>
         public bool IsFile(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -171,9 +179,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Remove a file.
+        /// Removes a file.
         /// </summary>
-        /// <param name="uri"></param>
+        /// <param name="uri">The file's URI.</param>
         public void RemoveFile(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -183,10 +191,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Get directory size.
+        /// Gets the size of a directory.
         /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
+        /// <param name="uri">The directory's URI.</param>
         public ulong DirSize(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -198,10 +205,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Get file size.
+        /// Gets the size of a file.
         /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
+        /// <param name="uri">The file's URI.</param>
         public ulong FileSize(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -213,10 +219,10 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Move file.
+        /// Renames a file.
         /// </summary>
-        /// <param name="old_uri"></param>
-        /// <param name="new_uri"></param>
+        /// <param name="old_uri">The source URI of the file.</param>
+        /// <param name="new_uri">The destination URI of the file. Will be overwritten if it exists.</param>
         public void MoveFile(string old_uri, string new_uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -227,10 +233,10 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Move directory.
+        /// Renames a directory.
         /// </summary>
-        /// <param name="old_uri"></param>
-        /// <param name="new_uri"></param>
+        /// <param name="old_uri">The source URI of the directory.</param>
+        /// <param name="new_uri">The destination URI of the directory. Will be overwritten if it exists.</param>
         public void MoveDir(string old_uri, string new_uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -241,10 +247,10 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Copy file.
+        /// Copies a file.
         /// </summary>
-        /// <param name="old_uri"></param>
-        /// <param name="new_uri"></param>
+        /// <param name="old_uri">The source URI of the file.</param>
+        /// <param name="new_uri">The destination URI of the file. Will be overwritten if it exists.</param>
         public void CopyFile(string old_uri, string new_uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -255,10 +261,10 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Copy directory.
+        /// Copies a directory.
         /// </summary>
-        /// <param name="old_uri"></param>
-        /// <param name="new_uri"></param>
+        /// <param name="old_uri">The source URI of the directory.</param>
+        /// <param name="new_uri">The destination URI of the directory. Will be overwritten if it exists.</param>
         public void CopyDir(string old_uri, string new_uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
@@ -269,9 +275,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Touch a file.
+        /// Touches a file, i.e., creates a new empty file.
         /// </summary>
-        /// <param name="uri"></param>
+        /// <param name="uri">The file's URI.</param>
         public void Touch(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();

--- a/sources/TileDB.CSharp/VFS.cs
+++ b/sources/TileDB.CSharp/VFS.cs
@@ -43,8 +43,6 @@ namespace TileDB.CSharp
             }
         }
 
-        #region capi functions 
-
         /// <summary>
         /// Get config.
         /// </summary>
@@ -60,7 +58,7 @@ namespace TileDB.CSharp
         public void CreateBucket(string uri) {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             ctx_.handle_error(Methods.tiledb_vfs_create_bucket(ctxHandle, handle, ms_uri));
         }
 
@@ -72,7 +70,7 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             ctx_.handle_error(Methods.tiledb_vfs_remove_bucket(ctxHandle, handle, ms_uri));
         }
 
@@ -84,7 +82,7 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             ctx_.handle_error(Methods.tiledb_vfs_empty_bucket(ctxHandle, handle, ms_uri));
         }
 
@@ -97,7 +95,7 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             int is_empty = 0;
             ctx_.handle_error(Methods.tiledb_vfs_is_empty_bucket(ctxHandle, handle, ms_uri, &is_empty));
             return is_empty > 0;
@@ -112,7 +110,7 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             int is_bucket = 0;
             ctx_.handle_error(Methods.tiledb_vfs_is_bucket(ctxHandle, handle, ms_uri, &is_bucket));
             return is_bucket > 0;
@@ -126,7 +124,7 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             ctx_.handle_error(Methods.tiledb_vfs_create_dir(ctxHandle, handle, ms_uri));
         }
 
@@ -139,7 +137,7 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             int is_dir = 0;
             ctx_.handle_error(Methods.tiledb_vfs_is_dir(ctxHandle, handle, ms_uri, &is_dir));
             return is_dir > 0;
@@ -153,7 +151,7 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             ctx_.handle_error(Methods.tiledb_vfs_remove_dir(ctxHandle, handle, ms_uri));
         }
 
@@ -166,7 +164,7 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             int is_file = 0;
             ctx_.handle_error(Methods.tiledb_vfs_is_file(ctxHandle, handle, ms_uri, &is_file));
             return is_file > 0;
@@ -180,7 +178,7 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             ctx_.handle_error(Methods.tiledb_vfs_remove_file(ctxHandle, handle, ms_uri));
         }
 
@@ -189,12 +187,12 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="uri"></param>
         /// <returns></returns>
-        public UInt64 DirSize(string uri)
+        public ulong DirSize(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
-            UInt64 size = 0;
+            using var ms_uri = new MarshaledString(uri);
+            ulong size = 0;
             ctx_.handle_error(Methods.tiledb_vfs_dir_size(ctxHandle, handle, ms_uri, &size));
             return size;
         }
@@ -204,12 +202,12 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="uri"></param>
         /// <returns></returns>
-        public UInt64 FileSize(string uri)
+        public ulong FileSize(string uri)
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
-            UInt64 size = 0;
+            using var ms_uri = new MarshaledString(uri);
+            ulong size = 0;
             ctx_.handle_error(Methods.tiledb_vfs_file_size(ctxHandle, handle, ms_uri, &size));
             return size;
         }
@@ -223,8 +221,8 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_old_uri = new MarshaledString(old_uri);
-            MarshaledString ms_new_uri = new MarshaledString(new_uri);
+            using var ms_old_uri = new MarshaledString(old_uri);
+            using var ms_new_uri = new MarshaledString(new_uri);
             ctx_.handle_error(Methods.tiledb_vfs_move_file(ctxHandle, handle, ms_old_uri, ms_new_uri));
         }
 
@@ -237,8 +235,8 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_old_uri = new MarshaledString(old_uri);
-            MarshaledString ms_new_uri = new MarshaledString(new_uri);
+            using var ms_old_uri = new MarshaledString(old_uri);
+            using var ms_new_uri = new MarshaledString(new_uri);
             ctx_.handle_error(Methods.tiledb_vfs_move_dir(ctxHandle, handle, ms_old_uri, ms_new_uri));
         }
 
@@ -251,8 +249,8 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_old_uri = new MarshaledString(old_uri);
-            MarshaledString ms_new_uri = new MarshaledString(new_uri);
+            using var ms_old_uri = new MarshaledString(old_uri);
+            using var ms_new_uri = new MarshaledString(new_uri);
             ctx_.handle_error(Methods.tiledb_vfs_copy_file(ctxHandle, handle, ms_old_uri, ms_new_uri));
         }
 
@@ -265,8 +263,8 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_old_uri = new MarshaledString(old_uri);
-            MarshaledString ms_new_uri = new MarshaledString(new_uri);
+            using var ms_old_uri = new MarshaledString(old_uri);
+            using var ms_new_uri = new MarshaledString(new_uri);
             ctx_.handle_error(Methods.tiledb_vfs_copy_dir(ctxHandle, handle, ms_old_uri, ms_new_uri));
         }
 
@@ -278,9 +276,8 @@ namespace TileDB.CSharp
         {
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
-            MarshaledString ms_uri = new MarshaledString(uri);
+            using var ms_uri = new MarshaledString(uri);
             ctx_.handle_error(Methods.tiledb_vfs_touch(ctxHandle, handle, ms_uri));
         }
-        #endregion capi functions
     }
 }

--- a/sources/TileDB.CSharp/VFS.cs
+++ b/sources/TileDB.CSharp/VFS.cs
@@ -7,11 +7,10 @@ namespace TileDB.CSharp
     /// <summary>
     /// Represents a TileDB VFS (Virtual File System) object.
     /// </summary>
-    public unsafe class VFS : IDisposable
+    public unsafe sealed class VFS : IDisposable
     {
         private readonly VFSHandle handle_;
         private readonly Context ctx_;
-        private bool disposed_ = false;
 
         /// <summary>
         /// Creates a <see cref="VFS"/>.
@@ -39,21 +38,7 @@ namespace TileDB.CSharp
         /// </summary>
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposed_)
-            {
-                if (disposing && (!handle_.IsInvalid))
-                {
-                    handle_.Dispose();
-                }
-
-                disposed_ = true;
-            }
+            handle_.Dispose();
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/VFS.cs
+++ b/sources/TileDB.CSharp/VFS.cs
@@ -276,6 +276,18 @@ namespace TileDB.CSharp
             ctx_.handle_error(Methods.tiledb_vfs_touch(ctxHandle, handle, ms_uri));
         }
 
+        /// <summary>
+        /// Opens a file.
+        /// </summary>
+        /// <param name="uri">The file's URI.</param>
+        /// <param name="mode">The mode in which the file is opened.</param>
+        /// <returns>A <see cref="VFSFile"/> object that can be used to perform operations on the file.</returns>
+        public VFSFile Open(string uri, VfsMode mode)
+        {
+            VFSFileHandle handle = VFSFileHandle.Open(ctx_, handle_, uri, (tiledb_vfs_mode_t)mode);
+            return new(ctx_, handle);
+        }
+
         [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
         private static int VisitCallback(sbyte* uriPtr, void* data)
         {

--- a/sources/TileDB.CSharp/VFSFile.cs
+++ b/sources/TileDB.CSharp/VFSFile.cs
@@ -51,12 +51,12 @@ namespace TileDB.CSharp
         /// <exception cref="Exception">The remaining data in the file after <paramref name="offset"/>
         /// are less than <paramref name="buffer"/>'s <see cref="Span{T}.Length"/>.</exception>
         /// <remarks>If you want to read more than <see cref="int.MaxValue"/> bytes
-        /// of data you should call <see cref="Read(ulong, byte*, ulong)"/>.</remarks>
-        public void Read(ulong offset, Span<byte> buffer)
+        /// of data you should call <see cref="ReadExactly(ulong, byte*, ulong)"/>.</remarks>
+        public void ReadExactly(ulong offset, Span<byte> buffer)
         {
             fixed(byte* ptr = &MemoryMarshal.GetReference(buffer))
             {
-                Read(offset, ptr, (ulong)buffer.Length);
+                ReadExactly(offset, ptr, (ulong)buffer.Length);
             }
         }
 
@@ -68,8 +68,8 @@ namespace TileDB.CSharp
         /// <param name="count">The number of bytes to read.</param>
         /// <exception cref="Exception">The remaining data in the file after <paramref name="offset"/>
         /// are less than <paramref name="count"/>.</exception>
-        /// <seealso cref="Read(ulong, Span{byte})"/>
-        public void Read(ulong offset, byte* buffer, ulong count)
+        /// <seealso cref="ReadExactly(ulong, Span{byte})"/>
+        public void ReadExactly(ulong offset, byte* buffer, ulong count)
         {
             using var contextHandle = _context.Handle.Acquire();
             using var handle = _handle.Acquire();

--- a/sources/TileDB.CSharp/VFSFile.cs
+++ b/sources/TileDB.CSharp/VFSFile.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using TileDB.CSharp.Marshalling.SafeHandles;
+using TileDB.Interop;
+
+namespace TileDB.CSharp
+{
+    /// <summary>
+    /// Represents a TileDB VFS (Virtual File System) file object.
+    /// </summary>
+    /// <remarks>
+    /// This class cannot be directly created.
+    /// To obtain an instance of it, use <see cref="VFS.Open"/>.
+    /// </remarks>
+    public unsafe sealed class VFSFile : IDisposable
+    {
+        private readonly Context _context;
+        private readonly VFSFileHandle _handle;
+
+        internal VFSFile(Context context, VFSFileHandle handle)
+        {
+            _context = context;
+            _handle = handle;
+        }
+
+        /// <summary>
+        /// Whether the file is closed.
+        /// </summary>
+        public bool IsClosed
+        {
+            get
+            {
+                using var contextHandle = _context.Handle.Acquire();
+                using var handle = _handle.Acquire();
+                int isClosed;
+                _context.handle_error(Methods.tiledb_vfs_fh_is_closed(contextHandle, handle, &isClosed));
+                return isClosed != 0;
+            }
+        }
+
+        /// <summary>
+        /// Disposes this <see cref="VFSFile"/>.
+        /// </summary>
+        public void Dispose() => _handle.Dispose();
+
+        /// <summary>
+        /// Reads from the file at a specified offset.
+        /// </summary>
+        /// <param name="offset">The offset to read from.</param>
+        /// <param name="buffer">A <see cref="Span{T}"/> of bytes where the file's data will be written into.</param>
+        /// <exception cref="Exception">The remaining data in the file after <paramref name="offset"/>
+        /// are less than <paramref name="buffer"/>'s <see cref="Span{T}.Length"/>.</exception>
+        /// <remarks>If you want to read more than <see cref="int.MaxValue"/> bytes
+        /// of data you should call <see cref="Read(ulong, byte*, ulong)"/>.</remarks>
+        public void Read(ulong offset, Span<byte> buffer)
+        {
+            fixed(byte* ptr = &MemoryMarshal.GetReference(buffer))
+            {
+                Read(offset, ptr, (ulong)buffer.Length);
+            }
+        }
+
+        /// <summary>
+        /// Reads from the file at a specified offset.
+        /// </summary>
+        /// <param name="offset">The offset to read from.</param>
+        /// <param name="buffer">A pointer to the memory region where the file's data will be written into.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <exception cref="Exception">The remaining data in the file after <paramref name="offset"/>
+        /// are less than <paramref name="count"/>.</exception>
+        /// <seealso cref="Read(ulong, Span{byte})"/>
+        public void Read(ulong offset, byte* buffer, ulong count)
+        {
+            using var contextHandle = _context.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            _context.handle_error(Methods.tiledb_vfs_read(contextHandle, handle, offset, buffer, count));
+        }
+
+        /// <summary>
+        /// Writes data to the end of the file.
+        /// </summary>
+        /// <param name="buffer">A <see cref="ReadOnlySpan{T}"/> of bytes whose content will be written.</param>
+        /// <remarks>
+        /// <para>If you want to write more than <see cref="int.MaxValue"/> bytes
+        /// of data you should call <see cref="Write(byte*, ulong)"/>.</para>
+        /// <para>If the file does not exist, it will be created.</para>
+        /// </remarks>
+        public void Write(ReadOnlySpan<byte> buffer)
+        {
+            fixed (byte* ptr = &MemoryMarshal.GetReference(buffer))
+            {
+                Write(ptr, (ulong)buffer.Length);
+            }
+        }
+
+        /// <summary>
+        /// Writes data to the end of the file.
+        /// </summary>
+        /// <param name="buffer">A pointer to the bytes that will be written.</param>
+        /// <param name="count">The number of bytes to write.</param>
+        /// <remarks>
+        /// If the file does not exist, it will be created.
+        /// </remarks>
+        public void Write(byte* buffer, ulong count)
+        {
+            using var contextHandle = _context.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            _context.handle_error(Methods.tiledb_vfs_write(contextHandle, handle, buffer, count));
+        }
+
+        /// <summary>
+        /// Closes a file. This flushes the buffered data into the file when the file was opened in write (or append) mode.
+        /// </summary>
+        /// <remarks>
+        /// It is particularly important to be called after <see cref="FileSystemType.S3"/> writes, as otherwise the writes will not take effect.
+        /// </remarks>
+        public void Close()
+        {
+            using var contextHandle = _context.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            _context.handle_error(Methods.tiledb_vfs_close(contextHandle, handle));
+        }
+
+        /// <summary>
+        /// Flushes the file's internal buffers.
+        /// </summary>
+        /// <remarks>
+        /// This has no effect for <see cref="FileSystemType.S3"/>.
+        /// </remarks>
+        public void Flush()
+        {
+            using var contextHandle = _context.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            _context.handle_error(Methods.tiledb_vfs_sync(contextHandle, handle));
+        }
+    }
+}

--- a/tests/TileDB.CSharp.Test/ContextTest.cs
+++ b/tests/TileDB.CSharp.Test/ContextTest.cs
@@ -56,6 +56,7 @@ namespace TileDB.CSharp.Test
         public void TestIsFileSystemSupported()
         {
             using var ctx = new Context();
+            // Info taken from https://github.com/TileDB-Inc/TileDB/blob/dev/azure-pipelines.yml.
             Assert.AreEqual(!OperatingSystem.IsWindows(), ctx.IsFileSystemSupported(FileSystemType.Hdfs));
             Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.S3));
             Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.Azure));

--- a/tests/TileDB.CSharp.Test/ContextTest.cs
+++ b/tests/TileDB.CSharp.Test/ContextTest.cs
@@ -1,4 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Runtime.InteropServices;
 
 namespace TileDB.CSharp.Test
 {
@@ -48,6 +50,17 @@ namespace TileDB.CSharp.Test
             Assert.AreEqual("512000000", config2.Get("sm.memory_budget"));
             Assert.AreEqual("5000", config2.Get("vfs.s3.connect_timeout_ms"));
             Assert.AreEqual("localhost:8888", config2.Get("vfs.s3.endpoint_override"));
+        }
+
+        [TestMethod]
+        public void TestIsFileSystemSupported()
+        {
+            using var ctx = new Context();
+            Assert.AreEqual(!OperatingSystem.IsWindows(), ctx.IsFileSystemSupported(FileSystemType.Hdfs));
+            Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.S3));
+            Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.Azure));
+            Assert.AreEqual(!(OperatingSystem.IsWindows() || (OperatingSystem.IsMacOS() && RuntimeInformation.ProcessArchitecture is Architecture.Arm64)), ctx.IsFileSystemSupported(FileSystemType.Hdfs));
+            Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.InMemory));
         }
     }
 }

--- a/tests/TileDB.CSharp.Test/VFSTest.cs
+++ b/tests/TileDB.CSharp.Test/VFSTest.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using TileDB.CSharp;
+using System.IO;
+using System.Security.Cryptography;
 
 namespace TileDB.CSharp.Test
 {
@@ -9,21 +10,88 @@ namespace TileDB.CSharp.Test
         [TestMethod]
         public void TestDir()
         {
-            var ctx = Context.GetDefault();
-            using (var vfs = new VFS(ctx)) 
+            using var vfs = new VFS();
+
+            string dirname = "tempdir";
+            if (vfs.IsDir(dirname))
             {
-                string dirname = "tempdir";
-                if(vfs.IsDir(dirname)) 
-                {
-                    vfs.RemoveDir(dirname);
-                }
-
-                vfs.CreateDir(dirname);
-                Assert.IsTrue(vfs.IsDir(dirname));
-
                 vfs.RemoveDir(dirname);
             }
+
+            vfs.CreateDir(dirname);
+            Assert.IsTrue(vfs.IsDir(dirname));
+
+            vfs.RemoveDir(dirname);
+        }
+
+        [TestMethod]
+        public void TestReadWrite()
+        {
+            const int DataSize = 4096;
+
+            using var dir = new TemporaryDirectory("vfs-read-write");
+            var fileUri = Path.Combine(dir, "file");
+
+            using var vfs = new VFS();
+
+            byte[] dataWrite = new byte[DataSize];
+            RandomNumberGenerator.Fill(dataWrite);
+
+            using (var f = vfs.Open(fileUri, VfsMode.Write))
+            {
+                f.Write(dataWrite);
+            }
+
+            using (var f = vfs.Open(fileUri, VfsMode.Read))
+            {
+                byte[] dataRead = new byte[DataSize];
+                f.ReadExactly(0, dataRead);
+                CollectionAssert.AreEqual(dataWrite, dataRead);
+            }
+        }
+
+        [TestMethod]
+        public void TestVisit()
+        {
+            using var dir = new TemporaryDirectory("vfs-visit");
+
+            using var vfs = new VFS();
+            vfs.Touch(Path.Combine(dir, "file1"));
+            vfs.Touch(Path.Combine(dir, "file2"));
+            vfs.Touch(Path.Combine(dir, "file3"));
+
+            int i = 0;
+
+            vfs.VisitChildren(dir, (_, _) =>
+            {
+                i++;
+                return i != 2;
+            }, null);
+
+            Assert.AreEqual(2, i);
+        }
+
+        [TestMethod]
+        public void TestVisitPropagatesExceptions()
+        {
+            using var dir = new TemporaryDirectory("vfs-visit-exceptions");
+
+            using var vfs = new VFS();
+            vfs.Touch(Path.Combine(dir, "file"));
+
+            try
+            {
+                vfs.VisitChildren(dir, static (_, _) =>
+                {
+                    Assert.Fail("Should be caught.");
+                    return false;
+                }, null);
+            }
+            catch (AssertFailedException)
+            {
+                return;
+            }
+            Assert.Fail("Exception was not propagated.");
         }
     }
-
-}//namespace
+}


### PR DESCRIPTION
[SC-24114](https://app.shortcut.com/tiledb-inc/story/24114/expose-all-vfs-functions-in-c)