### PR TITLE
Do not use `GCHandle`s for brief pinning of objects.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,11 @@ csharp_style_var_for_built_in_types=true:silent
 csharp_style_var_when_type_is_apparent=true:silent
 csharp_style_var_elsewhere=true:silent
 
+# This takes the address of, gets the size of, or declares a pointer to a managed type.
+# We check at runtime that generic types are not managed, and either way we can't take
+# a pointer to the heap by accident without using fixed or Unsafe.AsPointer.
+dotnet_diagnostic.CS8500.severity = None
+
 ##
 ## SonarAnalyzers.CSharp
 ##

--- a/docs/obsoletions.md
+++ b/docs/obsoletions.md
@@ -130,3 +130,27 @@ catch (TileDBException e)
     Console.WriteLine(e.Message);
 }
 ```
+
+## <span id="TILEDB0006">`TILEDB0006` - The overload of `Dimension.Create` method that takes an array is obsolete.</span>
+
+The `Dimension.Create<T>(Context, string, T[], T)` method is problematic because only the first two values of the array parameter are actually being used. For this reason it was marked as obsolete in version 5.3.0.
+
+### Version introduced
+
+5.3.0
+
+### Recommended action
+
+Use the `Dimension.Create<T>(Context, string, T, T, T)` overload which explicitly accepts the lower and upper bound and better represents the intended usage.
+
+### Existing code
+
+```csharp
+Dimension dimension = Dimension.Create(context, "test", new int[] { 1, 10 }, 5);
+```
+
+### New code
+
+```csharp
+Dimension dimension = Dimension.Create(context, "test", 1, 10, 5);
+```

--- a/examples/TileDB.CSharp.Example/ExampleIncompleteQuery.cs
+++ b/examples/TileDB.CSharp.Example/ExampleIncompleteQuery.cs
@@ -12,13 +12,8 @@ namespace TileDB.CSharp.Examples
 
         private static void CreateArray()
         {
-            int[] dim1_bound = { 1, 10 };
-            int dim1_ext = 4;
-            var dim1 = Dimension.Create<int>(Ctx, "rows", dim1_bound, dim1_ext);
-
-            int[] dim2_bound = { 1, 10 };
-            int dim2_ext = 4;
-            var dim2 = Dimension.Create<int>(Ctx, "cols", dim2_bound, dim2_ext);
+            var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 10, extent: 4);
+            var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 10, extent: 4);
 
             var domain = new Domain(Ctx);
             domain.AddDimension(dim1);
@@ -58,9 +53,9 @@ namespace TileDB.CSharp.Examples
 
                 var queryWrite = new Query(Ctx, arrayWrite);
                 queryWrite.SetLayout(LayoutType.Unordered);
-                queryWrite.SetDataBuffer<int>("rows", rowsData);
-                queryWrite.SetDataBuffer<int>("cols", colsData);
-                queryWrite.SetDataBuffer<int>("a1", attrData);
+                queryWrite.SetDataBuffer("rows", rowsData);
+                queryWrite.SetDataBuffer("cols", colsData);
+                queryWrite.SetDataBuffer("a1", attrData);
                 queryWrite.Submit();
 
                 Console.WriteLine($"Write query status: {queryWrite.Status()}");
@@ -82,9 +77,9 @@ namespace TileDB.CSharp.Examples
                 queryRead.SetLayout(LayoutType.Unordered);
                 queryRead.SetSubarray(new[] { 1, 100, 1, 100 });
 
-                queryRead.SetDataBuffer<int>("rows", rowsRead);
-                queryRead.SetDataBuffer<int>("cols", colsRead);
-                queryRead.SetDataBuffer<int>("a1", attrRead);
+                queryRead.SetDataBuffer("rows", rowsRead);
+                queryRead.SetDataBuffer("cols", colsRead);
+                queryRead.SetDataBuffer("a1", attrRead);
 
                 int batchNum = 1;
                 do

--- a/examples/TileDB.CSharp.Example/ExampleQuery.cs
+++ b/examples/TileDB.CSharp.Example/ExampleQuery.cs
@@ -11,12 +11,8 @@ namespace TileDB.CSharp.Examples
         private static void CreateArray()
         {
             // Create array
-            int[] dim1_bound = new int[] { 1, 4 };
-            int dim1_extent = 4;
-            var dim1 = Dimension.Create<int>(Ctx, "rows", dim1_bound, dim1_extent);
-            int[] dim2_bound = new int[] { 1, 4 };
-            int dim2_extent = 4;
-            var dim2 = Dimension.Create<int>(Ctx, "cols", dim2_bound, dim2_extent);
+            var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 4, extent: 4);
+            var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 4, extent: 4);
             var domain = new Domain(Ctx);
             domain.AddDimension(dim1);
             domain.AddDimension(dim2);
@@ -27,8 +23,7 @@ namespace TileDB.CSharp.Examples
             array_schema.Check();
 
             Array.Create(Ctx, ArrayPath, array_schema);
-
-        } //private void CreateArray()
+        }
 
         private static void WriteArray()
         {
@@ -41,13 +36,12 @@ namespace TileDB.CSharp.Examples
                 array_write.Open(QueryType.Write);
                 var query_write = new Query(Ctx, array_write);
                 query_write.SetLayout(LayoutType.Unordered);
-                query_write.SetDataBuffer<int>("rows", dim1_data_buffer);
-                query_write.SetDataBuffer<int>("cols", dim2_data_buffer);
-                query_write.SetDataBuffer<int>("a", attr_data_buffer);
+                query_write.SetDataBuffer("rows", dim1_data_buffer);
+                query_write.SetDataBuffer("cols", dim2_data_buffer);
+                query_write.SetDataBuffer("a", attr_data_buffer);
                 query_write.Submit();
                 array_write.Close();
-            }//array_write
-
+            }
         }
 
         private static void ReadArray()
@@ -61,21 +55,21 @@ namespace TileDB.CSharp.Examples
                 array_read.Open(QueryType.Read);
                 var query_read = new Query(Ctx, array_read);
                 query_read.SetLayout(LayoutType.RowMajor);
-                query_read.SetDataBuffer<int>("rows", dim1_data_buffer_read);
-                query_read.SetDataBuffer<int>("cols", dim2_data_buffer_read);
-                query_read.SetDataBuffer<int>("a", attr_data_buffer_read);
+                query_read.SetDataBuffer("rows", dim1_data_buffer_read);
+                query_read.SetDataBuffer("cols", dim2_data_buffer_read);
+                query_read.SetDataBuffer("a", attr_data_buffer_read);
                 query_read.Submit();
                 array_read.Close();
             }
 
-            System.Console.WriteLine("dim1:{0},{1},{2}", dim1_data_buffer_read[0], dim1_data_buffer_read[1], dim1_data_buffer_read[2]);
-            System.Console.WriteLine("dim2:{0},{1},{2}", dim2_data_buffer_read[0], dim2_data_buffer_read[1], dim2_data_buffer_read[2]);
-            System.Console.WriteLine("attr:{0},{1},{2}", attr_data_buffer_read[0], attr_data_buffer_read[1], attr_data_buffer_read[2]);
+            Console.WriteLine("dim1:{0},{1},{2}", dim1_data_buffer_read[0], dim1_data_buffer_read[1], dim1_data_buffer_read[2]);
+            Console.WriteLine("dim2:{0},{1},{2}", dim2_data_buffer_read[0], dim2_data_buffer_read[1], dim2_data_buffer_read[2]);
+            Console.WriteLine("attr:{0},{1},{2}", attr_data_buffer_read[0], attr_data_buffer_read[1], attr_data_buffer_read[2]);
         }
 
         private static void OnReadCompleted(object sender, QueryEventArgs args)
         {
-            System.Console.WriteLine("Read completed!");
+            Console.WriteLine("Read completed!");
         }
 
         private static void ReadArrayAsync()
@@ -88,9 +82,9 @@ namespace TileDB.CSharp.Examples
             array_read.Open(QueryType.Read);
             var query_read = new Query(Ctx, array_read);
             query_read.SetLayout(LayoutType.RowMajor);
-            query_read.SetDataBuffer<int>("rows", dim1_data_buffer_read);
-            query_read.SetDataBuffer<int>("cols", dim2_data_buffer_read);
-            query_read.SetDataBuffer<int>("a", attr_data_buffer_read);
+            query_read.SetDataBuffer("rows", dim1_data_buffer_read);
+            query_read.SetDataBuffer("cols", dim2_data_buffer_read);
+            query_read.SetDataBuffer("a", attr_data_buffer_read);
             query_read.QueryCompleted += OnReadCompleted!;
             query_read.SubmitAsync();
         }
@@ -107,5 +101,5 @@ namespace TileDB.CSharp.Examples
             ReadArray();
             ReadArrayAsync();
         }
-    }//class
-}//namespace
+    }
+}

--- a/sources/TileDB.CSharp/Array.cs
+++ b/sources/TileDB.CSharp/Array.cs
@@ -534,8 +534,8 @@ namespace TileDB.CSharp
             int start_size = checked((int)start_size64);
             int end_size = checked((int)end_size64);
 
-            using var start = new ScratchBuffer<byte>(start_size, stackalloc byte[128]);
-            using var end = new ScratchBuffer<byte>(end_size, stackalloc byte[128]);
+            using var start = new ScratchBuffer<byte>(start_size, stackalloc byte[128], exactSize: true);
+            using var end = new ScratchBuffer<byte>(end_size, stackalloc byte[128], exactSize: true);
 
             using (var ctxHandle = _ctx.Handle.Acquire())
             using (var handle = _handle.Acquire())
@@ -543,7 +543,7 @@ namespace TileDB.CSharp
                 _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_var_from_index(ctxHandle, handle, index,
                     startPtr, endPtr, &int_empty));
 
-            return (MarshaledStringOut.GetString(start.Span[0..start_size]), MarshaledStringOut.GetString(end.Span[0..end_size]), false);
+            return (MarshaledStringOut.GetString(start.Span), MarshaledStringOut.GetString(end.Span), false);
         }
 
         public (string, string, bool) NonEmptyDomainVar(string name)
@@ -567,8 +567,8 @@ namespace TileDB.CSharp
             int start_size = checked((int)start_size64);
             int end_size = checked((int)end_size64);
 
-            using var start = new ScratchBuffer<byte>(start_size, stackalloc byte[128]);
-            using var end = new ScratchBuffer<byte>(end_size, stackalloc byte[128]);
+            using var start = new ScratchBuffer<byte>(start_size, stackalloc byte[128], exactSize: true);
+            using var end = new ScratchBuffer<byte>(end_size, stackalloc byte[128], exactSize: true);
 
             using (var ctxHandle = _ctx.Handle.Acquire())
             using (var handle = _handle.Acquire())
@@ -576,7 +576,7 @@ namespace TileDB.CSharp
                 _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_var_from_name(ctxHandle, handle, ms_name,
                     startPtr, endPtr, &int_empty));
 
-            return new(MarshaledStringOut.GetString(start.Span[0..start_size]), MarshaledStringOut.GetString(end.Span[0..end_size]), false);
+            return new(MarshaledStringOut.GetString(start.Span), MarshaledStringOut.GetString(end.Span), false);
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/ArrayMetadata.cs
+++ b/sources/TileDB.CSharp/ArrayMetadata.cs
@@ -340,24 +340,17 @@ namespace TileDB.CSharp
         #region Private methods
         private void put_metadata<T>(string key, T[] value, tiledb_datatype_t tiledb_datatype, uint value_num) where T : struct
         {
+            ErrorHandling.ThrowIfManagedType<T>();
             if (string.IsNullOrEmpty(key) || value.Length == 0)
             {
                 throw new ArgumentException("ArrayMetadata.put_metadata, null or empty key-value!");
             }
             var ctx = _array.Context();
             using var ms_key = new MarshaledString(key);
-            var dataGcHandle = GCHandle.Alloc(value, GCHandleType.Pinned);
-            try
-            {
-                using var ctxHandle = ctx.Handle.Acquire();
-                using var arrayHandle = _array.Handle.Acquire();
-                ctx.handle_error(Methods.tiledb_array_put_metadata(ctxHandle, arrayHandle, ms_key, tiledb_datatype, value_num,
-                    (void*)dataGcHandle.AddrOfPinnedObject()));
-            }
-            finally
-            {
-                dataGcHandle.Free();
-            }
+            using var ctxHandle = ctx.Handle.Acquire();
+            using var arrayHandle = _array.Handle.Acquire();
+            fixed (T* dataPtr = &value[0])
+                ctx.handle_error(Methods.tiledb_array_put_metadata(ctxHandle, arrayHandle, ms_key, tiledb_datatype, value_num, dataPtr));
         }
 
         private (string key, byte[] data, tiledb_datatype_t tiledb_datatype, uint value_num) get_metadata(string key)

--- a/sources/TileDB.CSharp/Dimension.cs
+++ b/sources/TileDB.CSharp/Dimension.cs
@@ -239,9 +239,8 @@ namespace TileDB.CSharp
         /// <param name="name">The dimension's name.</param>
         /// <param name="boundLower">The dimension's lower bound, inclusive.</param>
         /// <param name="boundUpper">The dimension's upper bound, inclusive.</param>
-        /// <param name="extent"></param>
+        /// <param name="extent">The dimension's tile extent.</param>
         /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
-
         public static Dimension Create<T>(Context ctx, string name, T boundLower, T boundUpper, T extent)
         {
             var tiledb_datatype = (tiledb_datatype_t)EnumUtil.TypeToDataType(typeof(T));
@@ -260,7 +259,7 @@ namespace TileDB.CSharp
         /// <summary>
         /// Creates a <see cref="Dimension"/>. Deprecated, use <see cref="Create{T}(Context, string, T, T, T)"/> instead.
         /// </summary>
-        [Obsolete("Use the overload that does not accept an array instead.")]
+        [Obsolete(Obsoletions.DimensionCreateMessage, DiagnosticId = Obsoletions.DimensionCreateDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static Dimension Create<T>(Context ctx, string name, T[] bound, T extent)
         {
             var tiledb_datatype = (tiledb_datatype_t)EnumUtil.TypeToDataType(typeof(T));

--- a/sources/TileDB.CSharp/ErrorHandling.cs
+++ b/sources/TileDB.CSharp/ErrorHandling.cs
@@ -1,5 +1,7 @@
-﻿using System.Diagnostics;
+using System;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 using TileDB.Interop;
 
 namespace TileDB.CSharp
@@ -35,6 +37,18 @@ namespace TileDB.CSharp
                 Methods.tiledb_error_free(error);
                 throw new TileDBException(message) { StatusCode = status };
             }
+        }
+
+        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is managed.</exception>
+        public static void ThrowIfManagedType<T>()
+        {
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                Throw();
+            }
+
+            static void Throw() =>
+                throw new NotSupportedException("Types with managed references are not supported.");
         }
     }
 }

--- a/sources/TileDB.CSharp/File.cs
+++ b/sources/TileDB.CSharp/File.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 
@@ -100,6 +101,7 @@ namespace TileDB.CSharp
             return size;
         }
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public string MIMETypeToStr(MIMEType mimeType)
         {
             var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
@@ -109,7 +111,8 @@ namespace TileDB.CSharp
             return MarshaledStringOut.GetStringFromNullTerminated(result);
         }
 
-        public MIMEType MIMETypeFromStr(string str)
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static MIMEType MIMETypeFromStr(string str)
         {
             tiledb_mime_type_t mimeType;
             using var ms_str = new MarshaledString(str);

--- a/sources/TileDB.CSharp/File.cs
+++ b/sources/TileDB.CSharp/File.cs
@@ -61,6 +61,10 @@ namespace TileDB.CSharp
         public void BufferImport<T>(string arrayURI, T value, ulong size, MIMEType mimeType) where T : struct
         {
             ErrorHandling.ThrowIfManagedType<T>();
+            if (size > (ulong)sizeof(T))
+            {
+                ThrowHelpers.ThrowTooBigSize(size);
+            }
             using var ctxHandle = _ctx.Handle.Acquire();
             using var ms_arrayURI = new MarshaledString(arrayURI);
             var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
@@ -75,6 +79,10 @@ namespace TileDB.CSharp
         public T BufferExport<T>(string arrayURI, ulong offset, ulong size) where T : struct
         {
             ErrorHandling.ThrowIfManagedType<T>();
+            if (size > (ulong)sizeof(T))
+            {
+                ThrowHelpers.ThrowTooBigSize(size);
+            }
             using var ctxHandle = _ctx.Handle.Acquire();
             using var ms_arrayURI = new MarshaledString(arrayURI);
             T result;

--- a/sources/TileDB.CSharp/File.cs
+++ b/sources/TileDB.CSharp/File.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
 using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 
@@ -65,34 +59,30 @@ namespace TileDB.CSharp
 
         public void BufferImport<T>(string arrayURI, T value, ulong size, MIMEType mimeType) where T : struct
         {
+            ErrorHandling.ThrowIfManagedType<T>();
             using var ctxHandle = _ctx.Handle.Acquire();
             using var ms_arrayURI = new MarshaledString(arrayURI);
-            var data = new[] { value };
-            var dataGcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
             var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
             _ctx.handle_error(Methods.tiledb_filestore_buffer_import(
                 ctxHandle,
                 ms_arrayURI,
-                (void*)dataGcHandle.AddrOfPinnedObject(),
+                &value,
                 checked((nuint)size),
                 tiledb_mime_type));
         }
 
         public T BufferExport<T>(string arrayURI, ulong offset, ulong size) where T : struct
         {
+            ErrorHandling.ThrowIfManagedType<T>();
             using var ctxHandle = _ctx.Handle.Acquire();
             using var ms_arrayURI = new MarshaledString(arrayURI);
-            var data = new T[1];
-            var dataGcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            T result;
             _ctx.handle_error(Methods.tiledb_filestore_buffer_export(
                 ctxHandle,
                 ms_arrayURI,
                 checked((nuint)offset),
-                (void*)dataGcHandle.AddrOfPinnedObject(),
+                &result,
                 checked((nuint)size)));
-
-            var result = data[0];
-            dataGcHandle.Free();
 
             return result;
         }

--- a/sources/TileDB.CSharp/Filter.cs
+++ b/sources/TileDB.CSharp/Filter.cs
@@ -98,10 +98,7 @@ namespace TileDB.CSharp
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             var tiledb_filter_option = (tiledb_filter_option_t)filterOption;
-            var data = new[] { value };
-            var dataGcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
-            _ctx.handle_error(Methods.tiledb_filter_set_option(ctxHandle, handle, tiledb_filter_option, (void*)dataGcHandle.AddrOfPinnedObject()));
-            dataGcHandle.Free();
+            _ctx.handle_error(Methods.tiledb_filter_set_option(ctxHandle, handle, tiledb_filter_option, &value));
         }
 
         /// <summary>
@@ -116,13 +113,10 @@ namespace TileDB.CSharp
 
             var tiledb_filter_option = (tiledb_filter_option_t)filterOption;
 
-            var data = new T[1];
-            var dataGcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            T result;
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_filter_get_option(ctxHandle, handle, tiledb_filter_option, (void*)dataGcHandle.AddrOfPinnedObject()));
-            var result = data[0];
-            dataGcHandle.Free();
+            _ctx.handle_error(Methods.tiledb_filter_get_option(ctxHandle, handle, tiledb_filter_option, &result));
 
             return result;
         }

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -482,16 +482,16 @@ namespace TileDB.CSharp
                 handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, &startSize64, &endSize64));
             int startSize = checked((int)startSize64);
             int endSize = checked((int)endSize64);
-            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128]);
-            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128]);
+            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
+            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
             fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
             {
                 _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_var_from_index(ctxHandle,
                     handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, startBufPtr, endBufPtr));
             }
 
-            string startStr = MarshaledStringOut.GetString(startBuf.Span[0..startSize], dataType);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span[0..endSize], dataType);
+            string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
             return (startStr, endStr);
         }
 
@@ -505,16 +505,16 @@ namespace TileDB.CSharp
                 handle, fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, &startSize64, &endSize64));
             int startSize = checked((int)startSize64);
             int endSize = checked((int)endSize64);
-            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128]);
-            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128]);
+            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
+            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
             fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
             {
                 _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_var_from_name(ctxHandle, handle,
                     fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, startBufPtr, endBufPtr));
             }
 
-            string startStr = MarshaledStringOut.GetString(startBuf.Span[0..startSize], dataType);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span[0..endSize], dataType);
+            string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
+            string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
             return (startStr, endStr);
         }
 
@@ -605,8 +605,8 @@ namespace TileDB.CSharp
                 handle, fragmentIndex, dimensionIndex, &startSize64, &endSize64));
             int startSize = checked((int)startSize64);
             int endSize = checked((int)endSize64);
-            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128]);
-            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128]);
+            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
+            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
             fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
             {
                 _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_index(ctxHandle,
@@ -628,8 +628,8 @@ namespace TileDB.CSharp
                 handle, fragmentIndex, ms_dimensionName, &startSize64, &endSize64));
             int startSize = checked((int)startSize64);
             int endSize = checked((int)endSize64);
-            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128]);
-            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128]);
+            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
+            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
             fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
             {
                 _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_name(ctxHandle,

--- a/sources/TileDB.CSharp/Marshalling/ScratchBuffer.cs
+++ b/sources/TileDB.CSharp/Marshalling/ScratchBuffer.cs
@@ -16,6 +16,7 @@ namespace TileDB.CSharp.Marshalling
     internal ref struct ScratchBuffer<T>
     {
         public Span<T> Span { get; private set; }
+
         private T[]? _arrayToReturn;
 
         /// <summary>
@@ -24,16 +25,23 @@ namespace TileDB.CSharp.Marshalling
         /// <param name="minimumLength">The buffer's minimum length.</param>
         /// <param name="preAllocatedSpan">A pre-allocated <see cref="Span{T}"/> that will
         /// be preferred if it has at least <paramref name="minimumLength"/> elements.</param>
+        /// <param name="exactSize">Whether to make <see cref="Span"/> be
+        /// exactly of length <paramref name="minimumLength"/>. Defaults to <see langword="false"/>.</param>
         /// <remarks>
         /// <paramref name="preAllocatedSpan"/> could be allocated from the stack using
         /// the <see langword="stackalloc"/> keyword. If it is too small, <see cref="Span"/>
-        /// will come from the array pool.</remarks>
-        /// <seealso cref="ScratchBuffer{T}(Int32)"/>
-        public ScratchBuffer(int minimumLength, Span<T> preAllocatedSpan)
+        /// will come from the array pool.
+        /// </remarks>
+        /// <seealso cref="ScratchBuffer{T}(int, bool)"/>
+        public ScratchBuffer(int minimumLength, Span<T> preAllocatedSpan, bool exactSize = false)
         {
             if (preAllocatedSpan.Length >= minimumLength)
             {
                 Span = preAllocatedSpan;
+                if (exactSize)
+                {
+                    Span = Span[..minimumLength];
+                }
                 _arrayToReturn = null;
             }
             else
@@ -44,11 +52,17 @@ namespace TileDB.CSharp.Marshalling
         /// Creates a <see cref="ScratchBuffer{T}"/> of length at least <paramref name="minimumLength"/>.
         /// </summary>
         /// <param name="minimumLength">The buffer's minimum length.</param>
+        /// <param name="exactSize">Whether to make <see cref="Span"/> be
+        /// exactly of length <paramref name="minimumLength"/>. Defaults to <see langword="false"/>.</param>
         /// <remarks>The created instance's <see cref="Span"/>
         /// will always come from the array pool.</remarks>
-        public ScratchBuffer(int minimumLength)
+        public ScratchBuffer(int minimumLength, bool exactSize = false)
         {
             Span = _arrayToReturn = ArrayPool<T>.Shared.Rent(minimumLength);
+            if (exactSize)
+            {
+                Span = Span[..minimumLength];
+            }
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/Marshalling/SequentialPair.cs
+++ b/sources/TileDB.CSharp/Marshalling/SequentialPair.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace TileDB.CSharp.Marshalling
+{
+    /// <summary>
+    /// A struct containing two values of the same type that can be passed to native code.
+    /// Has implicit conversion operators between <see cref="ValueTuple{T,T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the values</typeparam>
+    /// <remarks>
+    /// We can't use value tuples in interop because they are marked with auto layout.
+    /// </remarks>
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SequentialPair<T>
+    {
+        public T First;
+        public T Second;
+
+        public static implicit operator (T First, T Second)(SequentialPair<T> x) => (x.First, x.Second);
+
+        public static implicit operator SequentialPair<T>((T First, T Second) x) => new() { First = x.First, Second = x.Second };
+    }
+}

--- a/sources/TileDB.CSharp/Obsoletions.cs
+++ b/sources/TileDB.CSharp/Obsoletions.cs
@@ -20,5 +20,8 @@ namespace TileDB.CSharp
 
         public const string ErrorExceptionMessage = "The ErrorException type is obsolete and will not be thrown. Catch TileDBException instead.";
         public const string ErrorExceptionDiagId = "TILEDB0005";
+
+        public const string DimensionCreateMessage = "The overload of Dimension.Create that accepts an array is obsolete. Use the overload that explicitly accepts the lower and upper bounds instead.";
+        public const string DimensionCreateDiagId = "TILEDB0006";
     }
 }

--- a/sources/TileDB.CSharp/QueryCondition.cs
+++ b/sources/TileDB.CSharp/QueryCondition.cs
@@ -54,12 +54,21 @@ namespace TileDB.CSharp
         /// <param name="optype"></param>
         public void Init<T>(string attribute_name, T condition_value, QueryConditionOperatorType optype) where T : struct
         {
-            ErrorHandling.ThrowIfManagedType<T>();
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             using var ms_attribute_name = new MarshaledString(attribute_name);
-            _ctx.handle_error(Methods.tiledb_query_condition_init(ctxHandle, handle, ms_attribute_name,
-                &condition_value, (ulong)sizeof(T), (tiledb_query_condition_op_t)optype));
+            T[] data = new T[1] { condition_value };
+            ulong size = (ulong)Marshal.SizeOf(data[0]);
+            var dataGcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            try
+            {
+                _ctx.handle_error(Methods.tiledb_query_condition_init(ctxHandle, handle, ms_attribute_name,
+                    (void*)dataGcHandle.AddrOfPinnedObject(), size, (tiledb_query_condition_op_t)optype));
+            }
+            finally
+            {
+                dataGcHandle.Free();
+            }
         }
 
         /// <summary>
@@ -73,10 +82,18 @@ namespace TileDB.CSharp
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             using var ms_attribute_name = new MarshaledString(attribute_name);
-            using var ms_condition_value = new MarshaledString(condition_value);
-            ulong size = (ulong)ms_condition_value.Length;
-            _ctx.handle_error(Methods.tiledb_query_condition_init(ctxHandle, handle, ms_attribute_name,
-                ms_condition_value, size, (tiledb_query_condition_op_t)optype));
+            byte[] data = Encoding.ASCII.GetBytes(condition_value);
+            ulong size = (ulong)data.Length;
+            var dataGcHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
+            try
+            {
+                _ctx.handle_error(Methods.tiledb_query_condition_init(ctxHandle, handle, ms_attribute_name,
+                    (void*)dataGcHandle.AddrOfPinnedObject(), size, (tiledb_query_condition_op_t)optype));
+            }
+            finally
+            {
+                dataGcHandle.Free();
+            }
         }
 
         public QueryCondition Combine(QueryCondition rhs, QueryConditionCombinationOperatorType combination_optype)

--- a/sources/TileDB.CSharp/ThrowHelpers.cs
+++ b/sources/TileDB.CSharp/ThrowHelpers.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
 
 namespace TileDB.CSharp
 {
@@ -17,5 +18,9 @@ namespace TileDB.CSharp
         [DoesNotReturn]
         public static void ThrowStringTypeMismatch(DataType type) =>
             throw new InvalidOperationException($"Cannot encode data type {type} into strings");
+
+        [DoesNotReturn]
+        public static void ThrowTooBigSize(ulong size, [CallerArgumentExpression(nameof(size))] string? paramName = null) =>
+            throw new ArgumentOutOfRangeException(paramName, size, "Size argument is too big for the type to fit.");
     }
 }

--- a/tests/TileDB.CSharp.Test/ArrayMetadataTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayMetadataTest.cs
@@ -26,12 +26,10 @@ namespace TileDB.CSharp.Test
         {
             var context = Context.GetDefault();
 
-            var bound = new short[] { 1, 4 };
-            const short extent = 4;
-            var rowDim = Dimension.Create(context, "rows", bound, extent);
+            var rowDim = Dimension.Create(context, "rows", 1, 4, 4);
             Assert.IsNotNull(rowDim);
 
-            var colDim = Dimension.Create(context, "cols", bound, extent);
+            var colDim = Dimension.Create(context, "cols", 1, 4, 4);
             Assert.IsNotNull(rowDim);
 
             var domain = new Domain(context);

--- a/tests/TileDB.CSharp.Test/ArraySchemaEvolutionTest.cs
+++ b/tests/TileDB.CSharp.Test/ArraySchemaEvolutionTest.cs
@@ -1,6 +1,4 @@
 using System;
-using System.IO;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace TileDB.CSharp.Test
@@ -15,8 +13,8 @@ namespace TileDB.CSharp.Test
         {
             var ctx = Context.GetDefault();
 
-            var rows = Dimension.Create(ctx, "rows", new[] { 1, 4 }, 4);
-            var cols = Dimension.Create(ctx, "cols", new[] { 1, 4 }, 4);
+            var rows = Dimension.Create(ctx, "rows", 1, 4, 4);
+            var cols = Dimension.Create(ctx, "cols", 1, 4, 4);
 
             var domain = new Domain(ctx);
             domain.AddDimensions(rows, cols);

--- a/tests/TileDB.CSharp.Test/ArraySchemaTest.cs
+++ b/tests/TileDB.CSharp.Test/ArraySchemaTest.cs
@@ -11,9 +11,7 @@ namespace TileDB.CSharp.Test
 		{
 			var context = Context.GetDefault();
 
-			var bound = new[] { 1, 10 };
-			const int extent = 5;
-			var dimension = Dimension.Create(context, "test", bound, extent);
+			var dimension = Dimension.Create(context, "test", 1, 10, 5);
 			Assert.IsNotNull(dimension);
 
 			var domain = new Domain(context);
@@ -86,11 +84,11 @@ namespace TileDB.CSharp.Test
 			var domain = new Domain(context);
 			Assert.IsNotNull(domain);
 
-			var dim_rows = Dimension.Create(context, "rows", new[] { 0, 4 }, 4);
+			var dim_rows = Dimension.Create(context, "rows", 0, 4, 4);
 			Assert.IsNotNull(dim_rows);
 			domain.AddDimension(dim_rows);
 
-			var dim_cols = Dimension.Create(context, "cols", new[] { 0, 4 }, 4);
+			var dim_cols = Dimension.Create(context, "cols", 0, 4, 4);
 			Assert.IsNotNull(dim_cols);
 			domain.AddDimension(dim_cols);
 
@@ -114,10 +112,10 @@ namespace TileDB.CSharp.Test
 			var config = new Config();
 			var context = new Context(config);
 
-			var d1 = Dimension.Create(context, "d1", new[] { 0, 100 }, 5);
+			var d1 = Dimension.Create(context, "d1", 0, 100, 5);
 			Assert.IsNotNull(d1);
 
-			var d2 = Dimension.Create(context, "d2", new[] { 0, 200 }, 5);
+			var d2 = Dimension.Create(context, "d2", 0, 200, 5);
 			Assert.IsNotNull(d1);
 
 			var domain = new Domain(context);
@@ -146,10 +144,10 @@ namespace TileDB.CSharp.Test
 			var config = new Config();
 			var context = new Context(config);
 
-			var d1 = Dimension.Create(context, "d1", new[] { 0, 100 }, 5);
+			var d1 = Dimension.Create(context, "d1", 0, 100, 5);
 			Assert.IsNotNull(d1);
 
-			var d2 = Dimension.Create(context, "d2", new[] { 0, 200 }, 5);
+			var d2 = Dimension.Create(context, "d2", 0, 200, 5);
 			Assert.IsNotNull(d1);
 
 			var domain = new Domain(context);
@@ -180,10 +178,10 @@ namespace TileDB.CSharp.Test
 			var config = new Config();
 			var context = new Context(config);
 
-			var d1 = Dimension.Create(context, "d1", new[] { -50, 50 }, 5);
+			var d1 = Dimension.Create(context, "d1", -50, 50, 5);
 			Assert.IsNotNull(d1);
 
-			var d2 = Dimension.Create(context, "d2", new[] { -100, 100 }, 5);
+			var d2 = Dimension.Create(context, "d2", -100, 100, 5);
 			Assert.IsNotNull(d1);
 
 			var domain = new Domain(context);
@@ -212,10 +210,10 @@ namespace TileDB.CSharp.Test
 			var config = new Config();
 			var context = new Context(config);
 
-			var d1 = Dimension.Create(context, "d1", new[] { 0.0f, 1.0f }, 0.01f);
+			var d1 = Dimension.Create(context, "d1", 0.0f, 1.0f, 0.01f);
 			Assert.IsNotNull(d1);
 
-			var d2 = Dimension.Create(context, "d2", new[] { 0.0f, 2.0f }, 0.01f);
+			var d2 = Dimension.Create(context, "d2", 0.0f, 2.0f, 0.01f);
 			Assert.IsNotNull(d1);
 
 			var domain = new Domain(context);

--- a/tests/TileDB.CSharp.Test/ArrayTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayTest.cs
@@ -201,14 +201,10 @@ namespace TileDB.CSharp.Test
 
         private ArraySchema BuildSparseArraySchema(Context context)
         {
-            var boundDim1 = new short[] { 1, 10 };
-            const short extentDim1 = 5;
-            var dim1 = Dimension.Create(context, "dim1", boundDim1, extentDim1);
+            var dim1 = Dimension.Create<short>(context, "dim1", 1, 10, 5);
             Assert.IsNotNull(dim1);
 
-            var boundDim2 = new float[] { 1.0f, 4.0f };
-            const float extentDim2 = 0.5f;
-            var dim2 = Dimension.Create(context, "dim2", boundDim2, extentDim2);
+            var dim2 = Dimension.Create(context, "dim2", 1.0f, 4.0f, 0.5f);
             Assert.IsNotNull(dim2);
 
             var domain = new Domain(context);

--- a/tests/TileDB.CSharp.Test/AttributeTest.cs
+++ b/tests/TileDB.CSharp.Test/AttributeTest.cs
@@ -163,11 +163,11 @@ namespace TileDB.CSharp.Test
             var domain = new Domain(context);
             Assert.IsNotNull(domain);
 
-            var dim_rows = Dimension.Create(context, "rows", new[] { 1, 4 }, 4);
+            var dim_rows = Dimension.Create(context, "rows", 1, 4, 4);
             Assert.IsNotNull(dim_rows);
             domain.AddDimension(dim_rows);
 
-            var dim_cols = Dimension.Create(context, "cols", new[] { 1, 4 }, 4);
+            var dim_cols = Dimension.Create(context, "cols", 1, 4, 4);
             Assert.IsNotNull(dim_cols);
             domain.AddDimension(dim_cols);
 

--- a/tests/TileDB.CSharp.Test/DimensionTest.cs
+++ b/tests/TileDB.CSharp.Test/DimensionTest.cs
@@ -15,9 +15,8 @@ namespace TileDB.CSharp.Test
             Assert.AreEqual("test", dimension.Name());
             Assert.AreEqual(DataType.Int32, dimension.Type());
             Assert.AreEqual(extent, dimension.TileExtent<int>());
-            var dim_domain = dimension.Domain<int>();
-            Assert.AreEqual(1, dim_domain[0]);
-            Assert.AreEqual(10, dim_domain[1]);
+            var dim_domain = dimension.GetDomain<int>();
+            Assert.AreEqual((1, 10), dim_domain);
         }
 
         [TestMethod]
@@ -25,9 +24,9 @@ namespace TileDB.CSharp.Test
         {
             var context = Context.GetDefault();
 
-            var dimension = Dimension.Create<string>(context, "strdim", "", "", "");
-            Assert.AreEqual<string>("strdim", dimension.Name());
+            var dimension = Dimension.CreateString(context, "strdim");
+            Assert.AreEqual("strdim", dimension.Name());
             Assert.AreEqual(DataType.StringAscii, dimension.Type());
         }
     }
-}//namespace
+}

--- a/tests/TileDB.CSharp.Test/GroupTest.cs
+++ b/tests/TileDB.CSharp.Test/GroupTest.cs
@@ -128,7 +128,7 @@ namespace TileDB.CSharp.Test
             var domain = new Domain(context);
             Assert.IsNotNull(domain);
 
-            var dim_1 = Dimension.Create(context, "d1", new[] { 1, 1 }, 1);
+            var dim_1 = Dimension.Create(context, "d1", 1, 1, 1);
             Assert.IsNotNull(dim_1);
             domain.AddDimension(dim_1);
 

--- a/tests/TileDB.CSharp.Test/QueryConditionTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryConditionTest.cs
@@ -11,14 +11,10 @@ namespace TileDB.CSharp.Test
             var context = Context.GetDefault();
             Assert.IsNotNull(context);
 
-            var bound1 = new int[] { 1, 4 };
-            const int extent1 = 2;
-            var dimension1 = Dimension.Create<int>(context, "rows", bound1, extent1);
+            var dimension1 = Dimension.Create(context, "rows", 1, 4, 2);
             Assert.IsNotNull(dimension1);
 
-            var bound2 = new int[] { 1, 4 };
-            const int extent2 = 2;
-            var dimension2 = Dimension.Create<int>(context, "cols", bound2, extent2);
+            var dimension2 = Dimension.Create(context, "cols", 1, 4, 2);
             Assert.IsNotNull(dimension2);
 
             var domain = new Domain(context);
@@ -58,7 +54,7 @@ namespace TileDB.CSharp.Test
             var query_write = new Query(context, array_write);
 
             var attr1_data_buffer = new int[16] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
-            query_write.SetDataBuffer<int>("a1", attr1_data_buffer);
+            query_write.SetDataBuffer("a1", attr1_data_buffer);
             query_write.Submit();
 
             var status = query_write.Status();
@@ -77,16 +73,16 @@ namespace TileDB.CSharp.Test
             query_read.SetLayout(LayoutType.RowMajor);
 
             int[] subarray = new int[4] { 1, 4, 1, 4 };
-            query_read.SetSubarray<int>(subarray);
+            query_read.SetSubarray(subarray);
 
-            QueryCondition qc1 = QueryCondition.Create<int>(context, "a1", 3, QueryConditionOperatorType.GreaterThan);
-            QueryCondition qc2 = QueryCondition.Create<int>(context, "a1", 7, QueryConditionOperatorType.LessThan);
+            QueryCondition qc1 = QueryCondition.Create(context, "a1", 3, QueryConditionOperatorType.GreaterThan);
+            QueryCondition qc2 = QueryCondition.Create(context, "a1", 7, QueryConditionOperatorType.LessThan);
             var qc = qc1.Combine(qc2, QueryConditionCombinationOperatorType.And);
 
             query_read.SetCondition(qc);
 
             var attr_data_buffer_read = new int[16];
-            query_read.SetDataBuffer<int>("a1", attr_data_buffer_read);
+            query_read.SetDataBuffer("a1", attr_data_buffer_read);
 
             query_read.Submit();
             var status_read = query_read.Status();

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -24,9 +24,9 @@ namespace TileDB.CSharp.Test
             Assert.IsNotNull(ctx);
 
             // Create array
-            var rows = Dimension.Create<int>(ctx, "rows", new[] { 1, 4 }, 2);
+            var rows = Dimension.Create(ctx, "rows", 1, 4, 2);
             Assert.IsNotNull(rows);
-            var cols = Dimension.Create<int>(ctx, "cols", new[] { 1, 4 }, 2);
+            var cols = Dimension.Create(ctx, "cols", 1, 4, 2);
             Assert.IsNotNull(cols);
             using var domain = new Domain(ctx);
             Assert.IsNotNull(domain);
@@ -97,10 +97,10 @@ namespace TileDB.CSharp.Test
             {
                 a1Expected = new[]
                 {
-                    1, 2, Int32.MinValue, Int32.MinValue,
-                    3, 4, Int32.MinValue, Int32.MinValue,
-                    5, 6, Int32.MinValue, Int32.MinValue,
-                    7, 8, Int32.MinValue, Int32.MinValue
+                    1, 2, int.MinValue, int.MinValue,
+                    3, 4, int.MinValue, int.MinValue,
+                    5, 6, int.MinValue, int.MinValue,
+                    7, 8, int.MinValue, int.MinValue
                 };
                 rowsExpected = new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 };
                 colsExpected = new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 };
@@ -122,9 +122,10 @@ namespace TileDB.CSharp.Test
             var context = Context.GetDefault();
             Assert.IsNotNull(context);
 
-            var bound = new sbyte[] { 0, 9 };
+            const sbyte boundLower = 0;
+            const sbyte boundUpper = 9;
             const sbyte extent = 2;
-            var dimension = Dimension.Create<sbyte>(context, "dim1", bound, extent);
+            var dimension = Dimension.Create(context, "dim1", boundLower, boundUpper, extent);
             Assert.IsNotNull(dimension);
 
             var domain = new Domain(context);
@@ -171,13 +172,13 @@ namespace TileDB.CSharp.Test
 
             var a1_data_buffer = new int[2] { 1, 2 };
 
-            query.SetDataBuffer<int>("a1", a1_data_buffer);
+            query.SetDataBuffer("a1", a1_data_buffer);
 
             var a2_data_buffer = new float[5] { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f };
 
-            query.SetDataBuffer<float>("a2", a2_data_buffer );
+            query.SetDataBuffer("a2", a2_data_buffer );
 
-            var a2_offset_buffer = new UInt64[2] { 0, 3 };
+            var a2_offset_buffer = new ulong[2] { 0, 3 };
 
             query.SetOffsetsBuffer("a2", a2_offset_buffer);
 
@@ -205,13 +206,13 @@ namespace TileDB.CSharp.Test
 
             var a1_data_buffer_read = new int[2];
 
-            query_read.SetDataBuffer<int>("a1", a1_data_buffer_read);
+            query_read.SetDataBuffer("a1", a1_data_buffer_read);
 
             var a2_data_buffer_read = new float[5];
 
-            query_read.SetDataBuffer<float>("a2", a2_data_buffer_read);
+            query_read.SetDataBuffer("a2", a2_data_buffer_read);
 
-            var a2_offset_buffer_read = new UInt64[2];
+            var a2_offset_buffer_read = new ulong[2];
 
             query_read.SetOffsetsBuffer("a2", a2_offset_buffer_read);
 
@@ -238,13 +239,15 @@ namespace TileDB.CSharp.Test
             Assert.IsNotNull(context);
 
             // Create array
-            int[] dim1_bound = new int[] { 1, 4 };
+            int dim1_bound_lower = 1;
+            int dim1_bound_upper = 4;
             int dim1_extent = 4;
-            var dim1 = Dimension.Create<int>(context, "rows", dim1_bound, dim1_extent);
+            var dim1 = Dimension.Create(context, "rows", dim1_bound_lower, dim1_bound_upper, dim1_extent);
 
-            int[] dim2_bound = new int[] { 1, 4 };
+            int dim2_bound_lower = 1;
+            int dim2_bound_upper = 4;
             int dim2_extent = 4;
-            var dim2 = Dimension.Create<int>(context, "cols", dim2_bound, dim2_extent);
+            var dim2 = Dimension.Create(context, "cols", dim2_bound_lower, dim2_bound_upper, dim2_extent);
 
             var domain = new Domain(context);
             Assert.IsNotNull(domain);
@@ -288,9 +291,9 @@ namespace TileDB.CSharp.Test
 
                 query_write.SetLayout(LayoutType.Unordered);
 
-                query_write.SetDataBuffer<int>("rows", dim1_data_buffer);
-                query_write.SetDataBuffer<int>("cols", dim2_data_buffer);
-                query_write.SetDataBuffer<int>("a", attr_data_buffer);
+                query_write.SetDataBuffer("rows", dim1_data_buffer);
+                query_write.SetDataBuffer("cols", dim2_data_buffer);
+                query_write.SetDataBuffer("a", attr_data_buffer);
 
                 query_write.Submit();
 
@@ -317,11 +320,11 @@ namespace TileDB.CSharp.Test
 
                 query_read.SetLayout(LayoutType.RowMajor);
 
-                query_read.SetDataBuffer<int>("rows", dim1_data_buffer_read);
+                query_read.SetDataBuffer("rows", dim1_data_buffer_read);
 
-                query_read.SetDataBuffer<int>("cols", dim2_data_buffer_read);
+                query_read.SetDataBuffer("cols", dim2_data_buffer_read);
 
-                query_read.SetDataBuffer<int>("a", attr_data_buffer_read);
+                query_read.SetDataBuffer("a", attr_data_buffer_read);
 
                 query_read.Submit();
                 var status_read = query_read.Status();
@@ -346,13 +349,15 @@ namespace TileDB.CSharp.Test
             Assert.IsNotNull(context);
 
             // Create array
-            int[] dim1_bound = new int[] { 1, 2 };
+            int dim1_bound_lower = 1;
+            int dim1_bound_upper = 2;
             int dim1_extent = 2;
-            var dim1 = Dimension.Create<int>(context, "rows", dim1_bound, dim1_extent);
+            var dim1 = Dimension.Create(context, "rows", dim1_bound_lower, dim1_bound_upper, dim1_extent);
 
-            int[] dim2_bound = new int[] { 1, 2 };
+            int dim2_bound_lower = 1;
+            int dim2_bound_upper = 2;
             int dim2_extent = 2;
-            var dim2 = Dimension.Create<int>(context, "cols", dim2_bound, dim2_extent);
+            var dim2 = Dimension.Create(context, "cols", dim2_bound_lower, dim2_bound_upper, dim2_extent);
 
             var domain = new Domain(context);
             Assert.IsNotNull(domain);
@@ -404,7 +409,7 @@ namespace TileDB.CSharp.Test
                 a2_off[i] = a2_el_off[i] * EnumUtil.DataTypeSize(DataType.Int32);
             }
 
-            byte[] a3_data = new byte[9] { Convert.ToByte('a'), Convert.ToByte('b'), Convert.ToByte('c'), Convert.ToByte('d'), Convert.ToByte('e'), Convert.ToByte('w'), Convert.ToByte('x'), Convert.ToByte('y'), Convert.ToByte('z') };
+            byte[] a3_data = "abcdewxyz"u8.ToArray();
             ulong[] a3_el_off = new ulong[4] { 0, 3, 4, 5 };
             ulong[] a3_off = new ulong[4];
             for (int i = 0; i < a3_el_off.Length; ++i)
@@ -425,14 +430,14 @@ namespace TileDB.CSharp.Test
                 var query_write = new Query(context, array_write);
                 query_write.SetLayout(LayoutType.RowMajor);
 
-                query_write.SetDataBuffer<int>("a1", a1_data);
+                query_write.SetDataBuffer("a1", a1_data);
                 query_write.SetValidityBuffer("a1", a1_validity);
 
-                query_write.SetDataBuffer<int>("a2", a2_data);
+                query_write.SetDataBuffer("a2", a2_data);
                 query_write.SetOffsetsBuffer("a2", a2_off);
                 query_write.SetValidityBuffer("a2", a2_validity);
 
-                query_write.SetDataBuffer<byte>("a3", a3_data);
+                query_write.SetDataBuffer("a3", a3_data);
                 query_write.SetOffsetsBuffer("a3", a3_off);
                 query_write.SetValidityBuffer("a3", a3_validity);
 
@@ -469,16 +474,16 @@ namespace TileDB.CSharp.Test
                 var query_read = new Query(context, array_read);
 
                 query_read.SetLayout(LayoutType.RowMajor);
-                query_read.SetSubarray<int>(subarray);
+                query_read.SetSubarray(subarray);
 
-                query_read.SetDataBuffer<int>("a1", a1_data_read);
+                query_read.SetDataBuffer("a1", a1_data_read);
                 query_read.SetValidityBuffer("a1", a1_validity_read);
 
-                query_read.SetDataBuffer<int>("a2", a2_data_read);
+                query_read.SetDataBuffer("a2", a2_data_read);
                 query_read.SetOffsetsBuffer("a2", a2_off_read);
                 query_read.SetValidityBuffer("a2", a2_validity_read);
 
-                query_read.SetDataBuffer<byte>("a3", a3_data_read);
+                query_read.SetDataBuffer("a3", a3_data_read);
                 query_read.SetOffsetsBuffer("a3", a3_off_read);
                 query_read.SetValidityBuffer("a3", a3_validity_read);
 
@@ -509,8 +514,8 @@ namespace TileDB.CSharp.Test
             var context = Context.GetDefault();
             Assert.IsNotNull(context);
 
-            var dim1 = Dimension.Create<int>(context, "rows", new [] { 1, 2 }, 2);
-            var dim2 = Dimension.Create<int>(context, "cols", new [] { 1, 2 }, 2);
+            var dim1 = Dimension.Create(context, "rows", 1, 2, 2);
+            var dim2 = Dimension.Create(context, "cols", 1, 2, 2);
             var domain = new Domain(context);
             domain.AddDimensions(dim1, dim2);
 
@@ -538,7 +543,7 @@ namespace TileDB.CSharp.Test
             query_write.SetLayout(LayoutType.RowMajor);
 
             var a1_data = new bool[] { false, true, true, false };
-            query_write.SetDataBuffer<bool>("a1", a1_data);
+            query_write.SetDataBuffer("a1", a1_data);
 
             query_write.Submit();
             var status = query_write.Status();
@@ -556,7 +561,7 @@ namespace TileDB.CSharp.Test
             query_read.SetLayout(LayoutType.RowMajor);
 
             var a1_data_read = new bool[4];
-            query_read.SetDataBuffer<bool>("a1", a1_data_read);
+            query_read.SetDataBuffer("a1", a1_data_read);
 
             query_read.Submit();
             status = query_read.Status();
@@ -571,7 +576,7 @@ namespace TileDB.CSharp.Test
             query_read.SetLayout(LayoutType.RowMajor);
 
             var a1_data_read_bytes = new byte[4];
-            query_read.SetDataBuffer<byte>("a1", a1_data_read_bytes);
+            query_read.SetDataBuffer("a1", a1_data_read_bytes);
 
             query_read.Submit();
             status = query_read.Status();


### PR DESCRIPTION
This PR removes most uses of `GCHandle`s and replaces them with directly using pointers when passing values on the stack to native code, or with the `fixed` statement when pinning values on the heap.

The remaining uses of `GCHandle`s are in the bindings example (that will eventually be removed), the deprecated `TileDBBuffer` class, the soon-to-be-deprecated subarray methods on `Query`, and the long-term pinning of query buffers and keeping alive the `Query` for the duration of an async submit (the only valid use casees).

I also took the opportunity to clean-up the files I touched and deprecate the `Dimension.Create` overload that takes an array; only the first two values are actually used; the overload that explicitly takes the lower and upper bounds better represents the method's intent.

[SC-23109](https://app.shortcut.com/tiledb-inc/story/23109/do-not-use-gchandles-for-brief-pinning-of-objects)