### PR TITLE
Streamline testing from CI.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -99,7 +99,6 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-latest, macos-latest, windows-latest]
         tag: [release-2.14, dev]
-        dotnet: ['net5.0', 'net6.0']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout TileDB-CSharp
@@ -126,11 +125,15 @@ jobs:
         run: dotnet build sources/TileDB.CSharp/TileDB.CSharp.csproj -c Release
 
       - name: Test TileDB-CSharp
-        run: dotnet test tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj -c Release -f ${{ matrix.dotnet }}
+        run: dotnet test tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj -c Release
 
-      - name: Run examples
+      - name: Run examples (.NET 5)
         shell: bash
-        run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f ${{ matrix.dotnet }}
+        run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0
+
+      - name: Run examples (.NET 6)
+        shell: bash
+        run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net6.0
 
   Create-Issue:
     needs: Test-NuGet

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,7 +97,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         tag: [release-2.14, dev]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Will be checking following versions
-        dotnet: ['net5.0', 'net6.0']
         # Repeat this test for each os
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -41,9 +39,14 @@ jobs:
       # DotNet test
       - name: Test TileDB.CSharp
         run: |
-          dotnet test -c Release tests/TileDB.CSharp.Test -f ${{ matrix.dotnet }}
+          dotnet test -c Release tests/TileDB.CSharp.Test
 
-      - name: Run examples
+      - name: Run examples (.NET 5)
         shell: bash
         run: |
-          find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f ${{ matrix.dotnet }}
+          find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0
+
+      - name: Run examples (.NET 6)
+        shell: bash
+        run: |
+          find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0


### PR DESCRIPTION
I discovered some time ago that if we run `dotnet test` in a multi-targeting project without specifying the framework, the tests will automatically run on all frameworks. This cuts the number of CI jobs in half.