### PR TITLE
Make `VFS.VisitChildren` generic.

### DIFF
--- a/sources/TileDB.CSharp/VFS.cs
+++ b/sources/TileDB.CSharp/VFS.cs
@@ -51,7 +51,28 @@ namespace TileDB.CSharp
         /// </summary>
         public Config Config()
         {
-            return ctx_.Config();
+            var handle = new ConfigHandle();
+            tiledb_config_t* config = null;
+            var successful = false;
+            try
+            {
+                using var ctxHandle = ctx_.Handle.Acquire();
+                using var vfsHandle = handle_.Acquire();
+                ctx_.handle_error(Methods.tiledb_vfs_get_config(ctxHandle, vfsHandle, &config));
+                successful = true;
+            }
+            finally
+            {
+                if (successful)
+                {
+                    handle.InitHandle(config);
+                }
+                else
+                {
+                    handle.SetHandleAsInvalid();
+                }
+            }
+            return new Config(handle);
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/VFS.cs
+++ b/sources/TileDB.CSharp/VFS.cs
@@ -323,7 +323,7 @@ namespace TileDB.CSharp
             var list = new List<string>();
             VisitChildren(uri, static (uri, list) =>
             {
-                ((List<string>)list!).Add(uri);
+                list.Add(uri);
                 return true;
             }, list);
             return list;
@@ -336,16 +336,27 @@ namespace TileDB.CSharp
         /// <param name="callback">A callback delegate that will be called with the URI of each child and
         /// <paramref name="callbackArg"/>, and returns whether to continue visiting.</param>
         /// <param name="callbackArg">An argument that will be passed to <paramref name="callback"/>.</param>
+        /// <typeparam name="T">The type of <paramref name="callbackArg"/>.</typeparam>
         /// <remarks>
         /// This function does not visit the children recursively; only the
         /// top-level children of <paramref name="uri"/> will be visited.
         /// </remarks>
-        public void VisitChildren(string uri, Func<string, object?, bool> callback, object? callbackArg)
+        public void VisitChildren<T>(string uri, Func<string, T, bool> callback, T callbackArg)
         {
+            ValueTuple<Func<string, T, bool>, T> data = (callback, callbackArg);
+            var callbackData = new VisitCallbackData()
+            {
+                Callback = static (uri, arg) =>
+                {
+                    var dataPtr = (ValueTuple<Func<string, T, bool>, T>*)arg;
+                    return dataPtr->Item1(uri, dataPtr->Item2);
+                },
+                CallbackArgument = (IntPtr)(&data)
+            };
+
             using var ctxHandle = ctx_.Handle.Acquire();
             using var handle = handle_.Acquire();
             using var ms_uri = new MarshaledString(uri);
-            var callbackData = new VisitCallbackData() { Callback = callback, CallbackArgument = callbackArg };
             // Taking a pointer to callbackData is safe; the callback will be invoked only
             // during the call to tiledb_vfs_ls. Contrast this with tiledb_query_submit_async where we
             // had to use a GCHandle because the callback might be invoked after we return from it.
@@ -356,9 +367,9 @@ namespace TileDB.CSharp
 
         private struct VisitCallbackData
         {
-            public Func<string, object?, bool> Callback;
+            public Func<string, IntPtr, bool> Callback;
 
-            public object? CallbackArgument;
+            public IntPtr CallbackArgument;
 
             // If the callback threw an exception we will save it here and rethrow it once we leave native code.
             // The reason we do this is that throwing exceptions in P/Invoke is not portable (works only on Windows

--- a/tests/TileDB.CSharp.Test/VFSTest.cs
+++ b/tests/TileDB.CSharp.Test/VFSTest.cs
@@ -97,15 +97,16 @@ namespace TileDB.CSharp.Test
 
             int i = 0;
 
-            vfs.VisitChildren(dir, (uri, _) =>
+            vfs.VisitChildren(dir, (uri, arg) =>
             {
                 string path = new Uri(uri).LocalPath;
                 Assert.IsTrue(System.IO.File.Exists(path));
                 Assert.AreEqual((string)dir, Path.GetDirectoryName(path));
+                Assert.AreEqual(555, arg);
 
                 i++;
                 return i != 2;
-            }, null);
+            }, 555);
 
             Assert.AreEqual(2, i);
         }
@@ -130,7 +131,7 @@ namespace TileDB.CSharp.Test
                 {
                     i++;
                     throw new Exception(ExceptionKey);
-                }, null);
+                }, 0);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
I thought we needed a not-yet-released C# feature to make it generic, turns out we didn't.

The way it works is the following: the Core used to call `VisitCallback` which took a pointer to a structure containing the callback the user gave and an object argument to it. Now we get an extra level of indirection and `VisitCallback` calls another callback which is generic and calls the user callbacks. The reason for this is that `VisitCallback` itself cannot be made generic.