### PR TITLE
Optimize and clean-up the `Query` class, and support setting buffers from more sources.

### DIFF
--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -278,13 +278,13 @@ namespace TileDB.CSharp
             SetDataBuffer(name, PinArray(data), (ulong)data.Length * (ulong)sizeof(T));
         }
 
-        private void SetDataBuffer(string name, MemoryHandle memoryHandle, ulong size)
+        private void SetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize)
         {
             BufferHandle? handle = null;
             bool successful = false;
             try
             {
-                handle = new BufferHandle(ref memoryHandle, size);
+                handle = new BufferHandle(ref memoryHandle, byteSize);
 
                 SetDataBuffer(name, handle.DataPointer, handle.SizePointer);
 
@@ -321,7 +321,7 @@ namespace TileDB.CSharp
                 throw new ArgumentException("Query.set_offsets_buffer, buffer is null or empty!");
             }
 
-            SetOffsetsBuffer(name, PinArray(data), (ulong)data.Length * sizeof(ulong));
+            SetOffsetsBuffer(name, PinArray(data), (ulong)data.Length);
         }
 
         private void SetOffsetsBuffer(string name, MemoryHandle memoryHandle, ulong size)
@@ -330,7 +330,7 @@ namespace TileDB.CSharp
             bool successful = false;
             try
             {
-                handle = new BufferHandle(ref memoryHandle, size);
+                handle = new BufferHandle(ref memoryHandle, size * sizeof(ulong));
 
                 SetOffsetsBuffer(name, (ulong*)handle.DataPointer, handle.SizePointer);
 

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -91,45 +91,6 @@ namespace TileDB.CSharp
         public string Message { get; set; }
     }
 
-    internal sealed unsafe class BufferHandle : IDisposable
-    {
-        private GCHandle DataHandle;
-        public ulong* SizePointer { get; private set; }
-
-        public void* DataPointer => (void*)DataHandle.AddrOfPinnedObject();
-
-        public ulong Size
-        {
-            get
-            {
-                Debug.Assert(SizePointer is not null);
-                return *SizePointer;
-            }
-            set
-            {
-                Debug.Assert(SizePointer is not null);
-                *SizePointer = value;
-            }
-        }
-
-        public BufferHandle(GCHandle handle, ulong size)
-        {
-            DataHandle = handle;
-            SizePointer = (ulong*)Marshal.AllocHGlobal(sizeof(ulong));
-            Size = size;
-        }
-
-        public void Dispose()
-        {
-            DataHandle.Free();
-            if (SizePointer != null)
-            {
-                Marshal.FreeHGlobal((IntPtr)SizePointer);
-            }
-            SizePointer = null;
-        }
-    }
-
     public sealed unsafe class Query : IDisposable
     {
         private readonly Array _array;
@@ -1066,5 +1027,44 @@ namespace TileDB.CSharp
 
         private BufferHandle AddValidityBufferHandle(string name, GCHandle handle, ulong size) =>
             AddBufferHandle(_validityBufferHandles, name, handle, size);
+
+        private sealed class BufferHandle : IDisposable
+        {
+            private GCHandle DataHandle;
+            public ulong* SizePointer { get; private set; }
+
+            public void* DataPointer => (void*)DataHandle.AddrOfPinnedObject();
+
+            public ulong Size
+            {
+                get
+                {
+                    Debug.Assert(SizePointer is not null);
+                    return *SizePointer;
+                }
+                set
+                {
+                    Debug.Assert(SizePointer is not null);
+                    *SizePointer = value;
+                }
+            }
+
+            public BufferHandle(GCHandle handle, ulong size)
+            {
+                DataHandle = handle;
+                SizePointer = (ulong*)Marshal.AllocHGlobal(sizeof(ulong));
+                Size = size;
+            }
+
+            public void Dispose()
+            {
+                DataHandle.Free();
+                if (SizePointer != null)
+                {
+                    Marshal.FreeHGlobal((IntPtr)SizePointer);
+                }
+                SizePointer = null;
+            }
+        }
     }
 }

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -277,7 +277,7 @@ namespace TileDB.CSharp
         {
             if (data is null)
             {
-                throw new ArgumentNullException(nameof(data));
+                ThrowHelpers.ThrowArgumentNullException(nameof(data));
             }
 
             SetDataBuffer(name, data.AsMemory());

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -340,30 +340,6 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Sets the data buffer for an attribute or dimension to an
-        /// unmanaged memory buffer without performing type validation.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">A pointer to the memory buffer.</param>
-        /// <param name="byteSize">The buffer's size <em>in bytes</em>.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="byteSize"/> is zero.</exception>
-        public void SetDataBuffer(string name, void* data, ulong byteSize)
-        {
-            if (data is null)
-            {
-                ThrowHelpers.ThrowArgumentNullException(nameof(data));
-            }
-
-            if (byteSize == 0)
-            {
-                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(byteSize));
-            }
-
-            UnsafeSetDataBuffer(name, new MemoryHandle(data), byteSize);
-        }
-
-        /// <summary>
         /// Sets the data buffer for an attribute or dimension to a <see cref="ReadOnlyMemory{T}"/>.
         /// Not supported for <see cref="QueryType.Read"/> queries.
         /// </summary>
@@ -384,8 +360,33 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
+        /// Sets the data buffer for an attribute or dimension to an
+        /// unmanaged memory buffer without performing type validation.
+        /// </summary>
+        /// <param name="name">The name of the attribute or the dimension.</param>
+        /// <param name="data">A pointer to the memory buffer.</param>
+        /// <param name="byteSize">The buffer's size <em>in bytes</em>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="byteSize"/> is zero.</exception>
+        public void UnsafeSetDataBuffer(string name, void* data, ulong byteSize)
+        {
+            if (data is null)
+            {
+                ThrowHelpers.ThrowArgumentNullException(nameof(data));
+            }
+
+            if (byteSize == 0)
+            {
+                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(byteSize));
+            }
+
+            UnsafeSetDataBuffer(name, new MemoryHandle(data), byteSize);
+        }
+
+        /// <summary>
         /// Sets the data buffer for an attribute or dimension
         /// to a pinned memory buffer pointed by a <see cref="MemoryHandle"/>.
+        /// This method does not perform type validation.
         /// </summary>
         /// <param name="name">The name of the attribute or the dimension.</param>
         /// <param name="memoryHandle">A <see cref="MemoryHandle"/> pointing to the buffer.</param>
@@ -506,7 +507,7 @@ namespace TileDB.CSharp
         /// <item>This method call throws an exception.</item>
         /// </list></para>
         /// </remarks>
-        public void UnsafeSetOffsetsBuffer(string name, MemoryHandle memoryHandle, ulong size)
+        private void UnsafeSetOffsetsBuffer(string name, MemoryHandle memoryHandle, ulong size)
         {
             BufferHandle? handle = null;
             bool successful = false;
@@ -660,7 +661,7 @@ namespace TileDB.CSharp
         /// <item>This method call throws an exception.</item>
         /// </list></para>
         /// </remarks>
-        public void UnsafeSetValidityBuffer(string name, MemoryHandle memoryHandle, ulong size)
+        private void UnsafeSetValidityBuffer(string name, MemoryHandle memoryHandle, ulong size)
         {
             BufferHandle? handle = null;
             bool successful = false;

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -90,7 +90,7 @@ namespace TileDB.CSharp
         public string Message { get; set; }
     }
 
-    internal class BufferHandle
+    internal sealed class BufferHandle : IDisposable
     {
         public GCHandle DataHandle;
         public ulong BytesSize;
@@ -103,16 +103,10 @@ namespace TileDB.CSharp
             SizeHandle = GCHandle.Alloc(BytesSize, GCHandleType.Pinned);
         }
 
-        public void Free()
+        public void Dispose()
         {
-            if (DataHandle.IsAllocated)
-            {
-                DataHandle.Free();
-            }
-            if (SizeHandle.IsAllocated)
-            {
-                SizeHandle.Free();
-            }
+            DataHandle.Free();
+            SizeHandle.Free();
         }
     }
 
@@ -1035,17 +1029,17 @@ namespace TileDB.CSharp
         {
             foreach (var bh in _dataBufferHandles)
             {
-                bh.Value.Free();
+                bh.Value.Dispose();
             }
 
             foreach (var bh in _offsetsBufferHandles)
             {
-                bh.Value.Free();
+                bh.Value.Dispose();
             }
 
             foreach (var bh in _validityBufferHandles)
             {
-                bh.Value.Free();
+                bh.Value.Dispose();
             }
         }
 
@@ -1059,7 +1053,7 @@ namespace TileDB.CSharp
         {
             if (_dataBufferHandles.ContainsKey(name))
             {
-                _dataBufferHandles[name].Free();
+                _dataBufferHandles[name].Dispose();
             }
             _dataBufferHandles[name] = new BufferHandle(handle, size);
         }
@@ -1074,7 +1068,7 @@ namespace TileDB.CSharp
         {
             if (_offsetsBufferHandles.ContainsKey(name))
             {
-                _offsetsBufferHandles[name].Free();
+                _offsetsBufferHandles[name].Dispose();
             }
             _offsetsBufferHandles[name] = new BufferHandle(handle, size);
         }
@@ -1089,7 +1083,7 @@ namespace TileDB.CSharp
         {
             if (_validityBufferHandles.ContainsKey(name))
             {
-                _validityBufferHandles[name].Free();
+                _validityBufferHandles[name].Dispose();
             }
             _validityBufferHandles[name] = new BufferHandle(handle, size);
         }

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -275,12 +275,6 @@ namespace TileDB.CSharp
                 throw new ArgumentException("Query.SetDataBuffer, buffer is null or empty!");
             }
 
-            if (data is bool[] boolData && QueryType() == CSharp.QueryType.Write)
-            {
-                SetDataBuffer(name, System.Array.ConvertAll(boolData, d => d ? (byte)1 : (byte)0));
-                return;
-            }
-
             SetDataBuffer(name, PinArray(data), (ulong)data.Length * (ulong)sizeof(T));
         }
 

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -13,10 +13,24 @@ using TileDB.Interop;
 
 namespace TileDB.CSharp
 {
+    /// <summary>
+    /// Contains estimates for the result's size.
+    /// </summary>
     public class ResultSize
     {
+        /// <summary>
+        /// The data size in bytes.
+        /// </summary>
         public ulong DataBytesSize;
+
+        /// <summary>
+        /// The offsets size in bytes.
+        /// </summary>
         public ulong? OffsetsBytesSize;
+
+        /// <summary>
+        /// The validities size in bytes.
+        /// </summary>
         public ulong? ValidityBytesSize;
 
         /// <summary>
@@ -33,28 +47,25 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Test if it is variable length.
+        /// Returns if the result is about a variable-length attribute or dimension.
         /// </summary>
-        /// <returns></returns>
         public bool IsVarSize()
         {
             return OffsetsBytesSize.HasValue;
         }
 
         /// <summary>
-        /// Test if it is nullable.
+        /// Returns if the result is about a nullable attribute.
         /// </summary>
-        /// <returns></returns>
         public bool IsNullable()
         {
             return ValidityBytesSize.HasValue;
         }
 
         /// <summary>
-        /// Get number of data elements.
+        /// Gets the number of data elements.
         /// </summary>
-        /// <param name="dataType"></param>
-        /// <returns></returns>
+        /// <param name="dataType">The data type of the attribute or dimension.</param>
         public ulong DataSize(DataType dataType)
         {
             tiledb_datatype_t tiledb_datatype = (tiledb_datatype_t)dataType;
@@ -62,24 +73,25 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Get number of offsets.
+        /// Gets the number of offsets.
         /// </summary>
-        /// <returns></returns>
         public ulong OffsetsSize()
         {
             return OffsetsBytesSize.HasValue ? OffsetsBytesSize.Value/Methods.tiledb_datatype_size(tiledb_datatype_t.TILEDB_UINT64) : 0;
         }
 
         /// <summary>
-        /// Get number of validities.
+        /// Gets the number of validities.
         /// </summary>
-        /// <returns></returns>
         public ulong ValiditySize()
         {
             return ValidityBytesSize.HasValue ? ValidityBytesSize.Value / Methods.tiledb_datatype_size(tiledb_datatype_t.TILEDB_UINT8) : 0;
         }
     }
 
+    /// <summary>
+    /// Used in <see cref="Query.SubmitAsync"/>.
+    /// </summary>
     [Obsolete(Obsoletions.QuerySubmitAsyncMessage, DiagnosticId = Obsoletions.QuerySubmitAsyncDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     public class QueryEventArgs : EventArgs
     {
@@ -88,10 +100,15 @@ namespace TileDB.CSharp
             Status = status;
             Message = message;
         }
+
         public int Status { get; set; }
+
         public string Message { get; set; }
     }
 
+    /// <summary>
+    /// Represents a TileDB query object.
+    /// </summary>
     public sealed unsafe class Query : IDisposable
     {
         private readonly Array _array;
@@ -103,6 +120,12 @@ namespace TileDB.CSharp
         private readonly Dictionary<string, BufferHandle> _offsetsBufferHandles = new Dictionary<string, BufferHandle>();
         private readonly Dictionary<string, BufferHandle> _validityBufferHandles = new Dictionary<string, BufferHandle>();
 
+        /// <summary>
+        /// Creates a <see cref="Query"/>.
+        /// </summary>
+        /// <param name="ctx">The context associated with this query.</param>
+        /// <param name="array">The array on which the query will operate.</param>
+        /// <param name="queryType">The query's type.</param>
         public Query(Context ctx, Array array, QueryType queryType)
         {
             _ctx = ctx;
@@ -110,6 +133,11 @@ namespace TileDB.CSharp
             _handle = QueryHandle.Create(ctx, array.Handle, (tiledb_query_type_t)queryType);
         }
 
+        /// <summary>
+        /// Creates a <see cref="Query"/> with an implicit <see cref="CSharp.QueryType"/>.
+        /// </summary>
+        /// <param name="ctx">The context associated with this query.</param>
+        /// <param name="array">The array on which the query will operate. Its <see cref="Array.QueryType"/> will be used for the query.</param>
         public Query(Context ctx, Array array)
         {
             _ctx = ctx;
@@ -117,13 +145,9 @@ namespace TileDB.CSharp
             _handle = QueryHandle.Create(ctx, array.Handle, (tiledb_query_type_t)array.QueryType());
         }
 
-        internal Query(Context ctx, Array array, QueryHandle handle)
-        {
-            _ctx = ctx;
-            _array = array;
-            _handle = handle;
-        }
-
+        /// <summary>
+        /// Disposes this <see cref="Query"/>.
+        /// </summary>
         public void Dispose()
         {
             if (_disposed) return;

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -556,9 +556,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Sets the validity buffer for a nullable attribute or dimension to an array.
+        /// Sets the validity buffer for a nullable attribute to an array.
         /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
+        /// <param name="name">The name of the attribute.</param>
         /// <param name="data">An array where the validities will be read or written.</param>
         /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
@@ -576,9 +576,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Sets the validity buffer for a nullable attribute or dimension to a <see cref="Memory{T}"/>.
+        /// Sets the validity buffer for a nullable attribute to a <see cref="Memory{T}"/>.
         /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
+        /// <param name="name">The name of the attribute.</param>
         /// <param name="data">A <see cref="Memory{T}"/> where the validities will be read or written.</param>
         /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
         /// <remarks>
@@ -595,9 +595,9 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Sets the validity buffer for a nullable attribute or dimension to an unmanaged memory buffer.
+        /// Sets the validity buffer for a nullable attribute to an unmanaged memory buffer.
         /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
+        /// <param name="name">The name of the attribute.</param>
         /// <param name="data">A pointer to the memory buffer.</param>
         /// <param name="size">The buffer's size.</param>
         /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
@@ -621,10 +621,10 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Sets the validity buffer for a nullable attribute or dimension to a <see cref="ReadOnlyMemory{T}"/>.
+        /// Sets the validity buffer for a nullable attribute to a <see cref="ReadOnlyMemory{T}"/>.
         /// Not supported for <see cref="QueryType.Read"/> queries.
         /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
+        /// <param name="name">The name of the attribute.</param>
         /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> from where the validities will be written.</param>
         /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
         /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
@@ -642,10 +642,10 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
-        /// Sets the validity buffer for a nullable attribute or dimension
+        /// Sets the validity buffer for a nullable attribute
         /// to a pinned memory buffer pointed by a <see cref="MemoryHandle"/>.
         /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
+        /// <param name="name">The name of the attribute.</param>
         /// <param name="memoryHandle">A <see cref="MemoryHandle"/> pointing to the buffer.</param>
         /// <param name="size">The buffer's size.</param>
         /// <exception cref="ArgumentException"><paramref name="size"/> is zero.</exception>

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -184,7 +184,28 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public Config Config()
         {
-            return _ctx.Config();
+            var handle = new ConfigHandle();
+            var successful = false;
+            tiledb_config_t* config = null;
+            try
+            {
+                using var ctxHandle = _ctx.Handle.Acquire();
+                using var queryHandle = _handle.Acquire();
+                _ctx.handle_error(Methods.tiledb_query_get_config(ctxHandle, queryHandle, &config));
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(config);
+                }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
+            }
+            return new Config(handle);
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -966,21 +966,21 @@ namespace TileDB.CSharp
             using var schema = _array.Schema();
             using var domain = schema.Domain();
             var buffers = new Dictionary<string, Tuple<ulong, ulong?, ulong?>>();
-            foreach (var key in _dataBufferHandles.Keys)
+            foreach ((string key, BufferHandle dataHandle) in _dataBufferHandles)
             {
                 ulong? offsetNum = null;
                 ulong? validityNum = null;
 
                 ulong typeSize = EnumUtil.DataTypeSize(GetDataType(key, schema, domain));
-                ulong dataNum = _dataBufferHandles[key].Size / typeSize;
+                ulong dataNum = dataHandle.Size / typeSize;
 
-                if (_offsetsBufferHandles.ContainsKey(key))
+                if (_offsetsBufferHandles.TryGetValue(key, out BufferHandle? offsetHandle))
                 {
-                    offsetNum = _offsetsBufferHandles[key].Size / sizeof(ulong);
+                    offsetNum = offsetHandle.Size / sizeof(ulong);
                 }
-                if (_validityBufferHandles.ContainsKey(key))
+                if (_validityBufferHandles.TryGetValue(key, out BufferHandle? validityHandle))
                 {
-                    validityNum = _validityBufferHandles[key].Size;
+                    validityNum = validityHandle.Size;
                 }
 
                 buffers.Add(key, new(dataNum, offsetNum, validityNum));
@@ -1010,11 +1010,11 @@ namespace TileDB.CSharp
 
         private static BufferHandle AddBufferHandle(Dictionary<string, BufferHandle> dict, string name, GCHandle handle, ulong size)
         {
-            if (dict.ContainsKey(name))
+            if (dict.TryGetValue(name, out var bufferHandle))
             {
-                dict[name].Dispose();
+                bufferHandle.Dispose();
             }
-            var bufferHandle = new BufferHandle(handle, size);
+            bufferHandle = new BufferHandle(handle, size);
             dict[name] = bufferHandle;
             return bufferHandle;
         }

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -1012,10 +1012,12 @@ namespace TileDB.CSharp
         {
             if (dict.TryGetValue(name, out var bufferHandle))
             {
-                bufferHandle.Dispose();
+                bufferHandle.Reset(handle, size);
             }
-            bufferHandle = new BufferHandle(handle, size);
-            dict[name] = bufferHandle;
+            else
+            {
+                dict[name] = bufferHandle = new BufferHandle(handle, size);
+            }
             return bufferHandle;
         }
 
@@ -1053,6 +1055,13 @@ namespace TileDB.CSharp
             {
                 DataHandle = handle;
                 SizePointer = (ulong*)Marshal.AllocHGlobal(sizeof(ulong));
+                Size = size;
+            }
+
+            public void Reset(GCHandle handle, ulong size)
+            {
+                DataHandle.Free();
+                DataHandle = handle;
                 Size = size;
             }
 

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -370,7 +370,7 @@ namespace TileDB.CSharp
         /// <exception cref="ArgumentException"><paramref name="data"/> is empty or <typeparamref name="T"/>
         /// does not match the excepted data type.</exception>
         /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
-        public void SetDataWriteBuffer<T>(string name, ReadOnlyMemory<T> data) where T : struct
+        public void SetDataReadOnlyBuffer<T>(string name, ReadOnlyMemory<T> data) where T : struct
         {
             if (QueryType() == CSharp.QueryType.Read)
             {
@@ -567,7 +567,7 @@ namespace TileDB.CSharp
         /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> from where the offsets will be written.</param>
         /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
         /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
-        public void SetOffsetsWriteBuffer(string name, ReadOnlyMemory<ulong> data)
+        public void SetOffsetsReadOnlyBuffer(string name, ReadOnlyMemory<ulong> data)
         {
             if (QueryType() != CSharp.QueryType.Read)
             {
@@ -653,7 +653,7 @@ namespace TileDB.CSharp
         /// <remarks>
         /// Each value corresponds to whether an element exists (1) or not (0).
         /// </remarks>
-        public void SetValidityWriteBuffer(string name, ReadOnlyMemory<byte> data)
+        public void SetValidityReadOnlyBuffer(string name, ReadOnlyMemory<byte> data)
         {
             if (QueryType() == CSharp.QueryType.Read)
             {

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -144,25 +144,14 @@ namespace TileDB.CSharp
 
         public void Dispose()
         {
-            Dispose(true);
-        }
-
-        private void Dispose(bool disposing)
-        {
             if (_disposed) return;
-            if (disposing && (!_handle.IsInvalid))
-            {
-                _handle.Dispose();
-            }
+            _handle.Dispose();
             FreeAllBufferHandles();
-
             _disposed = true;
-
         }
 
         internal QueryHandle Handle => _handle;
 
-        #region capi functions
         /// <summary>
         /// Gets a JSON string with statistics about the query.
         /// </summary>
@@ -261,13 +250,13 @@ namespace TileDB.CSharp
             var dim_datatype = _array.Schema().Domain().Type();
             if (EnumUtil.TypeToDataType(typeof(T)) != dim_datatype)
             {
-                throw new System.ArgumentException("Query.SetSubarray, datatype mismatch!");
+                throw new ArgumentException("Query.SetSubarray, datatype mismatch!");
             }
 
             var expected_size = _array.Schema().Domain().NDim() * 2;
             if (data == null || expected_size != data.Length)
             {
-                throw new System.ArgumentException("Query.SetSubarray, the length of data is not equal to num_dims*2!");
+                throw new ArgumentException("Query.SetSubarray, the length of data is not equal to num_dims*2!");
             }
 
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -290,7 +279,6 @@ namespace TileDB.CSharp
         /// <typeparam name="T"></typeparam>
         /// <param name="name"></param>
         /// <param name="data"></param>
-        /// <param name="size"></param>
         public void SetDataBuffer<T>(string name, T[] data) where T : struct
         {
             // check datatype
@@ -307,7 +295,7 @@ namespace TileDB.CSharp
 
             if (data is bool[] boolData && QueryType() == CSharp.QueryType.Write)
             {
-                SetDataBuffer<byte>(name, System.Array.ConvertAll(boolData as bool[], d => d ? (byte)1 : (byte)0));
+                SetDataBuffer(name, System.Array.ConvertAll(boolData, d => d ? (byte)1 : (byte)0));
                 return;
             }
 
@@ -326,8 +314,7 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="name"></param>
         /// <param name="data"></param>
-        /// <param name="size"></param>
-        public void SetOffsetsBuffer(string name, UInt64[] data)
+        public void SetOffsetsBuffer(string name, ulong[] data)
         {
             if (data == null || data.Length == 0)
             {
@@ -350,7 +337,6 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="name"></param>
         /// <param name="data"></param>
-        /// <param name="size"></param>
         public void SetValidityBuffer(string name, byte[] data)
         {
             if (data == null || data.Length == 0)
@@ -392,10 +378,10 @@ namespace TileDB.CSharp
             return (LayoutType)layout;
         }
 
-        ///// <summary>
-        ///// Sets the query condition to be applied on a read.
-        ///// </summary>
-        ///// <param name="condition"></param>
+        /// <summary>
+        /// Sets the query condition to be applied on a read.
+        /// </summary>
+        /// <param name="condition"></param>
         public void SetCondition(QueryCondition condition)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -494,7 +480,7 @@ namespace TileDB.CSharp
             using var handle = _handle.Acquire();
             int ret;
             _ctx.handle_error(Methods.tiledb_query_has_results(ctxHandle, handle, &ret));
-            return (ret > 0);
+            return ret > 0;
         }
 
         /// <summary>
@@ -537,7 +523,7 @@ namespace TileDB.CSharp
         /// </summary>
         [Obsolete(Obsoletions.QuerySubarrayMessage + " Use Subarray.AddRange on the query's assigned Subarray instead.", DiagnosticId = Obsoletions.QuerySubarrayDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void AddRange<T>(UInt32 index, T start, T end) where T : struct
+        public void AddRange<T>(uint index, T start, T end) where T : struct
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -594,7 +580,7 @@ namespace TileDB.CSharp
         /// </summary>
         [Obsolete(Obsoletions.QuerySubarrayMessage + " Use Subarray.AddRange on the query's assigned Subarray instead.", DiagnosticId = Obsoletions.QuerySubarrayDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public void AddRange(UInt32 index, string start, string end)
+        public void AddRange(uint index, string start, string end)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -647,11 +633,11 @@ namespace TileDB.CSharp
         /// </summary>
         [Obsolete(Obsoletions.QuerySubarrayMessage + " Use Subarray.GetRangeCount on the query's assigned Subarray instead.", DiagnosticId = Obsoletions.QuerySubarrayDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public UInt64 RangeNum(UInt32 index)
+        public ulong RangeNum(uint index)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            UInt64 range_num;
+            ulong range_num;
             _ctx.handle_error(Methods.tiledb_query_get_range_num(ctxHandle, handle, index, &range_num));
             return range_num;
         }
@@ -661,18 +647,18 @@ namespace TileDB.CSharp
         /// </summary>
         [Obsolete(Obsoletions.QuerySubarrayMessage + " Use Subarray.GetRangeCount on the query's assigned Subarray instead.", DiagnosticId = Obsoletions.QuerySubarrayDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public UInt64 RangeNumFromName(string name)
+        public ulong RangeNumFromName(string name)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            UInt64 range_num;
+            ulong range_num;
             using var ms_name = new MarshaledString(name);
             _ctx.handle_error(Methods.tiledb_query_get_range_num_from_name(ctxHandle, handle, ms_name, &range_num));
             return range_num;
         }
 
         [Obsolete(Obsoletions.QuerySubarrayMessage, DiagnosticId = Obsoletions.QuerySubarrayDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
-        private (byte[] start_bytes, byte[] end_bytes, byte[] stride_bytes) get_range<T>(UInt32 dim_idx, UInt32 range_idx) where T : struct
+        private (byte[] start_bytes, byte[] end_bytes, byte[] stride_bytes) get_range<T>(uint dim_idx, uint range_idx) where T : struct
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -693,7 +679,7 @@ namespace TileDB.CSharp
         /// </summary>
         [Obsolete(Obsoletions.QuerySubarrayMessage + " Use Subarray.GetRange on the query's assigned Subarray instead. Note that it does not return a stride.", DiagnosticId = Obsoletions.QuerySubarrayDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public System.Tuple<T, T, T> Range<T>(UInt32 dim_idx, UInt32 range_idx) where T : struct
+        public Tuple<T, T, T> Range<T>(uint dim_idx, uint range_idx) where T : struct
         {
             var (start_bytes, end_bytes, stride_bytes) = get_range<T>(dim_idx, range_idx);
             var start_span = MemoryMarshal.Cast<byte, T>(start_bytes);
@@ -704,7 +690,7 @@ namespace TileDB.CSharp
         }
 
         [Obsolete(Obsoletions.QuerySubarrayMessage, DiagnosticId = Obsoletions.QuerySubarrayDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
-        private (byte[] start_bytes, byte[] end_bytes, byte[] stride_bytes) get_range<T>(string dim_name, UInt32 range_idx) where T : struct
+        private (byte[] start_bytes, byte[] end_bytes, byte[] stride_bytes) get_range<T>(string dim_name, uint range_idx) where T : struct
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -726,7 +712,7 @@ namespace TileDB.CSharp
         /// </summary>
         [Obsolete(Obsoletions.QuerySubarrayMessage + " Use Subarray.GetRange on the query's assigned Subarray instead. Note that it does not return a stride.", DiagnosticId = Obsoletions.QuerySubarrayDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public System.Tuple<T, T, T> Range<T>(string dim_name, UInt32 range_idx) where T : struct
+        public Tuple<T, T, T> Range<T>(string dim_name, uint range_idx) where T : struct
         {
             var (start_bytes, end_bytes, stride_bytes) = get_range<T>(dim_name, range_idx);
             var start_span = MemoryMarshal.Cast<byte, T>(start_bytes);
@@ -741,12 +727,12 @@ namespace TileDB.CSharp
         /// </summary>
         [Obsolete(Obsoletions.QuerySubarrayMessage + " Use Subarray.GetStringRange on the query's assigned Subarray instead.", DiagnosticId = Obsoletions.QuerySubarrayDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public System.Tuple<string, string> RangeVar(UInt32 dim_idx, UInt32 range_idx)
+        public Tuple<string, string> RangeVar(uint dim_idx, uint range_idx)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            UInt64 start_size = 0;
-            UInt64 end_size = 0;
+            ulong start_size;
+            ulong end_size;
             _ctx.handle_error(Methods.tiledb_query_get_range_var_size(ctxHandle, handle, dim_idx, range_idx, &start_size, &end_size));
 
             byte[] startData = Enumerable.Repeat(default(byte), (int)start_size).ToArray();
@@ -776,13 +762,13 @@ namespace TileDB.CSharp
         /// </summary>
         [Obsolete(Obsoletions.QuerySubarrayMessage + " Use Subarray.GetStringRange on the query's assigned Subarray instead.", DiagnosticId = Obsoletions.QuerySubarrayDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public System.Tuple<string, string> RangeVar(string dim_name, UInt32 range_idx)
+        public Tuple<string, string> RangeVar(string dim_name, uint range_idx)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             using var ms_name = new MarshaledString(dim_name);
-            UInt64 start_size = 0;
-            UInt64 end_size = 0;
+            ulong start_size;
+            ulong end_size;
             _ctx.handle_error(Methods.tiledb_query_get_range_var_size_from_name(ctxHandle, handle, ms_name, range_idx, &start_size, &end_size));
 
             byte[] startData = Enumerable.Repeat(default(byte), (int)start_size).ToArray();
@@ -812,12 +798,12 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        private UInt64 est_result_size(string name)
+        private ulong est_result_size(string name)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             using var ms_name = new MarshaledString(name);
-            UInt64 size = 0;
+            ulong size;
             _ctx.handle_error(Methods.tiledb_query_get_est_result_size(ctxHandle, handle, ms_name, &size));
             return size;
         }
@@ -827,16 +813,16 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        private Tuple<UInt64, UInt64> est_result_size_var(string name)
+        private Tuple<ulong, ulong> est_result_size_var(string name)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             using var ms_name = new MarshaledString(name);
-            UInt64 size_off = 0;
-            UInt64 size_val = 0;
+            ulong size_off;
+            ulong size_val;
             _ctx.handle_error(Methods.tiledb_query_get_est_result_size_var(ctxHandle, handle, ms_name, &size_off, &size_val));
 
-            return new Tuple<UInt64, UInt64>(size_off, size_val);
+            return new Tuple<ulong, ulong>(size_off, size_val);
         }
 
         /// <summary>
@@ -844,16 +830,15 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        private Tuple<UInt64, UInt64> est_result_size_nullable(string name)
+        private Tuple<ulong, ulong> est_result_size_nullable(string name)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             using var ms_name = new MarshaledString(name);
-            UInt64 size_val = 0;
-            UInt64 size_validity = 0;
+            ulong size_val;
+            ulong size_validity;
             _ctx.handle_error(Methods.tiledb_query_get_est_result_size_nullable(ctxHandle, handle, ms_name, &size_val, &size_validity));
-            List<UInt64> ret = new List<ulong>();
-            return new Tuple<UInt64, UInt64>(size_val, size_validity);
+            return new Tuple<ulong, ulong>(size_val, size_validity);
         }
 
         /// <summary>
@@ -861,18 +846,18 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-        private Tuple<UInt64, UInt64, UInt64> est_result_size_var_nullable(string name)
+        private Tuple<ulong, ulong, ulong> est_result_size_var_nullable(string name)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             using var ms_name = new MarshaledString(name);
-            UInt64 size_off = 0;
-            UInt64 size_val = 0;
-            UInt64 size_validity = 0;
+            ulong size_off;
+            ulong size_val;
+            ulong size_validity;
 
             _ctx.handle_error(Methods.tiledb_query_get_est_result_size_var_nullable(ctxHandle, handle, ms_name, &size_off, &size_val, &size_validity));
 
-            return new Tuple<UInt64, UInt64, UInt64>(size_off, size_val, size_validity);
+            return new Tuple<ulong, ulong, ulong>(size_off, size_val, size_validity);
         }
 
         /// <summary>
@@ -942,16 +927,15 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="idx"></param>
         /// <returns></returns>
-        public System.Tuple<UInt64, UInt64> FragmentTimestampRange(ulong idx)
+        public Tuple<ulong, ulong> FragmentTimestampRange(ulong idx)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            ulong t1 = 0;
-            ulong t2 = 0;
+            ulong t1;
+            ulong t2;
             _ctx.handle_error(Methods.tiledb_query_get_fragment_timestamp_range(ctxHandle, handle, idx, &t1, &t2));
             return new Tuple<ulong, ulong>(t1, t2);
         }
-        #endregion
 
         private void CheckDataType<T>(DataType dataType)
         {
@@ -960,12 +944,12 @@ namespace TileDB.CSharp
                 if (!(dataType== DataType.StringAscii && (typeof(T)==typeof(byte) || typeof(T) == typeof(sbyte) || typeof(T) == typeof(string)))
                    && !(dataType == DataType.Boolean && typeof(T) == typeof(byte)))
                 {
-                    throw new System.ArgumentException("T " + typeof(T).Name + " doesnot match " + dataType.ToString());
+                    throw new ArgumentException("T " + typeof(T).Name + " doesnot match " + dataType.ToString());
                 }
             }
         }
 
-        private DataType GetDataType(string name, ArraySchema schema, Domain domain)
+        private static DataType GetDataType(string name, ArraySchema schema, Domain domain)
         {
             if (schema.HasAttribute(name))
             {
@@ -986,7 +970,6 @@ namespace TileDB.CSharp
             throw new ArgumentException("No datatype for " + name);
         }
 
-        #region buffers
         /// <summary>
         /// Returns the number of elements read into result buffers from a read query.
         ///
@@ -1090,6 +1073,5 @@ namespace TileDB.CSharp
             }
             _validityBufferHandles[name] = new BufferHandle(handle, size);
         }
-        #endregion
     }
 }

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -1196,7 +1196,7 @@ namespace TileDB.CSharp
                     return new ResultSize(offsetsSize, dataSize, validitySize);
                 case (true, false):
                     (offsetsSize, dataSize) = GetEstimatedResultSizeVar(name);
-                    return new ResultSize(offsetsSize, dataSize);
+                    return new ResultSize(dataSize, offsetsSize);
                 case (false, true):
                     (dataSize, validitySize) = GetEstimatedResultSizeNullable(name);
                     return new ResultSize(dataSize, null, validitySize);

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -1027,19 +1027,17 @@ namespace TileDB.CSharp
         /// </summary>
         private void FreeAllBufferHandles()
         {
-            foreach (var bh in _dataBufferHandles)
-            {
-                bh.Value.Dispose();
-            }
+            DisposeValuesAndClear(_dataBufferHandles);
+            DisposeValuesAndClear(_offsetsBufferHandles);
+            DisposeValuesAndClear(_validityBufferHandles);
 
-            foreach (var bh in _offsetsBufferHandles)
+            static void DisposeValuesAndClear(Dictionary<string, BufferHandle> handles)
             {
-                bh.Value.Dispose();
-            }
-
-            foreach (var bh in _validityBufferHandles)
-            {
-                bh.Value.Dispose();
+                foreach (var bh in handles)
+                {
+                    bh.Value.Dispose();
+                }
+                handles.Clear();
             }
         }
 

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -313,6 +313,38 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="name">The name of the attribute or the dimension.</param>
         /// <param name="data">A pointer to the memory buffer.</param>
+        /// <param name="size">The buffer's size <em>in <typeparamref name="T"/> values</em>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="size"/> is zero or <typeparamref name="T"/>
+        /// does not match the excepted data type.</exception>
+        public void SetDataBuffer<T>(string name, T* data, ulong size) where T : struct
+        {
+            if (data is null)
+            {
+                ThrowHelpers.ThrowArgumentNullException(nameof(data));
+            }
+
+            if (size == 0)
+            {
+                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(size));
+            }
+
+            // check datatype
+            using (var schema = _array.Schema())
+            using (var domain = schema.Domain())
+            {
+                CheckDataType<T>(GetDataType(name, schema, domain));
+            }
+
+            UnsafeSetDataBuffer(name, new MemoryHandle(data), size * (ulong)sizeof(T));
+        }
+
+        /// <summary>
+        /// Sets the data buffer for an attribute or dimension to an
+        /// unmanaged memory buffer without performing type validation.
+        /// </summary>
+        /// <param name="name">The name of the attribute or the dimension.</param>
+        /// <param name="data">A pointer to the memory buffer.</param>
         /// <param name="byteSize">The buffer's size <em>in bytes</em>.</param>
         /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
         /// <exception cref="ArgumentException"><paramref name="byteSize"/> is zero.</exception>

--- a/sources/TileDB.CSharp/ThrowHelpers.cs
+++ b/sources/TileDB.CSharp/ThrowHelpers.cs
@@ -38,5 +38,17 @@ namespace TileDB.CSharp
         [DoesNotReturn]
         public static void ThrowManagedType() =>
             throw new NotSupportedException("Types with managed references are not supported.");
+
+        [DoesNotReturn]
+        public static void ThrowOperationNotAllowedOnReadQueries() =>
+            throw new NotSupportedException("The operation is not allowed on read queries.");
+
+        [DoesNotReturn]
+        public static void ThrowBufferCannotBeEmpty(string paramName) =>
+            throw new ArgumentException("Buffer cannot be empty.", paramName);
+
+        [DoesNotReturn]
+        public static void ThrowArgumentNullException(string paramName) =>
+            throw new ArgumentNullException(paramName);
     }
 }

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -460,7 +460,7 @@ namespace TileDB.CSharp.Test
                 query_write.SetDataBuffer("a1", a1_data_ptr, (ulong)a1_data.Length);
                 query_write.SetValidityBuffer("a1", a1_validity);
 
-                query_write.SetDataBuffer("a2", (void*)a2_data_ptr, (ulong)a2_data.Length * sizeof(int));
+                query_write.UnsafeSetDataBuffer("a2", (void*)a2_data_ptr, (ulong)a2_data.Length * sizeof(int));
                 query_write.SetOffsetsBuffer("a2", a2_off_ptr, (ulong)a2_off.Length);
                 query_write.SetValidityBuffer("a2", a2_validity_ptr, (ulong)a2_validity.Length);
 
@@ -503,15 +503,15 @@ namespace TileDB.CSharp.Test
                 query_read.SetSubarray(subarray);
 
                 query_read.UnsafeSetDataBuffer("a1", a1_data_read.AsMemory().Pin(), (ulong)a1_data_read.Length * sizeof(int));
-                query_read.UnsafeSetValidityBuffer("a1", a1_validity_read.AsMemory().Pin(), (ulong)a1_validity_read.Length);
+                query_read.SetValidityBuffer("a1", a1_validity_read);
 
                 query_read.UnsafeSetDataBuffer("a2", a2_data_read.AsMemory().Pin(), (ulong)a2_data_read.Length * sizeof(int));
-                query_read.UnsafeSetOffsetsBuffer("a2", a2_off_read.AsMemory().Pin(), (ulong)a2_off_read.Length);
-                query_read.UnsafeSetValidityBuffer("a2", a2_validity_read.AsMemory().Pin(), (ulong)a2_validity_read.Length);
+                query_read.SetOffsetsBuffer("a2", a2_off_read);
+                query_read.SetValidityBuffer("a2", a2_validity_read);
 
                 query_read.UnsafeSetDataBuffer("a3", a3_data_read.AsMemory().Pin(), (ulong)a3_data_read.Length * sizeof(byte));
-                query_read.UnsafeSetOffsetsBuffer("a3", a3_off_read.AsMemory().Pin(), (ulong)a3_off_read.Length);
-                query_read.UnsafeSetValidityBuffer("a3", a3_validity_read.AsMemory().Pin(), (ulong)a3_validity_read.Length);
+                query_read.SetOffsetsBuffer("a3", a3_off_read);
+                query_read.SetValidityBuffer("a3", a3_validity_read);
 
                 query_read.Submit();
                 var status_read = query_read.Status();

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -58,13 +58,13 @@ namespace TileDB.CSharp.Test
                 Assert.AreEqual((1, 2), subarray.GetRange<int>(1, 0));
                 Assert.ThrowsException<InvalidOperationException>(() => subarray.GetRange<long>(1, 0));
                 queryWrite.SetSubarray(subarray);
-                queryWrite.SetDataWriteBuffer<int>("a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8 }.AsMemory());
+                queryWrite.SetDataReadOnlyBuffer<int>("a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8 }.AsMemory());
             }
             else // Sparse
             {
-                queryWrite.SetDataWriteBuffer<int>("rows", new[] { 1, 2, 2, 3, 4, 4 }.AsMemory());
-                queryWrite.SetDataWriteBuffer<int>("cols", new[] { 1, 1, 4, 1, 1, 4 }.AsMemory());
-                queryWrite.SetDataWriteBuffer<int>("a1", new[] { 1, 2, 3, 4, 5, 6 }.AsMemory());
+                queryWrite.SetDataReadOnlyBuffer<int>("rows", new[] { 1, 2, 2, 3, 4, 4 }.AsMemory());
+                queryWrite.SetDataReadOnlyBuffer<int>("cols", new[] { 1, 1, 4, 1, 1, 4 }.AsMemory());
+                queryWrite.SetDataReadOnlyBuffer<int>("a1", new[] { 1, 2, 3, 4, 5, 6 }.AsMemory());
             }
             queryWrite.Submit();
             Assert.AreEqual(QueryStatus.Completed, queryWrite.Status());

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -444,6 +444,7 @@ namespace TileDB.CSharp.Test
             byte[] a2_validity = new byte[4] { 0, 1, 1, 0 };
             byte[] a3_validity = new byte[4] { 1, 0, 0, 1 };
 
+            fixed (int* a1_data_ptr = &a1_data[0])
             fixed (int* a2_data_ptr = &a2_data[0])
             fixed (ulong* a2_off_ptr = &a2_off[0])
             fixed (byte* a2_validity_ptr = &a2_validity[0])
@@ -456,10 +457,10 @@ namespace TileDB.CSharp.Test
                 using var query_write = new Query(context, array_write);
                 query_write.SetLayout(LayoutType.RowMajor);
 
-                query_write.SetDataBuffer("a1", a1_data);
+                query_write.SetDataBuffer("a1", a1_data_ptr, (ulong)a1_data.Length);
                 query_write.SetValidityBuffer("a1", a1_validity);
 
-                query_write.SetDataBuffer("a2", a2_data_ptr, (ulong)a2_data.Length * sizeof(int));
+                query_write.SetDataBuffer("a2", (void*)a2_data_ptr, (ulong)a2_data.Length * sizeof(int));
                 query_write.SetOffsetsBuffer("a2", a2_off_ptr, (ulong)a2_off.Length);
                 query_write.SetValidityBuffer("a2", a2_validity_ptr, (ulong)a2_validity.Length);
 

--- a/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
+++ b/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>TileDB.CSharp.Test</RootNamespace>
     <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Apart from trivial clean-ups and fixes, the most important change in this PR is a refactoring of how the query buffers are managed.

Instead of `GCHandle` we use the newer `MemoryHandle` type which is more flexible and supports arbitrary pointers that might or might not be pinned. On top of that I added overloads to `Set***Buffer` that accept buffers from `Memory<T>` (a safe type that can repserent buffers like an array or part of an array). These overloads are essential for enabling user code to optimize performance and memory efficiency. I also changed the order of setting a buffer and unpinning the previous one to be more resilient to errors the Core might report.

[SC-24176](https://app.shortcut.com/tiledb-inc/story/24176/allow-query-buffers-from-more-sources)