### PR TITLE
Clean-up the `QueryCondition` class, introduce combination operators et.al.

### DIFF
--- a/docs/obsoletions.md
+++ b/docs/obsoletions.md
@@ -179,3 +179,31 @@ qc.Init("attr1", 15, QueryConditionOperatorType.GreaterThan);
 ```csharp
 using QueryCondition qc = QueryCondition.Create(Context.GetDefault(), "attr1", 15, QueryConditionOperatorType.GreaterThan);
 ```
+
+## <span id="TILEDB0008">`TILEDB0008` - The `QueryCondition.Combine` method is obsolete.</span>
+
+The `QueryCondition.Combine` method is verbose and does not clearly signify which combination operator types are unary or binary. For these reasons it was marked as obsolete in version 5.3.0 and replaced with operator overloading.
+
+### Version introduced
+
+5.3.0
+
+### Recommended action
+
+Use the `&`, `|` or `!` operators to combine query conditions.
+
+### Existing code
+
+```csharp
+using QueryCondition qc1 = QueryCondition.Create(Context.GetDefault(), "attr1", 15, QueryConditionOperatorType.GreaterThan);
+using QueryCondition qc2 = QueryCondition.Create(Context.GetDefault(), "attr2", 12, QueryConditionOperatorType.LessThan);
+using QueryCondition qc = qc1.Combine(qc2, QueryConditionCombinationOperatorType.And);
+```
+
+### New code
+
+```csharp
+using QueryCondition qc1 = QueryCondition.Create(Context.GetDefault(), "attr1", 15, QueryConditionOperatorType.GreaterThan);
+using QueryCondition qc2 = QueryCondition.Create(Context.GetDefault(), "attr2", 12, QueryConditionOperatorType.LessThan);
+using QueryCondition qc = qc1 & qc2;
+```

--- a/docs/obsoletions.md
+++ b/docs/obsoletions.md
@@ -154,3 +154,28 @@ Dimension dimension = Dimension.Create(context, "test", new int[] { 1, 10 }, 5);
 ```csharp
 Dimension dimension = Dimension.Create(context, "test", 1, 10, 5);
 ```
+
+## <span id="TILEDB0007">`TILEDB0007` - The constructor and `Init` methods of the `QueryCondition` class are obsolete.</span>
+
+There are two ways to create query conditions: by constructing `QueryCondition` objects and calling the `Init` method, or by calling the `QueryCondition.Create` static methods. The former way is prone to bugs because it unnecessarily requires two methods and so in version 5.3.0 the public constructor and `Init` methods of the `QueryCondition` class were marked as obsolete.
+
+### Version introduced
+
+5.3.0
+
+### Recommended action
+
+Use `QueryCondition.Create` to create `QueryCondition` objects.
+
+### Existing code
+
+```csharp
+using QueryCondition qc = new QueryCondition(Context.GetDefault());
+qc.Init("attr1", 15, QueryConditionOperatorType.GreaterThan);
+```
+
+### New code
+
+```csharp
+using QueryCondition qc = QueryCondition.Create(Context.GetDefault(), "attr1", 15, QueryConditionOperatorType.GreaterThan);
+```

--- a/sources/TileDB.CSharp/Obsoletions.cs
+++ b/sources/TileDB.CSharp/Obsoletions.cs
@@ -26,5 +26,8 @@ namespace TileDB.CSharp
 
         public const string QueryConditionInitMessage = "The constructor and Init method of the QueryCondition classes is obsolete. Use the static Create methods instead.";
         public const string QueryConditionInitDiagId = "TILEDB0007";
+
+        public const string QueryConditionCombineMessage = "The QueryCondition.Combine method is obsolete. Use the '&', '|' and '!' operators instead.";
+        public const string QueryConditionCombineDiagId = "TILEDB0008";
     }
 }

--- a/sources/TileDB.CSharp/Obsoletions.cs
+++ b/sources/TileDB.CSharp/Obsoletions.cs
@@ -23,5 +23,8 @@ namespace TileDB.CSharp
 
         public const string DimensionCreateMessage = "The overload of Dimension.Create that accepts an array is obsolete. Use the overload that explicitly accepts the lower and upper bounds instead.";
         public const string DimensionCreateDiagId = "TILEDB0006";
+
+        public const string QueryConditionInitMessage = "The constructor and Init method of the QueryCondition classes is obsolete. Use the static Create methods instead.";
+        public const string QueryConditionInitDiagId = "TILEDB0007";
     }
 }

--- a/sources/TileDB.CSharp/QueryCondition.cs
+++ b/sources/TileDB.CSharp/QueryCondition.cs
@@ -163,5 +163,34 @@ namespace TileDB.CSharp
             ret.Init(attribute_name, value, optype);
             return ret;
         }
+
+        /// <summary>
+        /// Creates the conjunction of two <see cref="QueryCondition"/>s.
+        /// </summary>
+        /// <param name="lhs">The first query condition.</param>
+        /// <param name="rhs">The second query condition.</param>
+        /// <returns>A query condition that will be satisfied if both
+        /// <paramref name="lhs"/> and <paramref name="rhs"/> are satisfied.</returns>
+        public static QueryCondition operator &(QueryCondition lhs, QueryCondition rhs) =>
+            Combine(lhs, rhs, QueryConditionCombinationOperatorType.And);
+
+        /// <summary>
+        /// Creates the disjunction of two <see cref="QueryCondition"/>s.
+        /// </summary>
+        /// <param name="lhs">The first query condition.</param>
+        /// <param name="rhs">The second query condition.</param>
+        /// <returns>A query condition that will be satisfied if at least one of
+        /// <paramref name="lhs"/> or <paramref name="rhs"/> are satisfied.</returns>
+        public static QueryCondition operator |(QueryCondition lhs, QueryCondition rhs) =>
+            Combine(lhs, rhs, QueryConditionCombinationOperatorType.Or);
+
+        /// <summary>
+        /// Creates the negation of a <see cref="QueryCondition"/>.
+        /// </summary>
+        /// <param name="condition">The query condition to negate.</param>
+        /// <returns>A query condition that will be satisfied if
+        /// <paramref name="condition"/> is not satisfied.</returns>
+        public static QueryCondition operator !(QueryCondition condition) =>
+            Combine(condition, null, QueryConditionCombinationOperatorType.Not);
     }
 }

--- a/sources/TileDB.CSharp/QueryCondition.cs
+++ b/sources/TileDB.CSharp/QueryCondition.cs
@@ -2,6 +2,9 @@ using System;
 using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 
+// We are allowed to construct and initialize query conditions.
+#pragma warning disable TILEDB0006
+
 namespace TileDB.CSharp
 {
     /// <summary>
@@ -21,6 +24,7 @@ namespace TileDB.CSharp
         /// <see cref="Init(string, string, QueryConditionOperatorType)"/>
         /// or <see cref="Init{T}(string, T, QueryConditionOperatorType)"/>.
         /// </remarks>
+        [Obsolete(Obsoletions.QueryConditionInitMessage, DiagnosticId = Obsoletions.QueryConditionInitDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public QueryCondition(Context ctx)
         {
             _ctx = ctx;
@@ -54,6 +58,7 @@ namespace TileDB.CSharp
         /// Query conditions created with <see cref="Create(Context, string, string, QueryConditionOperatorType)"/>
         /// must not call this method.
         /// </remarks>
+        [Obsolete(Obsoletions.QueryConditionInitMessage, DiagnosticId = Obsoletions.QueryConditionInitDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public void Init<T>(string attribute_name, T condition_value, QueryConditionOperatorType optype) where T : struct
         {
             ErrorHandling.ThrowIfManagedType<T>();
@@ -71,6 +76,7 @@ namespace TileDB.CSharp
         /// Query conditions created with <see cref="Create(Context, string, string, QueryConditionOperatorType)"/>
         /// must not call this method.
         /// </remarks>
+        [Obsolete(Obsoletions.QueryConditionInitMessage, DiagnosticId = Obsoletions.QueryConditionInitDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public void Init(string attribute_name, string condition_value, QueryConditionOperatorType optype)
         {
             using var ms_condition_value = new MarshaledString(condition_value);

--- a/sources/TileDB.CSharp/QueryCondition.cs
+++ b/sources/TileDB.CSharp/QueryCondition.cs
@@ -100,6 +100,7 @@ namespace TileDB.CSharp
         /// <returns>A new query condition that combines this one with <paramref name="rhs"/>.</returns>
         /// <exception cref="InvalidOperationException">This query condition and <paramref name="rhs"/>
         /// are associated with a different <see cref="Context"/>.</exception>
+        [Obsolete(Obsoletions.QueryConditionCombineMessage, DiagnosticId = Obsoletions.QueryConditionCombineDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public QueryCondition Combine(QueryCondition? rhs, QueryConditionCombinationOperatorType combination_optype) =>
             Combine(this, rhs, combination_optype);
 

--- a/sources/TileDB.CSharp/QueryCondition.cs
+++ b/sources/TileDB.CSharp/QueryCondition.cs
@@ -8,13 +8,24 @@ using TileDB.Interop;
 
 namespace TileDB.CSharp
 {
+    /// <summary>
+    /// Represents a TileDB query condition object.
+    /// </summary>
     public sealed unsafe class QueryCondition : IDisposable
     {
         private readonly QueryConditionHandle _handle;
         private readonly Context _ctx;
         private bool _disposed;
 
-
+        /// <summary>
+        /// Creates a <see cref="QueryCondition"/>.
+        /// </summary>
+        /// <param name="ctx">The <see cref="Context"/> associated with this query condition.</param>
+        /// <remarks>
+        /// The query condition must be initialized by calling
+        /// <see cref="Init(string, string, QueryConditionOperatorType)"/>
+        /// or <see cref="Init{T}(string, T, QueryConditionOperatorType)"/>.
+        /// </remarks>
         public QueryCondition(Context ctx)
         {
             _ctx = ctx;
@@ -26,6 +37,10 @@ namespace TileDB.CSharp
             _ctx = ctx;
             _handle = handle;
         }
+
+        /// <summary>
+        /// Disposes this <see cref="QueryCondition"/>.
+        /// </summary>
         public void Dispose()
         {
             Dispose(true);
@@ -47,11 +62,16 @@ namespace TileDB.CSharp
 
         #region capi functions
         /// <summary>
-        /// Initialize a TileDB query condition object.
+        /// Initializes this <see cref="QueryCondition"/> with a value of type <typeparamref name="T"/>.
         /// </summary>
-        /// <param name="attribute_name"></param>
-        /// <param name="condition_value"></param>
-        /// <param name="optype"></param>
+        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+        /// <param name="condition_value">The value to compare the attribute with.</param>
+        /// <param name="optype">The type of the relationship between the attribute with
+        /// the name <paramref name="attribute_name"/> and <paramref name="condition_value"/>.</param>
+        /// <remarks>
+        /// Query conditions created with <see cref="Create(Context, string, string, QueryConditionOperatorType)"/>
+        /// must not call this method.
+        /// </remarks>
         public void Init<T>(string attribute_name, T condition_value, QueryConditionOperatorType optype) where T : struct
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -72,11 +92,16 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Initialize a TileDB query string condition object.
+        /// Initializes this <see cref="QueryCondition"/> with a string.
         /// </summary>
-        /// <param name="attribute_name"></param>
-        /// <param name="condition_value"></param>
-        /// <param name="optype"></param>
+        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+        /// <param name="condition_value">The string to compare the attribute with.</param>
+        /// <param name="optype">The type of the relationship between the attribute with
+        /// the name <paramref name="attribute_name"/> and <paramref name="condition_value"/>.</param>
+        /// <remarks>
+        /// Query conditions created with <see cref="Create(Context, string, string, QueryConditionOperatorType)"/>
+        /// must not call this method.
+        /// </remarks>
         public void Init(string attribute_name, string condition_value, QueryConditionOperatorType optype)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -96,6 +121,12 @@ namespace TileDB.CSharp
             }
         }
 
+        /// <summary>
+        /// Combines this <see cref="QueryCondition"/> with another one.
+        /// </summary>
+        /// <param name="rhs">The other query condition to combine.</param>
+        /// <param name="combination_optype">The type of the combination.</param>
+        /// <returns>A new query condition that combines this one with <paramref name="rhs"/>.</returns>
         public QueryCondition Combine(QueryCondition rhs, QueryConditionCombinationOperatorType combination_optype)
         {
             var handle = new QueryConditionHandle();
@@ -129,13 +160,13 @@ namespace TileDB.CSharp
         #endregion capi functions
 
         /// <summary>
-        /// Create a new query condition with a string.
+        /// Creates a new <see cref="QueryCondition"/> with a string.
         /// </summary>
-        /// <param name="ctx"></param>
-        /// <param name="attribute_name"></param>
-        /// <param name="value"></param>
-        /// <param name="optype"></param>
-        /// <returns></returns>
+        /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
+        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+        /// <param name="value">The value to compare the attribute with.</param>
+        /// <param name="optype">The type of the relationship between the attribute with
+        /// the name <paramref name="attribute_name"/> and <paramref name="value"/>.</param>
         public static QueryCondition Create(Context ctx, string attribute_name, string value, QueryConditionOperatorType optype)
         {
             var ret = new QueryCondition(ctx);
@@ -144,14 +175,13 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Create a new query condition with datatype T.
+        /// Creates a new query condition with datatype <typeparamref name="T"/>.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="ctx"></param>
-        /// <param name="attribute_name"></param>
-        /// <param name="value"></param>
-        /// <param name="optype"></param>
-        /// <returns></returns>
+        /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
+        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+        /// <param name="value">The value to compare the attribute with.</param>
+        /// <param name="optype">The type of the relationship between the attribute with
+        /// the name <paramref name="attribute_name"/> and <paramref name="value"/>.</param>
         public static QueryCondition Create<T>(Context ctx, string attribute_name, T value, QueryConditionOperatorType optype) where T : struct
         {
             var ret = new QueryCondition(ctx);

--- a/sources/TileDB.CSharp/ThrowHelpers.cs
+++ b/sources/TileDB.CSharp/ThrowHelpers.cs
@@ -22,5 +22,9 @@ namespace TileDB.CSharp
         [DoesNotReturn]
         public static void ThrowTooBigSize(ulong size, [CallerArgumentExpression(nameof(size))] string? paramName = null) =>
             throw new ArgumentOutOfRangeException(paramName, size, "Size argument is too big for the type to fit.");
+
+        [DoesNotReturn]
+        public static void ThrowQueryConditionDifferentContexts() =>
+            throw new InvalidOperationException("Cannot combine query conditions associated with different contexts.");
     }
 }

--- a/tests/TileDB.CSharp.Test/QueryConditionTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryConditionTest.cs
@@ -78,7 +78,7 @@ namespace TileDB.CSharp.Test
 
             using QueryCondition qc1 = QueryCondition.Create(context, "a1", 3, QueryConditionOperatorType.GreaterThan);
             using QueryCondition qc2 = QueryCondition.Create(context, "a1", 7, QueryConditionOperatorType.LessThan);
-            using QueryCondition qc = qc1.Combine(qc2, QueryConditionCombinationOperatorType.And);
+            using QueryCondition qc = qc1 & qc2;
 
             query_read.SetCondition(qc);
 

--- a/tests/TileDB.CSharp.Test/QueryConditionTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryConditionTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace TileDB.CSharp.Test
@@ -17,17 +18,17 @@ namespace TileDB.CSharp.Test
             var dimension2 = Dimension.Create(context, "cols", 1, 4, 2);
             Assert.IsNotNull(dimension2);
 
-            var domain = new Domain(context);
+            using var domain = new Domain(context);
             Assert.IsNotNull(domain);
 
             domain.AddDimension(dimension1);
             domain.AddDimension(dimension2);
 
-            var array_schema = new ArraySchema(context, ArrayType.Dense);
+            using var array_schema = new ArraySchema(context, ArrayType.Dense);
             Assert.IsNotNull(array_schema);
 
 
-            var attr1 = new Attribute(context, "a1", DataType.Int32);
+            using var attr1 = new Attribute(context, "a1", DataType.Int32);
             Assert.IsNotNull(attr1);
 
             array_schema.AddAttribute(attr1);
@@ -46,12 +47,12 @@ namespace TileDB.CSharp.Test
             Array.Create(context, tmpArrayPath, array_schema);
 
             //Write array
-            var array_write = new Array(context, tmpArrayPath);
+            using var array_write = new Array(context, tmpArrayPath);
             Assert.IsNotNull(array_write);
 
             array_write.Open(QueryType.Write);
 
-            var query_write = new Query(context, array_write);
+            using var query_write = new Query(context, array_write);
 
             var attr1_data_buffer = new int[16] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
             query_write.SetDataBuffer("a1", attr1_data_buffer);
@@ -63,21 +64,21 @@ namespace TileDB.CSharp.Test
 
             array_write.Close();
 
-            var array_read = new Array(context, tmpArrayPath);
+            using var array_read = new Array(context, tmpArrayPath);
             Assert.IsNotNull(array_read);
 
             array_read.Open(QueryType.Read);
 
-            var query_read = new Query(context, array_read);
+            using var query_read = new Query(context, array_read);
 
             query_read.SetLayout(LayoutType.RowMajor);
 
             int[] subarray = new int[4] { 1, 4, 1, 4 };
             query_read.SetSubarray(subarray);
 
-            QueryCondition qc1 = QueryCondition.Create(context, "a1", 3, QueryConditionOperatorType.GreaterThan);
-            QueryCondition qc2 = QueryCondition.Create(context, "a1", 7, QueryConditionOperatorType.LessThan);
-            var qc = qc1.Combine(qc2, QueryConditionCombinationOperatorType.And);
+            using QueryCondition qc1 = QueryCondition.Create(context, "a1", 3, QueryConditionOperatorType.GreaterThan);
+            using QueryCondition qc2 = QueryCondition.Create(context, "a1", 7, QueryConditionOperatorType.LessThan);
+            using QueryCondition qc = qc1.Combine(qc2, QueryConditionCombinationOperatorType.And);
 
             query_read.SetCondition(qc);
 

--- a/tests/TileDB.CSharp.Test/QueryConditionTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryConditionTest.cs
@@ -97,5 +97,17 @@ namespace TileDB.CSharp.Test
             // Assert.AreEqual<int>(5, attr_data_buffer_read[1]);
             // Assert.AreEqual<int>(6, attr_data_buffer_read[2]);
         }
+
+        [TestMethod]
+        public void TestCombineDifferentContexts()
+        {
+            using var context1 = new Context();
+            using var context2 = new Context();
+
+            using var qc1 = QueryCondition.Create(context1, "a1", 5, QueryConditionOperatorType.GreaterThan);
+            using var qc2 = QueryCondition.Create(context2, "a1", 8, QueryConditionOperatorType.LessThan);
+
+            Assert.ThrowsException<InvalidOperationException>(() => qc1 | qc2);
+        }
     }
 }


### PR DESCRIPTION
This PR introduces the `&`, `|` and `!` operators for `QueryConditions` that replace the `Combine` method which was marked as obsolete. I also obsoleted the constructor and `Init` method, in favor of the `Create` static factory.

[SC-24169](https://app.shortcut.com/tiledb-inc/story/24169/more-fluent-query-condition-combining)