### PR TITLE
Set the `x-tiledb-api-language` tag when creating new contexts.

### DIFF
--- a/sources/TileDB.CSharp/Context.cs
+++ b/sources/TileDB.CSharp/Context.cs
@@ -16,7 +16,6 @@ namespace TileDB.CSharp
     public sealed unsafe class Context : IDisposable
     {
         private readonly ContextHandle _handle;
-        private readonly Config _config;
 
         private bool IsDefault { get; init; }
 
@@ -26,7 +25,7 @@ namespace TileDB.CSharp
         public Context()
         {
             _handle = ContextHandle.Create();
-            _config = new Config();
+            SetDefaultTags();
         }
 
         /// <summary>
@@ -36,7 +35,12 @@ namespace TileDB.CSharp
         public Context(Config config)
         {
             _handle = ContextHandle.Create(config.Handle);
-            _config = config;
+            SetDefaultTags();
+        }
+
+        private void SetDefaultTags()
+        {
+            SetTag("x-tiledb-api-language", "csharp");
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ContextHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ContextHandle.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Runtime.InteropServices;
-using TileDB.CSharp;
 using TileDB.Interop;
 
 namespace TileDB.CSharp.Marshalling.SafeHandles
@@ -11,42 +10,15 @@ namespace TileDB.CSharp.Marshalling.SafeHandles
 
         public ContextHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
 
-        public static ContextHandle Create()
+        public static ContextHandle Create(ConfigHandle? configHandle = null)
         {
             var handle = new ContextHandle();
             var successful = false;
             tiledb_ctx_t* context = null;
             try
             {
-                using var configHandle = ConfigHandle.Create();
-                using var configHandleHolder = configHandle.Acquire();
+                using var configHandleHolder = configHandle?.Acquire() ?? default;
                 ErrorHandling.ThrowOnError(Methods.tiledb_ctx_alloc(configHandleHolder, &context));
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(context);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return handle;
-        }
-
-        public static ContextHandle Create(ConfigHandle configHandle)
-        {
-            var handle = new ContextHandle();
-            var successful = false;
-            tiledb_ctx_t* context = null;
-            try
-            {
-                using var configHandleHolder = configHandle.Acquire();
-                Methods.tiledb_ctx_alloc(configHandleHolder, &context);
                 successful = true;
             }
             finally


### PR DESCRIPTION
I just learned what `tiledb_context_set_tag` does, and saw that the Core sets the tag to `c`. We set it to `csharp`.