### PR TITLE
Add high-performance alternatives to `Query.ResultBufferElements`.

### DIFF
--- a/examples/TileDB.CSharp.Example/ExampleIncompleteQueryStringDimensions.cs
+++ b/examples/TileDB.CSharp.Example/ExampleIncompleteQueryStringDimensions.cs
@@ -86,13 +86,12 @@ namespace TileDB.CSharp.Examples
                 do
                 {
                     queryRead.Submit();
-                    var resultBufferElements = queryRead.ResultBufferElements();
 
-                    var rowDataElements = (int)resultBufferElements["rows"].Item1;
-                    var rowOffsetElements = (int)resultBufferElements["rows"].Item2!;
+                    var rowDataElements = (int)queryRead.GetResultDataElements("rows");
+                    var rowOffsetElements = (int)queryRead.GetResultOffsets("rows");
 
-                    var colDataElements = (int)resultBufferElements["cols"].Item1;
-                    var colOffsetElements = (int)resultBufferElements["cols"].Item2!;
+                    var colDataElements = (int)queryRead.GetResultDataElements("cols");
+                    var colOffsetElements = (int)queryRead.GetResultOffsets("cols");
 
                     // Copy rows data into string buffer
                     List<string> rowsData = new();

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -1308,16 +1308,34 @@ namespace TileDB.CSharp
 
         /// <summary>
         /// Returns the number of elements read into result buffers from a read query.
-        ///
-        /// Dictionary key: Name of buffer used in call to SetDataBuffer, SetOffsetBuffer, or SetValidityBuffer
-        /// Tuple Item1: Number of elements read by the query
-        /// Tuple Item2: Number of offset elements read by the query
-        /// Tuple Item3: Number of validity bytes read by the query
-        ///
-        /// If the buffer is not variable-sized, Tuple.Item2 will be set to null
-        /// If the buffer is not nullable, Tuple.Item3 will be set to null
+        /// <list type="table">
+        /// <item>
+        /// <term>Dictionary key</term>
+        /// <description>Name of buffer used in call to <see cref="SetDataBuffer{T}(string, T[])"/>,
+        /// <see cref="SetOffsetsBuffer(string, ulong[])"/>, or <see cref="SetValidityBuffer(string, byte[])"/>.</description>
+        /// </item>
+        /// <item>
+        /// <term>Tuple <see cref="Tuple{T1, T2, T3}.Item1"/></term>
+        /// <description>Number of elements read by the query</description>
+        /// </item>
+        /// <item>
+        /// <term>Tuple <see cref="Tuple{T1, T2, T3}.Item2"/></term>
+        /// <description>Number of offset elements read by the query
+        /// or <see langword="null"/> if the buffer is not variable-sized.</description>
+        /// </item>
+        /// <item>
+        /// <term>Tuple <see cref="Tuple{T1, T2, T3}.Item3"/></term>
+        /// <description>Number of validity bytes read by the query
+        /// or <see langword="null"/> if the buffer is not nullable.</description>
+        /// </item>
+        /// </list>
         /// </summary>
         /// <returns>Dictionary mapping buffer name to number of results</returns>
+        /// <remarks>
+        /// This method exhibits poor performance characteristics. Consider using
+        /// <see cref="GetResultDataElements"/>, <see cref="GetResultDataBytes"/>,
+        /// <see cref="GetResultOffsets"/> and <see cref="GetResultValidities"/> instead.
+        /// </remarks>
         public Dictionary<string, Tuple<ulong, ulong?, ulong?>> ResultBufferElements()
         {
             using var schema = _array.Schema();

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -326,7 +326,7 @@ namespace TileDB.CSharp
                 ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(data));
             }
 
-            UnsafeSetDataBuffer(name, data.Pin(), (ulong)data.Length * (ulong)sizeof(T));
+            UnsafeSetDataBuffer(name, data.Pin(), (ulong)data.Length * (ulong)sizeof(T), sizeof(T));
         }
 
         /// <summary>
@@ -357,7 +357,7 @@ namespace TileDB.CSharp
                 CheckDataType<T>(GetDataType(name, schema, domain));
             }
 
-            UnsafeSetDataBuffer(name, new MemoryHandle(data), size * (ulong)sizeof(T));
+            UnsafeSetDataBuffer(name, new MemoryHandle(data), size * (ulong)sizeof(T), sizeof(T));
         }
 
         /// <summary>
@@ -423,13 +423,16 @@ namespace TileDB.CSharp
         /// <item>This method call throws an exception.</item>
         /// </list></para>
         /// </remarks>
-        public void UnsafeSetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize)
+        public void UnsafeSetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize) =>
+            UnsafeSetDataBuffer(name, memoryHandle, byteSize, 0);
+
+        private void UnsafeSetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize, int elementSize)
         {
             BufferHandle? handle = null;
             bool successful = false;
             try
             {
-                handle = new BufferHandle(ref memoryHandle, byteSize);
+                handle = new BufferHandle(ref memoryHandle, byteSize, elementSize);
 
                 SetDataBufferCore(name, handle.DataPointer, handle.SizePointer);
 
@@ -534,7 +537,7 @@ namespace TileDB.CSharp
             bool successful = false;
             try
             {
-                handle = new BufferHandle(ref memoryHandle, size * sizeof(ulong));
+                handle = new BufferHandle(ref memoryHandle, size * sizeof(ulong), sizeof(ulong));
 
                 SetOffsetsBufferCore(name, (ulong*)handle.DataPointer, handle.SizePointer);
 
@@ -688,7 +691,7 @@ namespace TileDB.CSharp
             bool successful = false;
             try
             {
-                handle = new BufferHandle(ref memoryHandle, size * sizeof(byte));
+                handle = new BufferHandle(ref memoryHandle, size * sizeof(byte), sizeof(byte));
 
                 SetValidityBufferCore(name, (byte*)handle.DataPointer, handle.SizePointer);
 
@@ -1326,15 +1329,15 @@ namespace TileDB.CSharp
                 ulong? validityNum = null;
 
                 ulong typeSize = EnumUtil.DataTypeSize(GetDataType(key, schema, domain));
-                ulong dataNum = dataHandle.Size / typeSize;
+                ulong dataNum = dataHandle.SizeInBytes / typeSize;
 
                 if (_offsetsBufferHandles.TryGetValue(key, out BufferHandle? offsetHandle))
                 {
-                    offsetNum = offsetHandle.Size / sizeof(ulong);
+                    offsetNum = offsetHandle.SizeInBytes / sizeof(ulong);
                 }
                 if (_validityBufferHandles.TryGetValue(key, out BufferHandle? validityHandle))
                 {
-                    validityNum = validityHandle.Size;
+                    validityNum = validityHandle.SizeInBytes;
                 }
 
                 buffers.Add(key, new(dataNum, offsetNum, validityNum));
@@ -1342,6 +1345,44 @@ namespace TileDB.CSharp
 
             return buffers;
         }
+
+        /// <summary>
+        /// Returns the number of elements read into the data buffer of an attribute or dimension.
+        /// </summary>
+        /// <param name="name">The name of the attribute or dimension.</param>
+        /// <exception cref="KeyNotFoundException">No data buffer has
+        /// been registered with <paramref name="name"/>.</exception>
+        /// <exception cref="InvalidOperationException">The data buffer had been
+        /// set with an overload of <c>UnsafeSetDataBuffer</c>.</exception>
+        public ulong GetResultDataElements(string name) => _dataBufferHandles[name].SizeInElements;
+
+        /// <summary>
+        /// Returns the number of bytes read into the data buffer of an attribute or dimension.
+        /// </summary>
+        /// <param name="name">The name of the attribute or dimension.</param>
+        /// <returns>
+        /// The number of elements read, or the number of bytes read if the data buffer had been
+        /// assigned with an overload of the <c>Query.UnsafeSetDataBuffer</c> method.
+        /// </returns>
+        /// <exception cref="KeyNotFoundException">No data buffer has
+        /// been registered with <paramref name="name"/>.</exception>
+        public ulong GetResultDataBytes(string name) => _dataBufferHandles[name].SizeInBytes;
+
+        /// <summary>
+        /// Returns the number of offsets read into the offsets buffer of a variable-sized attribute or dimension.
+        /// </summary>
+        /// <param name="name">The name of the attribute or dimension.</param>
+        /// <exception cref="KeyNotFoundException">No offsets buffer has
+        /// been registered with <paramref name="name"/>.</exception>
+        public ulong GetResultOffsets(string name) => _offsetsBufferHandles[name].SizeInElements;
+
+        /// <summary>
+        /// Returns the number of validity bytes read into the validity buffer of a nullable attribute.
+        /// </summary>
+        /// <param name="name">The name of the attribute or dimension.</param>
+        /// <exception cref="KeyNotFoundException">No validity buffer has
+        /// been registered with <paramref name="name"/>.</exception>
+        public ulong GetResultValidities(string name) => _validityBufferHandles[name].SizeInElements;
 
         /// <summary>
         /// Free all handles.
@@ -1373,29 +1414,33 @@ namespace TileDB.CSharp
 
         private sealed class BufferHandle : IDisposable
         {
+            private readonly int _elementSize;
+
             private MemoryHandle DataHandle;
+
             public ulong* SizePointer { get; private set; }
 
             public void* DataPointer => DataHandle.Pointer;
 
-            public ulong Size
+            public ulong SizeInBytes => *SizePointer;
+
+            public ulong SizeInElements
             {
                 get
                 {
-                    Debug.Assert(SizePointer is not null);
-                    return *SizePointer;
-                }
-                set
-                {
-                    Debug.Assert(SizePointer is not null);
-                    *SizePointer = value;
+                    if (_elementSize == 0)
+                    {
+                        ThrowHelpers.ThrowBufferUnsafelySet();
+                    }
+                    return *SizePointer / (ulong)_elementSize;
                 }
             }
 
-            public BufferHandle(ref MemoryHandle handle, ulong size)
+            public BufferHandle(ref MemoryHandle handle, ulong size, int elementSize)
             {
                 DataHandle = handle;
                 handle = default;
+                _elementSize = elementSize;
                 bool successful = false;
                 try
                 {
@@ -1409,7 +1454,7 @@ namespace TileDB.CSharp
                         DataHandle.Dispose();
                     }
                 }
-                Size = size;
+                *SizePointer = size;
             }
 
             public void Dispose()

--- a/sources/TileDB.CSharp/ThrowHelpers.cs
+++ b/sources/TileDB.CSharp/ThrowHelpers.cs
@@ -12,16 +12,16 @@ namespace TileDB.CSharp
 
         [DoesNotReturn]
         public static void ThrowTypeNotSupported() =>
-            throw new NotSupportedException("Type is not supported");
+            throw new NotSupportedException("Type is not supported.");
 
         // We don't have to specify the type in the type argument, it can be seen from the stacktrace.
         [DoesNotReturn]
         public static void ThrowTypeMismatch(DataType type) =>
-            throw new InvalidOperationException($"Type is not compatible with data type {type}");
+            throw new InvalidOperationException($"Type is not compatible with data type {type}.");
 
         [DoesNotReturn]
         public static void ThrowStringTypeMismatch(DataType type) =>
-            throw new InvalidOperationException($"Cannot encode data type {type} into strings");
+            throw new InvalidOperationException($"Cannot encode data type {type} into strings.");
 
         [DoesNotReturn]
         public static void ThrowTooBigSize(ulong size, [CallerArgumentExpression(nameof(size))] string? paramName = null) =>
@@ -50,5 +50,9 @@ namespace TileDB.CSharp
         [DoesNotReturn]
         public static void ThrowArgumentNullException(string paramName) =>
             throw new ArgumentNullException(paramName);
+
+        [DoesNotReturn]
+        public static void ThrowBufferUnsafelySet() =>
+            throw new InvalidOperationException("Cannot get the number of elements read into a buffer set with the 'Query.UnsafeSetDataBuffer' method.");
     }
 }

--- a/tests/TileDB.CSharp.Test/DeletesTest.cs
+++ b/tests/TileDB.CSharp.Test/DeletesTest.cs
@@ -72,6 +72,7 @@ namespace TileDB.CSharp.Test
 
             array.Open(QueryType.Read);
             Assert.AreEqual(12UL, readQuery.ResultBufferElements()["a1"].Item1);
+            Assert.AreEqual(12UL, readQuery.GetResultDataElements("a1"));
             array.Close();
             TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
         }
@@ -142,6 +143,7 @@ namespace TileDB.CSharp.Test
 
             array.Open(QueryType.Read);
             Assert.AreEqual(15UL, readQuery.ResultBufferElements()["a1"].Item1);
+            Assert.AreEqual(15UL, readQuery.GetResultDataElements("a1"));
             array.Close();
             var expectedData = new Dictionary<string, System.Array>()
             {
@@ -259,6 +261,7 @@ namespace TileDB.CSharp.Test
             using (var readQuery = TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx)) {
                 array.Open(QueryType.Read);
                 Assert.AreEqual(15UL, readQuery.ResultBufferElements()["a1"].Item1);
+                Assert.AreEqual(15UL, readQuery.GetResultDataElements("a1"));
                 array.Close();
             }
             var expectedData = new Dictionary<string, System.Array>()
@@ -296,6 +299,7 @@ namespace TileDB.CSharp.Test
                 array.Open(QueryType.Read);
                 // For duplicates we allocate for 17 values including deleted cell, but we only retrieve 16 valid results
                 Assert.AreEqual(16UL, readQuery.ResultBufferElements()["a1"].Item1);
+                Assert.AreEqual(16UL, readQuery.GetResultDataElements("a1"));
                 array.Close();
             }
             TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
@@ -838,7 +842,9 @@ namespace TileDB.CSharp.Test
                 var bufferElements = readQuery.ResultBufferElements();
                 array.Close();
                 var elementCount = (int)bufferElements["a1"].Item1;
+                Assert.AreEqual((ulong)elementCount, readQuery.GetResultDataElements("a1"));
                 var offsetCount = (int)bufferElements["a1"].Item2!;
+                Assert.AreEqual((ulong)offsetCount, readQuery.GetResultOffsets("a1"));
                 var a1Data = new List<string>();
                 for (int i = 0; i < offsetCount; i++)
                 {
@@ -869,7 +875,9 @@ namespace TileDB.CSharp.Test
                 array.Close();
 
                 var elementCount = (int)bufferElements["a1"].Item1;
+                Assert.AreEqual((ulong)elementCount, readQuery.GetResultDataElements("a1"));
                 var offsetCount = (int)bufferElements["a1"].Item2!;
+                Assert.AreEqual((ulong)offsetCount, readQuery.GetResultOffsets("a1"));
                 var a1Data = new List<string>();
                 for (int i = 0; i < offsetCount; i++)
                 {

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -517,6 +517,18 @@ namespace TileDB.CSharp.Test
                 var status_read = query_read.Status();
 
                 Assert.AreEqual(QueryStatus.Completed, status_read);
+                Assert.AreEqual((ulong)a1_data_read.Length * sizeof(int), query_read.GetResultDataBytes("a1"));
+                Assert.AreEqual((ulong)a2_data_read.Length * sizeof(int), query_read.GetResultDataBytes("a2"));
+                Assert.AreEqual((ulong)a3_data_read.Length * sizeof(byte), query_read.GetResultDataBytes("a3"));
+                Assert.ThrowsException<InvalidOperationException>(() => query_read.GetResultDataElements("a1"));
+                Assert.ThrowsException<InvalidOperationException>(() => query_read.GetResultDataElements("a2"));
+                Assert.ThrowsException<InvalidOperationException>(() => query_read.GetResultDataElements("a3"));
+
+                Assert.AreEqual((ulong)a2_off_read.Length, query_read.GetResultOffsets("a2"));
+                Assert.AreEqual((ulong)a3_off_read.Length, query_read.GetResultOffsets("a3"));
+
+                Assert.AreEqual((ulong)a2_validity_read.Length, query_read.GetResultValidities("a2"));
+                Assert.AreEqual((ulong)a3_validity_read.Length, query_read.GetResultValidities("a3"));
 
                 array_read.Close();
             }


### PR DESCRIPTION
[SC-24679](https://app.shortcut.com/tiledb-inc/story/24679/add-high-performance-alternatives-to-query-resultbufferelements)

This PR adds four new `Query` APIs that get the number of elements written at a single buffer and for a single attribute/dimension at a time. Their advantage over `ResultBufferElements` is that they are much faster; they do not allocate, nor call into the Core to get the element size; it is kept when we set the buffers. If they are called with a name that does not exist, they throw.

This is the final API shape (differs from the story):

```csharp
public class Query
{
    public ulong GetResultDataBytes(string name);
    // It will throw if the data buffer had been set with UnsafeSetDataBuffer.
    // Consumers can either keep using ResultBufferElements, or call GetResultDataBytes.
    public ulong GetResultDataElements(string name);
    public ulong GetResultOffsets(string name);
    public ulong GetResultValidities(string name);
}
```