### PR TITLE
Simplify testing with custom native binaries.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,11 @@
     It is enabled by default in nightly builds. -->
     <DevelopmentBuild Condition="'$(TILEDB_NIGHTLY_BUILD)' != ''">true</DevelopmentBuild>
 
-    <!-- If you want to manually test with custom builds, place the native packages
+    <!-- If you want to manually test with custom builds, you have two options. The first
+    is to uncomment the following property and change it to the path of your binary. -->
+    <!-- <LocalLibraryFile>../TileDB/dist/bin/tiledb.dll</LocalLibraryFile> -->
+
+    <!-- The second option which is used by nightly builds is to place the native packages
     (Local.TileDB.Native and the one corresponding to your RID are required), and
     uncomment the following line. You might also need to clean the repository. -->
     <!-- <DevelopmentBuild>true</DevelopmentBuild> -->

--- a/sources/TileDB.CSharp/TileDB.CSharp.csproj
+++ b/sources/TileDB.CSharp/TileDB.CSharp.csproj
@@ -2,7 +2,7 @@
   <Import Project="../NuGet.props" />
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
-    <IsPackable Condition="$(DevelopmentBuild) == true">false</IsPackable>
+    <IsPackable Condition="$(DevelopmentBuild) == true OR '$(LocalLibraryFile)' != ''">false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <RootNamespace>TileDB.CSharp</RootNamespace>
@@ -17,6 +17,7 @@
     <None Include="README.md" Pack="True" PackagePath="" />
     <None Include="build/TileDB.CSharp.targets" Pack="True" PackagePath="build" />
     <None Include="buildTransitive/TileDB.CSharp.targets" Pack="True" PackagePath="buildTransitive" />
-    <PackageReference Include="$(TileDBNativePackageName)" />
+    <None Include="$(LocalLibraryFile)" CopyToOutputDirectory="PreserveNewest" />
+    <PackageReference Condition="'$(LocalLibraryFile)' == ''" Include="$(TileDBNativePackageName)" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We add a `LocalLibraryFile` property that if set, it will just copy the native file to the output directory, without using the native NuGet packages mechanism.

Tested locally on a Windows machine and works.

c.c. @ihnorton who had asked for it.