### PR TITLE
Improve string decoding; use UTF-8 by default.

### DIFF
--- a/sources/TileDB.CSharp/ArrayMetadata.cs
+++ b/sources/TileDB.CSharp/ArrayMetadata.cs
@@ -31,7 +31,7 @@ namespace TileDB.CSharp
         public void PutMetadata<T>(string key, T[] data) where T : struct
         {
             var tiledb_datatype = (tiledb_datatype_t)EnumUtil.TypeToDataType(typeof(T));
-            put_metadata<T>(key, data, tiledb_datatype, (uint)data.Length);
+            put_metadata(key, data, tiledb_datatype);
         }
 
         /// <inheritdoc cref="Array.PutMetadata{T}(string, T)"/>
@@ -44,10 +44,8 @@ namespace TileDB.CSharp
         /// <inheritdoc cref="Array.PutMetadata(string, string)"/>
         public void PutMetadata(string key, string value)
         {
-            var tiledb_datatype = tiledb_datatype_t.TILEDB_STRING_ASCII;
-            var data = Encoding.ASCII.GetBytes(value);
-            var val_num = (uint)data.Length;
-            put_metadata<byte>(key, data, tiledb_datatype, val_num);
+            var data = Encoding.UTF8.GetBytes(value);
+            put_metadata(key, data, tiledb_datatype_t.TILEDB_STRING_UTF8);
         }
 
         /// <inheritdoc cref="Array.DeleteMetadata"/>
@@ -229,7 +227,7 @@ namespace TileDB.CSharp
         /// <inheritdoc cref="IDictionary{TKey, TValue}.Add"/>
         public void Add(string key, byte[] value)
         {
-            put_metadata<byte>(key, value, tiledb_datatype_t.TILEDB_UINT8, (uint)value.Length);
+            put_metadata(key, value, tiledb_datatype_t.TILEDB_UINT8);
         }
 
         /// <inheritdoc cref="ICollection{T}.Add"/>
@@ -300,7 +298,7 @@ namespace TileDB.CSharp
             throw new NotImplementedException();
         }
 
-        private void put_metadata<T>(string key, T[] value, tiledb_datatype_t tiledb_datatype, uint value_num) where T : struct
+        private void put_metadata<T>(string key, T[] value, tiledb_datatype_t tiledb_datatype) where T : struct
         {
             ErrorHandling.ThrowIfManagedType<T>();
             if (string.IsNullOrEmpty(key) || value.Length == 0)
@@ -312,7 +310,7 @@ namespace TileDB.CSharp
             using var ctxHandle = ctx.Handle.Acquire();
             using var arrayHandle = _array.Handle.Acquire();
             fixed (T* dataPtr = &value[0])
-                ctx.handle_error(Methods.tiledb_array_put_metadata(ctxHandle, arrayHandle, ms_key, tiledb_datatype, value_num, dataPtr));
+                ctx.handle_error(Methods.tiledb_array_put_metadata(ctxHandle, arrayHandle, ms_key, tiledb_datatype, (uint)value.Length, dataPtr));
         }
 
         private (string key, byte[] data, tiledb_datatype_t tiledb_datatype, uint value_num) get_metadata(string key)

--- a/sources/TileDB.CSharp/ArrayMetadata.cs
+++ b/sources/TileDB.CSharp/ArrayMetadata.cs
@@ -73,8 +73,8 @@ namespace TileDB.CSharp
         /// <inheritdoc cref="Array.GetMetadata(string)"/>
         public string GetMetadata(string key)
         {
-            var (_, byte_array, _, _) = get_metadata(key);
-            return MarshaledStringOut.GetString(byte_array);
+            var (_, byte_array, datatype, _) = get_metadata(key);
+            return MarshaledStringOut.GetString(byte_array, (DataType)datatype);
         }
 
         /// <inheritdoc cref="Array.MetadataNum"/>

--- a/sources/TileDB.CSharp/Attribute.cs
+++ b/sources/TileDB.CSharp/Attribute.cs
@@ -290,7 +290,7 @@ namespace TileDB.CSharp
                 throw new NotSupportedException("Attribute.FillValue, please use FillValue<T> for non-string attribute!");
             }
             var fill_bytes = get_fill_value();
-            return MarshaledStringOut.GetString(fill_bytes);
+            return MarshaledStringOut.GetString(fill_bytes, datatype);
         }
 
         /// <summary>
@@ -395,7 +395,7 @@ namespace TileDB.CSharp
                 throw new NotSupportedException("Attribute.FillValueNullable, please use fill_value<T> for non-string attribute!");
             }
             var (fill_bytes, _) = get_fill_value_nullable();
-            return MarshaledStringOut.GetString(fill_bytes);
+            return MarshaledStringOut.GetString(fill_bytes, datatype);
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/GroupMetadata.cs
+++ b/sources/TileDB.CSharp/GroupMetadata.cs
@@ -93,8 +93,8 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public string GetMetadata(string key)
         {
-            var (_, byte_array, _, _) = get_metadata(key);
-            return MarshaledStringOut.GetString(byte_array);
+            var (_, byte_array, datatype, _) = get_metadata(key);
+            return MarshaledStringOut.GetString(byte_array, (DataType)datatype);
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/Marshalling/MarshaledStringOut.cs
+++ b/sources/TileDB.CSharp/Marshalling/MarshaledStringOut.cs
@@ -10,7 +10,7 @@ namespace TileDB.Interop
         /// Encodes a read-only span of bytes into a string, using the default encoding.
         /// </summary>
         public static string GetString(ReadOnlySpan<byte> span) =>
-            Encoding.ASCII.GetString(span);
+            Encoding.UTF8.GetString(span);
 
         public static string GetString(ReadOnlySpan<byte> span, DataType dataType) =>
             dataType switch

--- a/tests/TileDB.CSharp.Test/ArrayMetadataTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayMetadataTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -74,7 +74,7 @@ namespace TileDB.CSharp.Test
 
             array.PutMetadata<float>("key4", new float[] { 25.1f, 26.2f, 27.3f, 28.4f });
 
-            array.PutMetadata("key5", "This is TileDB array metadata");
+            array.PutMetadata("key5", "This is TileDB array metadata, that supports Unicode characters! 🥳");
 
             array.Close();
         }
@@ -101,7 +101,7 @@ namespace TileDB.CSharp.Test
             CollectionAssert.AreEqual(new float[]{ 25.1f, 26.2f, 27.3f, 28.4f }, v4);
 
             var s = array.GetMetadata("key5");
-            Assert.AreEqual("This is TileDB array metadata", s);
+            Assert.AreEqual("This is TileDB array metadata, that supports Unicode characters! 🥳", s);
 
             var num = array.MetadataNum();
             Assert.AreEqual((ulong)5,  num);


### PR DESCRIPTION
This PR does three things:

*
  It changes the default encoding for incoming strings from the Core from ASCII to UTF-8. It is needed for TileDB-Inc/TileDB#3987 and is more flexible in general.

  If `Encoding.UTF8` encounters invalid byte sequences, it converts them to `U+FFFD � REPLACEMENT CHARACTER`. If `Encoding.ASCII` encounters invalid bytes, it converts them to question marks (thought it would throw, turns out it does not).

* It uses the correct encoding in cases we know it (metadata and attribute fill values).

* It changes the encoding for string metadata values to UTF-8. Metadata from existing arrays with different encodings will be correctly handled (from the above bullet point).