### PR TITLE
Add `QueryStatusDetails`.

### DIFF
--- a/sources/TileDB.CSharp/Enums.cs
+++ b/sources/TileDB.CSharp/Enums.cs
@@ -97,6 +97,25 @@ namespace TileDB.CSharp
     }
 
     /// <summary>
+    /// Specifies the reason a <see cref="Query"/> cannot proceed.
+    /// </summary>
+    public enum QueryStatusDetailsReason : uint
+    {
+        /// <summary>
+        /// There is no reason. This is the default value.
+        /// </summary>
+        None = tiledb_query_status_details_reason_t.TILEDB_REASON_NONE,
+        /// <summary>
+        /// The user-provided buffers are too small and need to be resized.
+        /// </summary>
+        UserBufferSize = tiledb_query_status_details_reason_t.TILEDB_REASON_USER_BUFFER_SIZE,
+        /// <summary>
+        /// The memory budget was exceeded. The query can be submitted again without resizing the buffers.
+        /// </summary>
+        MemoryBudget = tiledb_query_status_details_reason_t.TILEDB_REASON_MEMORY_BUDGET,
+    }
+
+    /// <summary>
     /// Specifies the relation type of a <see cref="QueryCondition"/> between its attribute and its value.
     /// </summary>
     public enum QueryConditionOperatorType : uint

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -846,6 +846,18 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
+        /// Returns a <see cref="QueryStatusDetails"/> value describing this <see cref="Query"/>.
+        /// </summary>
+        public QueryStatusDetails GetStatusDetails()
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            QueryStatusDetails statusDetails;
+            _ctx.handle_error(Methods.tiledb_query_get_status_details(ctxHandle, handle, &statusDetails._details));
+            return statusDetails;
+        }
+
+        /// <summary>
         /// Returns the query status.
         /// </summary>
         /// <returns></returns>

--- a/sources/TileDB.CSharp/QueryStatusDetails.cs
+++ b/sources/TileDB.CSharp/QueryStatusDetails.cs
@@ -1,0 +1,21 @@
+﻿using TileDB.Interop;
+
+namespace TileDB.CSharp
+{
+    /// <summary>
+    /// Specifies additional details about the status of a <see cref="Query"/>.
+    /// </summary>
+    public struct QueryStatusDetails
+    {
+        internal tiledb_query_status_details_t _details;
+
+        /// <summary>
+        /// The reason the <see cref="Query"/> cannot continue.
+        /// </summary>
+        public QueryStatusDetailsReason Reason
+        {
+            readonly get => (QueryStatusDetailsReason)_details.incomplete_reason;
+            set => _details.incomplete_reason = (tiledb_query_status_details_reason_t)value;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #238.

TODO: Add tests and use it in the examples.

[SC-24941](https://app.shortcut.com/tiledb-inc/story/24941/add-wrapping-for-querystatusdetailsreason)