### PR TITLE
Expose the `tiledb_object_***` APIs.

### DIFF
--- a/sources/TileDB.CSharp/Context.cs
+++ b/sources/TileDB.CSharp/Context.cs
@@ -1,4 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Runtime.InteropServices;
 using System.Text;
 using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
@@ -172,6 +177,133 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
+        /// Returns the TileDB object type for a given resource path.
+        /// </summary>
+        /// <param name="uri">The path to check.</param>
+        /// <returns>
+        /// The type of the object in <paramref name="uri"/> or
+        /// <see cref="ObjectType.Invalid"/> if it is not a TileDB object.</returns>
+        public ObjectType GetObjectType(string uri)
+        {
+            using var handle = _handle.Acquire();
+            using var ms_uri = new MarshaledString(uri);
+            tiledb_object_t type;
+            handle_error(Methods.tiledb_object_type(handle, ms_uri, &type));
+            return (ObjectType)type;
+        }
+
+        /// <summary>
+        /// Deletes a TileDB resource (group or array).
+        /// </summary>
+        /// <param name="uri">The resource's path.</param>
+        public void RemoveObject(string uri)
+        {
+            using var handle = _handle.Acquire();
+            using var ms_uri = new MarshaledString(uri);
+            handle_error(Methods.tiledb_object_remove(handle, ms_uri));
+        }
+
+        /// <summary>
+        /// Moves a TileDB resource (group or array).
+        /// </summary>
+        /// <param name="oldUri">The resource's old directory.</param>
+        /// <param name="newUri">The resource's new directory.</param>
+        public void MoveObject(string oldUri, string newUri)
+        {
+            using var handle = _handle.Acquire();
+            using var ms_oldUri = new MarshaledString(oldUri);
+            using var ms_newUri = new MarshaledString(newUri);
+            handle_error(Methods.tiledb_object_move(handle, ms_oldUri, ms_newUri));
+        }
+
+        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        private static int VisitCallback(sbyte* uriPtr, tiledb_object_t objectType, void* arg)
+        {
+            VisitCallbackData* data = (VisitCallbackData*)arg;
+            Debug.Assert(data->Exception is null);
+            bool shouldContinue;
+            try
+            {
+                string uri = MarshaledStringOut.GetStringFromNullTerminated(uriPtr);
+                shouldContinue = data->Invoke(uri, (ObjectType)objectType);
+            }
+            catch (Exception e)
+            {
+                data->Exception = ExceptionDispatchInfo.Capture(e);
+                shouldContinue = false;
+            }
+            return shouldContinue ? 1 : 0;
+        }
+
+        /// <summary>
+        /// Visits the TileDB objects contained in <paramref name="uri"/>.
+        /// </summary>
+        /// <typeparam name="T">The type of <paramref name="callbackArg"/>.</typeparam>
+        /// <param name="uri">The URI to check.</param>
+        /// <param name="walkOrder">The order to recursively visit the objects.
+        /// Setting this parameter to <see langword="null"/> will visit only
+        /// the top-level objects of <paramref name="uri"/>.</param>
+        /// <param name="callback">A callback that gets called for each TileDB object that got found.
+        /// It accepts its URI, its <see cref="ObjectType"/> and <paramref name="callbackArg"/>.</param>
+        /// <param name="callbackArg">An argument that will be passed to <paramref name="callback"/>.</param>
+        /// <remarks>
+        /// This method ignores any file system object that is not TileDB-related.
+        /// </remarks>
+        /// <seealso cref="GetChildObjects"/>
+        public void VisitChildObjects<T>(string uri, WalkOrderType? walkOrder, Func<string, ObjectType, T, bool> callback, T callbackArg)
+        {
+            // See VFS.VisitChildren for comments on how it works.
+            ValueTuple<Func<string, ObjectType, T, bool>, T> genericCallbackData = (callback, callbackArg);
+            var callbackData = new VisitCallbackData()
+            {
+                Callback = static (uri, objectType, arg) =>
+                {
+                    var dataPtr = (ValueTuple<Func<string, ObjectType, T, bool>, T>*)arg;
+                    return dataPtr->Item1(uri, objectType, dataPtr->Item2);
+                },
+                CallbackArgument = (IntPtr)(&genericCallbackData)
+            };
+
+            using var handle = _handle.Acquire();
+            using var ms_uri = new MarshaledString(uri);
+            switch (walkOrder)
+            {
+                case WalkOrderType order:
+                    handle_error(Methods.tiledb_object_walk(handle, ms_uri, (tiledb_walk_order_t)order, &VisitCallback, &callbackData));
+                    break;
+                case null:
+                    handle_error(Methods.tiledb_object_ls(handle, ms_uri, &VisitCallback, &callbackData));
+                    break;
+            }
+            callbackData.Exception?.Throw();
+        }
+
+        /// <summary>
+        /// Returns the TileDB objects contained in <paramref name="uri"/>.
+        /// </summary>
+        /// <param name="uri">The URI to check.</param>
+        /// <param name="walkOrder">The order to recursively visit the objects.
+        /// Setting this parameter to <see langword="null"/> will visit only
+        /// the top-level objects of <paramref name="uri"/>.</param>
+        /// <remarks>
+        /// This method ignores any file system object that is not TileDB-related.
+        /// </remarks>
+        /// <returns>
+        /// A <see cref="List{T}"/> with the URIs of each TileDB object in <paramref name="uri"/>,
+        /// along with its <see cref="ObjectType"/>.
+        /// </returns>
+        public List<(string Uri, ObjectType ObjectType)> GetChildObjects(string uri, WalkOrderType? walkOrder)
+        {
+            var list = new List<(string Uri, ObjectType ObjectType)>();
+            VisitChildObjects(uri, walkOrder, static (uri, objectType, list) =>
+            {
+                list.Add((uri, objectType));
+                return true;
+            }, list);
+            return list;
+        }
+
+        /// <summary>
         /// Deprecated.
         /// </summary>
         [Obsolete(Obsoletions.ContextErrorHappenedMessage, DiagnosticId = Obsoletions.ContextErrorHappenedDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
@@ -213,6 +345,17 @@ namespace TileDB.CSharp
             Methods.tiledb_error_free(&p_tiledb_error);
 
             throw new TileDBException(message) { StatusCode = (int)status };
+        }
+
+        private struct VisitCallbackData
+        {
+            public Func<string, ObjectType, IntPtr, bool> Callback;
+
+            public IntPtr CallbackArgument;
+
+            public ExceptionDispatchInfo? Exception;
+
+            public bool Invoke(string uri, ObjectType objectType) => Callback(uri, objectType, CallbackArgument);
         }
     }
 }

--- a/tests/TileDB.CSharp.Test/TemporaryDirectory.cs
+++ b/tests/TileDB.CSharp.Test/TemporaryDirectory.cs
@@ -21,7 +21,7 @@ namespace TileDB.CSharp.Test
 
         public static implicit operator string(TemporaryDirectory directory) => directory._path;
 
-        private static void DeleteDirectory(string directory)
+        public static void DeleteDirectory(string directory)
         {
             try
             {


### PR DESCRIPTION
TODO: Add tests.

[SC-24856](https://app.shortcut.com/tiledb-inc/story/24586/add-high-level-api-for-tiledb-object-type-and-related-functions)