### PR TITLE
Add `TileDBException` and obsolete `Context.ErrorHappened` and `ErrorException`.

### DIFF
--- a/docs/obsoletions.md
+++ b/docs/obsoletions.md
@@ -80,3 +80,15 @@ To reduce the library's public API surface and improve its ability to evolve, th
 Use the high-level APIs in the `TileDB.CSharp` namespace; they are easier and safer to use.
 
 > The eventual goal is to expose all features of TileDB in a high-level API. Until that happens, please contact us if you need to use a particular feature to help us prioritize.
+
+## <span id="TILEDB0004">`TILEDB0004` - The `Context.ErrorHappened` event is obsolete.</span>
+
+Due to a programming mistake the `Context.ErrorHappened` event never worked as expected. Given its limited utility it was marked as obsolete in version 5.3.0.
+
+### Version introduced
+
+5.3.0
+
+### Recommended action
+
+Stop subscribing to `Context.ErrorHappened`. If you want to react to errors, you can now catch exceptions of type `TileDBException` which was introduced in version 5.3.0.

--- a/docs/obsoletions.md
+++ b/docs/obsoletions.md
@@ -92,3 +92,41 @@ Due to a programming mistake the `Context.ErrorHappened` event never worked as e
 ### Recommended action
 
 Stop subscribing to `Context.ErrorHappened`. If you want to react to errors, you can now catch exceptions of type `TileDBException` which was introduced in version 5.3.0.
+
+## <span id="TILEDB0005">`TILEDB0005` - The `ErrorException` type is obsolete.</span>
+
+The `ErrorException` type is badly named and was thrown only in limited circumstances. It was marked as obsolete in version 5.3.0 and replaced by the `TileDBException` type, which is thrown in any error reported by TileDB Embedded.
+
+### Version introduced
+
+5.3.0
+
+### Recommended action
+
+Catch exceptions of type `TileDBException` instead of `ErrorException`.
+
+### Existing code
+
+```csharp
+try
+{
+    // �
+}
+catch (ErrorException e)
+{
+    Console.WriteLine(e.Message);
+}
+```
+
+### New code
+
+```csharp
+try
+{
+    // �
+}
+catch (TileDBException e)
+{
+    Console.WriteLine(e.Message);
+}
+```

--- a/sources/TileDB.CSharp/Array.cs
+++ b/sources/TileDB.CSharp/Array.cs
@@ -530,11 +530,6 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public (string, string, bool) NonEmptyDomainVar(uint index)
         {
-            var dim = Schema().Domain().Dimension(index);
-            if (!EnumUtil.IsStringType(dim.Type()))
-            {
-                throw new ErrorException("Array.NonEmptyDomainVar, not string dimension for index:" + index);
-            }
             ulong start_size;
             ulong end_size;
             var int_empty = 1;
@@ -572,11 +567,6 @@ namespace TileDB.CSharp
 
         public (string, string, bool) NonEmptyDomainVar(string name)
         {
-            var dim = Schema().Domain().Dimension(name);
-            if (!EnumUtil.IsStringType(dim.Type()))
-            {
-                throw new ErrorException("Array.NonEmptyDomainVar, not string dimension for name:" + name);
-            }
             ulong start_size;
             ulong end_size;
             var int_empty = 1;

--- a/sources/TileDB.CSharp/Config.cs
+++ b/sources/TileDB.CSharp/Config.cs
@@ -45,7 +45,6 @@ namespace TileDB.CSharp
         /// <param name="param"></param>
         /// <param name="value"></param>
         /// <exception cref="System.ArgumentException"></exception>
-        /// <exception cref="ErrorException"></exception>
         public void Set(string param, string value)
         {
             if (string.IsNullOrEmpty(param) || string.IsNullOrEmpty(value))
@@ -71,7 +70,6 @@ namespace TileDB.CSharp
         /// <param name="param"></param>
         /// <returns></returns>
         /// <exception cref="System.ArgumentException"></exception>
-        /// <exception cref="ErrorException"></exception>
         public string Get(string param)
         {
             if (string.IsNullOrEmpty(param))
@@ -98,7 +96,6 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="param"></param>
         /// <exception cref="System.ArgumentException"></exception>
-        /// <exception cref="ErrorException"></exception>
         public void Unset(string param)
         {
             if (string.IsNullOrEmpty(param))
@@ -122,7 +119,6 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="filename"></param>
         /// <exception cref="System.ArgumentException"></exception>
-        /// <exception cref="ErrorException"></exception>
         public void LoadFromFile(string filename)
         {
             if (string.IsNullOrEmpty(filename))
@@ -146,7 +142,6 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="filename"></param>
         /// <exception cref="System.ArgumentException"></exception>
-        /// <exception cref="ErrorException"></exception>
         public void SaveToFile(string filename)
         {
             if (string.IsNullOrEmpty(filename))

--- a/sources/TileDB.CSharp/Config.cs
+++ b/sources/TileDB.CSharp/Config.cs
@@ -40,31 +40,6 @@ namespace TileDB.CSharp
         internal ConfigHandle Handle => _handle;
 
         /// <summary>
-        /// Get last error message.
-        /// </summary>
-        /// <param name="pTileDBError"></param>
-        /// <param name="status"></param>
-        /// <returns></returns>
-        private static string GetLastError(tiledb_error_t* pTileDBError, int status)
-        {
-            var sb_result = new StringBuilder();
-            if (Enum.IsDefined(typeof(Status), status))
-            {
-                sb_result.Append("Status: " + (Status)status).ToString();
-                sbyte* messagePtr;
-                Methods.tiledb_error_message(pTileDBError, &messagePtr);
-                string message = MarshaledStringOut.GetStringFromNullTerminated(messagePtr);
-                sb_result.Append(", Message: " + message);
-            }
-            else
-            {
-                sb_result.Append("Unknown error with code: " + status);
-            }
-
-            return sb_result.ToString();
-        }
-
-        /// <summary>
         /// Set parameter value.
         /// </summary>
         /// <param name="param"></param>
@@ -80,21 +55,14 @@ namespace TileDB.CSharp
 
             using var ms_param = new MarshaledString(param);
             using var ms_value = new MarshaledString(value);
-            var tiledb_error = new tiledb_error_t();
 
-            var p_tiledb_error = &tiledb_error;
+            tiledb_error_t* p_tiledb_error;
             int status;
             using (var handle = _handle.Acquire())
             {
                 status = Methods.tiledb_config_set(handle, ms_param, ms_value, &p_tiledb_error);
             }
-            if (status != (int)Status.TILEDB_OK)
-            {
-                var err_message = GetLastError(p_tiledb_error, status);
-                Methods.tiledb_error_free(&p_tiledb_error);
-                throw new ErrorException("Config.set, caught exception:" + err_message);
-            }
-            Methods.tiledb_error_free(&p_tiledb_error);
+            ErrorHandling.CheckLastError(&p_tiledb_error, status);
         }
 
         /// <summary>
@@ -114,21 +82,14 @@ namespace TileDB.CSharp
             using var ms_param = new MarshaledString(param);
             sbyte* result;
 
-            var tiledb_error = new tiledb_error_t();
-            var p_tiledb_error = &tiledb_error;
+            tiledb_error_t* p_tiledb_error;
             int status;
             using (var handle = _handle.Acquire())
             {
                 status = Methods.tiledb_config_get(handle, ms_param, &result, &p_tiledb_error);
             }
-            if (status != (int)Status.TILEDB_OK)
-            {
-                var err_message = GetLastError(p_tiledb_error, status);
-                Methods.tiledb_error_free(&p_tiledb_error);
-                throw new ErrorException("Config.get, caught exception:" + err_message);
-            }
+            ErrorHandling.CheckLastError(&p_tiledb_error, status);
 
-            Methods.tiledb_error_free(&p_tiledb_error);
             return MarshaledStringOut.GetStringFromNullTerminated(result);
         }
 
@@ -146,21 +107,14 @@ namespace TileDB.CSharp
             }
 
             using var ms_param = new MarshaledString(param);
-            var tiledb_error = new tiledb_error_t();
 
-            var p_tiledb_error = &tiledb_error;
+            tiledb_error_t* p_tiledb_error;
             int status;
             using (var handle = _handle.Acquire())
             {
                 status = Methods.tiledb_config_unset(handle, ms_param, &p_tiledb_error);
             }
-            if (status != (int)Status.TILEDB_OK)
-            {
-                var err_message = GetLastError(p_tiledb_error, status);
-                Methods.tiledb_error_free(&p_tiledb_error);
-                throw new ErrorException("Config.unset, caught exception:" + err_message);
-            }
-            Methods.tiledb_error_free(&p_tiledb_error);
+            ErrorHandling.CheckLastError(&p_tiledb_error, status);
         }
 
         /// <summary>
@@ -177,21 +131,14 @@ namespace TileDB.CSharp
             }
 
             using var ms_filename = new MarshaledString(filename);
-            var tiledb_error = new tiledb_error_t();
 
-            var p_tiledb_error = &tiledb_error;
+            tiledb_error_t* p_tiledb_error;
             int status;
             using (var handle = _handle.Acquire())
             {
                 status = Methods.tiledb_config_load_from_file(handle, ms_filename, &p_tiledb_error);
             }
-            if (status != (int)Status.TILEDB_OK)
-            {
-                var err_message = GetLastError(p_tiledb_error, status);
-                Methods.tiledb_error_free(&p_tiledb_error);
-                throw new ErrorException("Config.load_from_file, caught exception:" + err_message);
-            }
-            Methods.tiledb_error_free(&p_tiledb_error);
+            ErrorHandling.CheckLastError(&p_tiledb_error, status);
         }
 
         /// <summary>
@@ -208,21 +155,14 @@ namespace TileDB.CSharp
             }
 
             using var ms_filename = new MarshaledString(filename);
-            var tiledb_error = new tiledb_error_t();
 
-            var p_tiledb_error = &tiledb_error;
+            tiledb_error_t* p_tiledb_error;
             int status;
             using (var handle = _handle.Acquire())
             {
                 status = Methods.tiledb_config_save_to_file(handle, ms_filename, &p_tiledb_error);
             }
-            if (status != (int)Status.TILEDB_OK)
-            {
-                var err_message = GetLastError(p_tiledb_error, status);
-                Methods.tiledb_error_free(&p_tiledb_error);
-                throw new ErrorException("Config.save_to_file, caught exception:" + err_message);
-            }
-            Methods.tiledb_error_free(&p_tiledb_error);
+            ErrorHandling.CheckLastError(&p_tiledb_error, status);
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/ConfigIterator.cs
+++ b/sources/TileDB.CSharp/ConfigIterator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Text;
 using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 
@@ -35,29 +34,9 @@ namespace TileDB.CSharp
 
         internal ConfigIteratorHandle Handle => _handle;
 
-        private string GetLastError(tiledb_error_t* pTiledbError, int status)
-        {
-            var sb_result = new StringBuilder();
-            if (Enum.IsDefined(typeof(Status), status))
-            {
-                sb_result.Append("Status: " + (Status)status).ToString();
-                sbyte* messagePtr;
-                Methods.tiledb_error_message(pTiledbError, &messagePtr);
-                string message = MarshaledStringOut.GetStringFromNullTerminated(messagePtr);
-                sb_result.Append(", Message: " + message);
-            }
-            else
-            {
-                sb_result.Append("Unknown error with code: " + status);
-            }
-
-            return sb_result.ToString();
-        }
-
         public Tuple<string, string> Here()
         {
-            var tiledb_error = new tiledb_error_t();
-            var p_tiledb_error = &tiledb_error;
+            tiledb_error_t* p_tiledb_error;
             sbyte* paramPtr;
             sbyte* valuePtr;
             int status;
@@ -66,13 +45,7 @@ namespace TileDB.CSharp
                 status = Methods.tiledb_config_iter_here(handle, &paramPtr, &valuePtr, &p_tiledb_error);
             }
 
-            if (status != (int)Status.TILEDB_OK)
-            {
-                var err_message = GetLastError(p_tiledb_error, status);
-                Methods.tiledb_error_free(&p_tiledb_error);
-                throw new ErrorException("Config.set, caught exception:" + err_message);
-            }
-            Methods.tiledb_error_free(&p_tiledb_error);
+            ErrorHandling.CheckLastError(&p_tiledb_error, status);
 
             string param = MarshaledStringOut.GetStringFromNullTerminated(paramPtr);
             string value = MarshaledStringOut.GetStringFromNullTerminated(valuePtr);
@@ -81,46 +54,31 @@ namespace TileDB.CSharp
 
         public void Next()
         {
-            var tiledb_error = new tiledb_error_t();
-            var p_tiledb_error = &tiledb_error;
+            tiledb_error_t* p_tiledb_error;
             int status;
             using (var handle = _handle.Acquire())
             {
                 status = Methods.tiledb_config_iter_next(handle, &p_tiledb_error);
             }
-            if (status != (int)Status.TILEDB_OK)
-            {
-                var err_message = GetLastError(p_tiledb_error, status);
-                Methods.tiledb_error_free(&p_tiledb_error);
-                throw new ErrorException("ConfigIterator.next, caught exception:" + err_message);
-            }
-            Methods.tiledb_error_free(&p_tiledb_error);
+            ErrorHandling.CheckLastError(&p_tiledb_error, status);
         }
 
         public bool Done()
         {
-            var tiledb_error = new tiledb_error_t();
-            var p_tiledb_error = &tiledb_error;
+            tiledb_error_t* p_tiledb_error;
             int c_done;
             int status;
             using (var handle = _handle.Acquire())
             {
                 status = Methods.tiledb_config_iter_done(handle, &c_done, &p_tiledb_error);
             }
-            if (status != (int)Status.TILEDB_OK)
-            {
-                var err_message = GetLastError(p_tiledb_error, status);
-                Methods.tiledb_error_free(&p_tiledb_error);
-                throw new ErrorException("ConfigIterator.done, caught exception:" + err_message);
-            }
-            Methods.tiledb_error_free(&p_tiledb_error);
+            ErrorHandling.CheckLastError(&p_tiledb_error, status);
             return c_done == 1;
         }
 
         public void Reset(string prefix)
         {
-            var tiledb_error = new tiledb_error_t();
-            var p_tiledb_error = &tiledb_error;
+            tiledb_error_t* p_tiledb_error;
             using var ms_prefix = new MarshaledString(prefix);
             int status;
             using (var configHandle = _hConfig.Acquire())
@@ -128,13 +86,7 @@ namespace TileDB.CSharp
             {
                 status = Methods.tiledb_config_iter_reset(configHandle, handle, ms_prefix, &p_tiledb_error);
             }
-            if (status != (int)Status.TILEDB_OK)
-            {
-                var err_message = GetLastError(p_tiledb_error, status);
-                Methods.tiledb_error_free(&p_tiledb_error);
-                throw new ErrorException("Config.reset, caught exception:" + err_message);
-            }
-            Methods.tiledb_error_free(&p_tiledb_error);
+            ErrorHandling.CheckLastError(&p_tiledb_error, status);
         }
     }
 }

--- a/sources/TileDB.CSharp/Context.cs
+++ b/sources/TileDB.CSharp/Context.cs
@@ -150,8 +150,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// An event that gets raised if an operation that used this <see cref="Context"/> failed, before throwing a <see cref="TileDBException"/>.
+        /// Deprecated.
         /// </summary>
+        [Obsolete(Obsoletions.ContextErrorHappenedMessage, DiagnosticId = Obsoletions.ContextErrorHappenedDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public event EventHandler<ErrorEventArgs>? ErrorHappened;
 
         internal void handle_error(int rc)
@@ -189,7 +190,6 @@ namespace TileDB.CSharp
             }
             Methods.tiledb_error_free(&p_tiledb_error);
 
-            ErrorHappened?.Invoke(this, new ErrorEventArgs((int)status, message));
             throw new TileDBException(message) { StatusCode = (int)status };
         }
     }

--- a/sources/TileDB.CSharp/Context.cs
+++ b/sources/TileDB.CSharp/Context.cs
@@ -150,13 +150,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// An event that gets raised if an operation that used this <see cref="Context"/> failed.
+        /// An event that gets raised if an operation that used this <see cref="Context"/> failed, before throwing a <see cref="TileDBException"/>.
         /// </summary>
-        /// <remarks>
-        /// By default it throws an exception.
-        /// </remarks>
-        public event EventHandler<ErrorEventArgs> ErrorHappened = (_, e) =>
-            throw new TileDBException(e.Message) { StatusCode = e.Code };
+        public event EventHandler<ErrorEventArgs> ErrorHappened;
 
         internal void handle_error(int rc)
         {
@@ -193,8 +189,8 @@ namespace TileDB.CSharp
             }
             Methods.tiledb_error_free(&p_tiledb_error);
 
-            //fire event
-            ErrorHappened(this, new ErrorEventArgs(rc, message));
+            ErrorHappened?.Invoke(this, new ErrorEventArgs((int)status, message));
+            throw new TileDBException(message) { StatusCode = (int)status };
         }
     }
 }

--- a/sources/TileDB.CSharp/Context.cs
+++ b/sources/TileDB.CSharp/Context.cs
@@ -152,7 +152,7 @@ namespace TileDB.CSharp
         /// <summary>
         /// An event that gets raised if an operation that used this <see cref="Context"/> failed, before throwing a <see cref="TileDBException"/>.
         /// </summary>
-        public event EventHandler<ErrorEventArgs> ErrorHappened;
+        public event EventHandler<ErrorEventArgs>? ErrorHappened;
 
         internal void handle_error(int rc)
         {

--- a/sources/TileDB.CSharp/Error.cs
+++ b/sources/TileDB.CSharp/Error.cs
@@ -14,12 +14,23 @@ namespace TileDB.CSharp
         public string Message {get; set;}
     }
 
+    /// <summary>
+    /// Deprecated, use <see cref="TileDBException"/> instead.
+    /// </summary>
+    [Obsolete(Obsoletions.ErrorExceptionMessage, DiagnosticId = Obsoletions.ErrorExceptionDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     public class ErrorException: Exception 
     {
+        /// <summary>
+        /// Creates an <see cref="ErrorException"/>.
+        /// </summary>
         public ErrorException()
         {
         }
 
+        /// <summary>
+        /// Creates an <see cref="ErrorException"/> with a message.
+        /// </summary>
+        /// <param name="message">The exception's message.</param>
         public ErrorException(string message): base(message) {
  
         }

--- a/sources/TileDB.CSharp/Error.cs
+++ b/sources/TileDB.CSharp/Error.cs
@@ -2,6 +2,7 @@
 
 namespace TileDB.CSharp
 {
+    [Obsolete(Obsoletions.ContextErrorHappenedMessage, DiagnosticId = Obsoletions.ContextErrorHappenedDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     public class ErrorEventArgs : EventArgs
     {
         public ErrorEventArgs(int code, string message)
@@ -23,5 +24,4 @@ namespace TileDB.CSharp
  
         }
     }
- 
 }

--- a/sources/TileDB.CSharp/ErrorHandling.cs
+++ b/sources/TileDB.CSharp/ErrorHandling.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using TileDB.Interop;
 
@@ -20,7 +19,7 @@ namespace TileDB.CSharp
         {
             if (status == (int)Status.TILEDB_OK)
             {
-                Methods.tiledb_error_free(error);
+                Debug.Assert(*error is null);
                 return;
             }
 

--- a/sources/TileDB.CSharp/ErrorHandling.cs
+++ b/sources/TileDB.CSharp/ErrorHandling.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using TileDB.Interop;
 
 namespace TileDB.CSharp
 {
@@ -10,7 +13,29 @@ namespace TileDB.CSharp
             {
                 return;
             }
-            throw new Exception($"Operation failed with error code {errorCode}.");
+            throw new TileDBException($"Operation failed with error code {errorCode}.") { StatusCode = errorCode };
+        }
+
+        public static unsafe void CheckLastError(tiledb_error_t** error, int status)
+        {
+            if (status == (int)Status.TILEDB_OK)
+            {
+                Methods.tiledb_error_free(error);
+                return;
+            }
+
+            ThrowLastError(error, status);
+
+            [DoesNotReturn]
+            static void ThrowLastError(tiledb_error_t** error, int status)
+            {
+                sbyte* messagePtr;
+                int messageResult = Methods.tiledb_error_message(*error, &messagePtr);
+                Debug.Assert(messageResult == (int)Status.TILEDB_OK);
+                string message = MarshaledStringOut.GetStringFromNullTerminated(messagePtr);
+                Methods.tiledb_error_free(error);
+                throw new TileDBException(message) { StatusCode = status };
+            }
         }
     }
 }

--- a/sources/TileDB.CSharp/FilterList.cs
+++ b/sources/TileDB.CSharp/FilterList.cs
@@ -94,7 +94,6 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="filterIndex"></param>
         /// <returns></returns>
-        /// <exception cref="ErrorException"></exception>
         public Filter Filter(uint filterIndex)
         {
             var handle = new FilterHandle();

--- a/sources/TileDB.CSharp/Obsoletions.cs
+++ b/sources/TileDB.CSharp/Obsoletions.cs
@@ -17,5 +17,8 @@ namespace TileDB.CSharp
 
         public const string ContextErrorHappenedMessage = "The Context.ErrorHappened event is obsolete and will not be invoked.";
         public const string ContextErrorHappenedDiagId = "TILEDB0004";
+
+        public const string ErrorExceptionMessage = "The ErrorException type is obsolete and will not be thrown. Catch TileDBException instead.";
+        public const string ErrorExceptionDiagId = "TILEDB0005";
     }
 }

--- a/sources/TileDB.CSharp/Obsoletions.cs
+++ b/sources/TileDB.CSharp/Obsoletions.cs
@@ -14,5 +14,8 @@ namespace TileDB.CSharp
 
         public const string TileDBInteropMessage = "Members of the TileDB.Interop namespace should not be used by user code will become internal in a future version.";
         public const string TileDBInteropDiagId = "TILEDB0003";
+
+        public const string ContextErrorHappenedMessage = "The Context.ErrorHappened event is obsolete and will not be invoked.";
+        public const string ContextErrorHappenedDiagId = "TILEDB0004";
     }
 }

--- a/sources/TileDB.CSharp/TileDBException.cs
+++ b/sources/TileDB.CSharp/TileDBException.cs
@@ -1,0 +1,36 @@
+﻿using System;
+
+namespace TileDB.CSharp
+{
+    /// <summary>
+    /// This exception is thrown when a TileDB Embedded method fails with an error.
+    /// </summary>
+    /// <remarks>
+    /// Almost all methods of this library may throw it.
+    /// </remarks>
+    public sealed class TileDBException : Exception
+    {
+        /// <summary>
+        /// The exception's status code, as reported by <c>tiledb_status_code</c> function.
+        /// </summary>
+        public int StatusCode { get; set; }
+
+        /// <summary>
+        /// Creates a <see cref="TileDBException"/>.
+        /// </summary>
+        public TileDBException() { }
+
+        /// <summary>
+        /// Creates a <see cref="TileDBException"/> with a message.
+        /// </summary>
+        /// <param name="message">The exception's message.</param>
+        public TileDBException(string? message) : base(message) { }
+
+        /// <summary>
+        /// Creates a <see cref="TileDBException"/> with a message and inner exception.
+        /// </summary>
+        /// <param name="message">The exception's message.</param>
+        /// <param name="inner">The exception's inner exception.</param>
+        public TileDBException(string? message, Exception? inner) : base(message, inner) { }
+    }
+}

--- a/tests/TileDB.CSharp.Test/ArraySchemaTest.cs
+++ b/tests/TileDB.CSharp.Test/ArraySchemaTest.cs
@@ -168,8 +168,8 @@ namespace TileDB.CSharp.Test
 			array_schema.SetDomain(domain);
 
 			
-			Assert.ThrowsException<Exception>(()=>array_schema.SetCellOrder(LayoutType.Hilbert));
-			Assert.ThrowsException<Exception>(()=>array_schema.SetTileOrder(LayoutType.Hilbert));
+			Assert.ThrowsException<TileDBException>(()=>array_schema.SetCellOrder(LayoutType.Hilbert));
+			Assert.ThrowsException<TileDBException>(()=>array_schema.SetTileOrder(LayoutType.Hilbert));
 			array_schema.SetCapacity(2);
 			array_schema.Check();
 		}

--- a/tests/TileDB.CSharp.Test/DomainTest.cs
+++ b/tests/TileDB.CSharp.Test/DomainTest.cs
@@ -29,7 +29,7 @@ namespace TileDB.CSharp.Test
             var dimension2 = Dimension.Create(context, "testint", bound_lower2, bound_upper2, extent2);
             domain.AddDimension(dimension2);
             Assert.AreEqual(true, domain.HasDimension("testint"));
-            Assert.ThrowsException<Exception>(() => domain.Type());
+            Assert.ThrowsException<TileDBException>(() => domain.Type());
             Assert.AreEqual<uint>(2, domain.NDim());
 
             var dim1 = domain.Dimension(0);

--- a/tests/TileDB.CSharp.Test/GroupTest.cs
+++ b/tests/TileDB.CSharp.Test/GroupTest.cs
@@ -20,11 +20,11 @@ namespace TileDB.CSharp.Test
 
             // Put metadata on a group that is not opened
             int v = 5;
-            Assert.ThrowsException<Exception>(() => group.PutMetadata("key", v));
+            Assert.ThrowsException<TileDBException>(() => group.PutMetadata("key", v));
 
             // Write metadata on a group opened in READ mode
             group.Open(QueryType.Read);
-            Assert.ThrowsException<Exception>(() => group.PutMetadata("key", v));
+            Assert.ThrowsException<TileDBException>(() => group.PutMetadata("key", v));
 
             // Close and reopen in WRITE mode
             group.Close();


### PR DESCRIPTION
Until now, when a native API call fails, we throw a plain `Exception`, giving little ways for consumers to distinguish between TileDB errors and anything else.

This PR introduces a new exception type called `TileDBException` that gets thrown when a native API call fails, and corresponds to the `TileDBError` type that C++, Python and Java have. Since we throw a more derived type of exception, [this is not a breaking change](https://learn.microsoft.com/en-us/dotnet/core/compatibility/#exceptions).

I also made the `Context.ErrorHappened` ~~event useful; as explained in [SC-23974](https://app.shortcut.com/tiledb-inc/story/23974/context-errorhappened-is-useless), the default value we give to it throws and prevents user-supplied events to be invoked. We might want to just~~ obsolete and ignore it; I still prefer it.