### PR TITLE
Invalidate safe handles that failed to be created.

### DIFF
--- a/sources/TileDB.CSharp/Array.cs
+++ b/sources/TileDB.CSharp/Array.cs
@@ -235,6 +235,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(array_schema_p);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
             return new ArraySchema(_ctx, handle);
         }

--- a/sources/TileDB.CSharp/ArraySchema.cs
+++ b/sources/TileDB.CSharp/ArraySchema.cs
@@ -239,6 +239,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(filter_list_p);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return new FilterList(_ctx, handle);
@@ -268,6 +272,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(filter_list_p);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return new FilterList(_ctx, handle);
@@ -296,6 +304,10 @@ namespace TileDB.CSharp
                 if (successful)
                 {
                     handle.InitHandle(domain_p);
+                }
+                else
+                {
+                    handle.SetHandleAsInvalid();
                 }
             }
 
@@ -353,6 +365,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(attribute_p);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return new Attribute(_ctx, handle);
@@ -383,6 +399,10 @@ namespace TileDB.CSharp
                 if (successful)
                 {
                     handle.InitHandle(attribute_p);
+                }
+                else
+                {
+                    handle.SetHandleAsInvalid();
                 }
             }
 
@@ -429,6 +449,10 @@ namespace TileDB.CSharp
                 if (successful)
                 {
                     handle.InitHandle(array_schema_p);
+                }
+                else
+                {
+                    handle.SetHandleAsInvalid();
                 }
             }
             return new ArraySchema(ctx, handle);

--- a/sources/TileDB.CSharp/Attribute.cs
+++ b/sources/TileDB.CSharp/Attribute.cs
@@ -155,6 +155,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(filter_list_p);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return new FilterList(_ctx, handle);

--- a/sources/TileDB.CSharp/Dimension.cs
+++ b/sources/TileDB.CSharp/Dimension.cs
@@ -93,6 +93,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(filter_list_p);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return new FilterList(_ctx, handle);

--- a/sources/TileDB.CSharp/Domain.cs
+++ b/sources/TileDB.CSharp/Domain.cs
@@ -116,6 +116,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(dimension_p);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return new Dimension(_ctx, handle);
@@ -146,6 +150,10 @@ namespace TileDB.CSharp
                 if (successful)
                 {
                     handle.InitHandle(dimension_p);
+                }
+                else
+                {
+                    handle.SetHandleAsInvalid();
                 }
             }
 

--- a/sources/TileDB.CSharp/File.cs
+++ b/sources/TileDB.CSharp/File.cs
@@ -38,6 +38,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(array_schema_p);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
             return new ArraySchema(_ctx, handle);
         }

--- a/sources/TileDB.CSharp/FilterList.cs
+++ b/sources/TileDB.CSharp/FilterList.cs
@@ -115,6 +115,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(filter_p);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return new Filter(_ctx, handle);

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -69,6 +69,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(config);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return new Config(handle);
@@ -172,6 +176,10 @@ namespace TileDB.CSharp
                 if (successful)
                 {
                     handle.InitHandle(schema);
+                }
+                else
+                {
+                    handle.SetHandleAsInvalid();
                 }
             }
 

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ArrayHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ArrayHandle.cs
@@ -29,6 +29,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(array);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaEvolutionHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaEvolutionHandle.cs
@@ -29,6 +29,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(evolution);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaHandle.cs
@@ -29,6 +29,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(schema);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/AttributeHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/AttributeHandle.cs
@@ -28,6 +28,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(attribute);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigHandle.cs
@@ -27,6 +27,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(config);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigIteratorHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigIteratorHandle.cs
@@ -29,6 +29,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(config_iter);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ContextHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ContextHandle.cs
@@ -29,6 +29,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(context);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;
@@ -50,6 +54,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 if (successful)
                 {
                     handle.InitHandle(context);
+                }
+                else
+                {
+                    handle.SetHandleAsInvalid();
                 }
             }
 

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/DimensionHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/DimensionHandle.cs
@@ -28,6 +28,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(dimension);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/DomainHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/DomainHandle.cs
@@ -27,6 +27,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(domain);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterHandle.cs
@@ -27,6 +27,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(filter);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterListHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterListHandle.cs
@@ -27,6 +27,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(filterList);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/FragmentInfoHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/FragmentInfoHandle.cs
@@ -29,6 +29,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(fragmentInfo);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/GroupHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/GroupHandle.cs
@@ -27,6 +27,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(group);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryConditionHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryConditionHandle.cs
@@ -27,6 +27,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(queryCondition);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryHandle.cs
@@ -28,6 +28,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(query);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSHandle.cs
@@ -28,6 +28,10 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
                 {
                     handle.InitHandle(vfs);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return handle;

--- a/sources/TileDB.CSharp/QueryCondition.cs
+++ b/sources/TileDB.CSharp/QueryCondition.cs
@@ -118,6 +118,10 @@ namespace TileDB.CSharp
                 {
                     handle.InitHandle(condition_p);
                 }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
             }
 
             return new QueryCondition(_ctx, handle);


### PR DESCRIPTION
This will allow the GC to skip finalization and collect them sooner.