### PR TITLE
Use SemVer 2.0 versions for pre-release native packages.

### DIFF
--- a/scripts/nuget/GenerateNuGetPackages.proj
+++ b/scripts/nuget/GenerateNuGetPackages.proj
@@ -5,6 +5,7 @@
     <RuntimeJson>$(TempDir)/runtime.json</RuntimeJson>
     <MetapackageProject>./TileDB.Native.proj</MetapackageProject>
     <NativePackageTemplateProject>./TileDB.Native.runtime.template.proj</NativePackageTemplateProject>
+    <PackageVersion>$(Version.Replace('-rc','-rc.'))</PackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(DevelopmentBuild) == true">
@@ -78,7 +79,7 @@
       Projects="@(ProjectsToBuild)"
       BuildInParallel="true"
       Targets="Pack"
-      Properties="PackageIdPrefix=$(PackageIdPrefix);PackageOutputPath=$(OutDir);Version=$(Version)" />
+      Properties="PackageIdPrefix=$(PackageIdPrefix);PackageOutputPath=$(OutDir);Version=$(PackageVersion)" />
   </Target>
 
   <Target Name="WriteRuntimeJson">
@@ -99,7 +100,7 @@
     <MSBuild
       Projects="$(MetapackageProject)"
       Targets="Pack"
-      Properties="PackageIdPrefix=$(PackageIdPrefix);PackageOutputPath=$(OutDir);Version=$(Version)" />
+      Properties="PackageIdPrefix=$(PackageIdPrefix);PackageOutputPath=$(OutDir);Version=$(PackageVersion)" />
   </Target>
 
   <Target Name="Pack"


### PR DESCRIPTION
Pre-release Core versions have the form `<major>.<minor>.0-rc<rc_number>`. When publishing them to NuGet, adding a dot between the `-rc` and the RC number would make the package version [compatible with Semantic Versioning 2.0](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#semantic-versioning-200), enabling things like `rc.10` being greater than `rc.1`. This PR adds this dot.