### PR TITLE
Add `Query` constructor overloads that do not take a `Context`.

### DIFF
--- a/examples/TileDB.CSharp.Example/ExampleIncompleteQuery.cs
+++ b/examples/TileDB.CSharp.Example/ExampleIncompleteQuery.cs
@@ -51,7 +51,7 @@ namespace TileDB.CSharp.Examples
             {
                 arrayWrite.Open(QueryType.Write);
 
-                var queryWrite = new Query(Ctx, arrayWrite);
+                var queryWrite = new Query(arrayWrite);
                 queryWrite.SetLayout(LayoutType.Unordered);
                 queryWrite.SetDataBuffer("rows", rowsData);
                 queryWrite.SetDataBuffer("cols", colsData);
@@ -73,7 +73,7 @@ namespace TileDB.CSharp.Examples
             using (var arrayRead = new Array(Ctx, ArrayPath))
             {
                 arrayRead.Open(QueryType.Read);
-                var queryRead = new Query(Ctx, arrayRead);
+                var queryRead = new Query(arrayRead);
                 queryRead.SetLayout(LayoutType.Unordered);
 
                 queryRead.SetDataBuffer("rows", rowsRead);

--- a/examples/TileDB.CSharp.Example/ExampleIncompleteQueryStringDimensions.cs
+++ b/examples/TileDB.CSharp.Example/ExampleIncompleteQueryStringDimensions.cs
@@ -43,7 +43,7 @@ namespace TileDB.CSharp.Examples
             {
                 arrayWrite.Open(QueryType.Write);
 
-                var queryWrite = new Query(Ctx, arrayWrite);
+                var queryWrite = new Query(arrayWrite);
                 queryWrite.SetLayout(LayoutType.Unordered);
                 queryWrite.SetDataBuffer("rows", rowsData);
                 queryWrite.SetOffsetsBuffer("rows", rowsOffsets);
@@ -62,7 +62,7 @@ namespace TileDB.CSharp.Examples
             using (var arrayRead = new Array(Ctx, ArrayPath))
             {
                 arrayRead.Open(QueryType.Read);
-                var queryRead = new Query(Ctx, arrayRead);
+                var queryRead = new Query(arrayRead);
                 queryRead.SetLayout(LayoutType.Unordered);
                 var subarray = new Subarray(arrayRead);
                 subarray.AddRange("rows", "a", "eeeee");

--- a/examples/TileDB.CSharp.Example/ExampleIncompleteQueryVariableSize.cs
+++ b/examples/TileDB.CSharp.Example/ExampleIncompleteQueryVariableSize.cs
@@ -37,7 +37,7 @@ namespace TileDB.CSharp.Examples
             using (var array_write = new Array(Ctx, ArrayPath))
             {
                 array_write.Open(QueryType.Write);
-                var query_write = new Query(Ctx, array_write);
+                var query_write = new Query(array_write);
                 query_write.SetLayout(LayoutType.Unordered);
                 query_write.SetDataBuffer("rows", dim1_data_buffer);
                 query_write.SetDataBuffer("cols", dim2_data_buffer);
@@ -58,7 +58,7 @@ namespace TileDB.CSharp.Examples
             using (var array_read = new Array(Ctx, ArrayPath))
             {
                 array_read.Open(QueryType.Read);
-                var query_read = new Query(Ctx, array_read);
+                var query_read = new Query(array_read);
                 query_read.SetLayout(LayoutType.Unordered);
                 query_read.SetDataBuffer("rows", dim1_data_buffer_read);
                 query_read.SetDataBuffer("cols", dim2_data_buffer_read);

--- a/examples/TileDB.CSharp.Example/ExampleQuery.cs
+++ b/examples/TileDB.CSharp.Example/ExampleQuery.cs
@@ -34,7 +34,7 @@ namespace TileDB.CSharp.Examples
             using (var array_write = new Array(Ctx, ArrayPath))
             {
                 array_write.Open(QueryType.Write);
-                var query_write = new Query(Ctx, array_write);
+                var query_write = new Query(array_write);
                 query_write.SetLayout(LayoutType.Unordered);
                 query_write.SetDataBuffer("rows", dim1_data_buffer);
                 query_write.SetDataBuffer("cols", dim2_data_buffer);
@@ -53,7 +53,7 @@ namespace TileDB.CSharp.Examples
             using (var array_read = new Array(Ctx, ArrayPath))
             {
                 array_read.Open(QueryType.Read);
-                var query_read = new Query(Ctx, array_read);
+                var query_read = new Query(array_read);
                 query_read.SetLayout(LayoutType.RowMajor);
                 query_read.SetDataBuffer("rows", dim1_data_buffer_read);
                 query_read.SetDataBuffer("cols", dim2_data_buffer_read);

--- a/examples/TileDB.CSharp.Example/ExampleWritingDenseGlobal.cs
+++ b/examples/TileDB.CSharp.Example/ExampleWritingDenseGlobal.cs
@@ -29,7 +29,7 @@ namespace TileDB.CSharp.Examples
             using var array = new Array(Ctx, ArrayPath);
             array.Open(QueryType.Write);
 
-            using var queryWrite = new Query(Ctx, array, QueryType.Write);
+            using var queryWrite = new Query(array, QueryType.Write);
             queryWrite.SetLayout(LayoutType.GlobalOrder);
             // Slice rows 1-4, columns 1-2 for a total of 8 cells
             using var subarray = new Subarray(array);
@@ -56,7 +56,7 @@ namespace TileDB.CSharp.Examples
         {
             using var array = new Array(Ctx, ArrayPath);
             array.Open(QueryType.Read);
-            using var readQuery = new Query(Ctx, array, QueryType.Read);
+            using var readQuery = new Query(array, QueryType.Read);
             using var subarray = new Subarray(array);
             subarray.SetSubarray(1, 4, 1, 4);
             readQuery.SetSubarray(subarray);

--- a/examples/TileDB.CSharp.Example/ExampleWritingSparseGlobal.cs
+++ b/examples/TileDB.CSharp.Example/ExampleWritingSparseGlobal.cs
@@ -29,7 +29,7 @@ namespace TileDB.CSharp.Examples
         {
             using var array = new Array(Ctx, ArrayPath);
             array.Open(QueryType.Write);
-            using var queryWrite = new Query(Ctx, array, QueryType.Write);
+            using var queryWrite = new Query(array, QueryType.Write);
             queryWrite.SetLayout(LayoutType.GlobalOrder);
 
             // Coordinates for global order writes must be provided in-order
@@ -57,7 +57,7 @@ namespace TileDB.CSharp.Examples
         {
             using var array = new Array(Ctx, ArrayPath);
             array.Open(QueryType.Read);
-            using var readQuery = new Query(Ctx, array, QueryType.Read);
+            using var readQuery = new Query(array, QueryType.Read);
             using var subarray = new Subarray(array);
             subarray.SetSubarray(1, 4, 1, 4);
             readQuery.SetSubarray(subarray);

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -91,6 +91,11 @@ namespace TileDB.CSharp
         /// <param name="ctx">The context associated with this query.</param>
         /// <param name="array">The array on which the query will operate.</param>
         /// <param name="queryType">The query's type.</param>
+        /// <remarks>
+        /// This overload is not recommended for use in new code.
+        /// You should use <see cref="Query(CSharp.Array, CSharp.QueryType)"/> instead.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
         public Query(Context ctx, Array array, QueryType queryType)
         {
             _ctx = ctx;
@@ -103,12 +108,25 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="ctx">The context associated with this query.</param>
         /// <param name="array">The array on which the query will operate. Its <see cref="Array.QueryType"/> will be used for the query.</param>
-        public Query(Context ctx, Array array)
-        {
-            _ctx = ctx;
-            _array = array;
-            _handle = QueryHandle.Create(ctx, array.Handle, (tiledb_query_type_t)array.QueryType());
-        }
+        /// <remarks>
+        /// This overload is not recommended for use in new code.
+        /// You should use <see cref="Query(CSharp.Array)"/> instead.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Query(Context ctx, Array array) : this(ctx, array, array.QueryType()) { }
+
+        /// <summary>
+        /// Creates a <see cref="Query"/>.
+        /// </summary>
+        /// <param name="array">The array on which the query will operate.</param>
+        /// <param name="queryType">The query's type.</param>
+        public Query(Array array, QueryType queryType) : this(array.Context(), array, queryType) { }
+
+        /// <summary>
+        /// Creates a <see cref="Query"/> with an implicit <see cref="CSharp.QueryType"/>.
+        /// </summary>
+        /// <param name="array">The array on which the query will operate. Its <see cref="Array.QueryType"/> will be used for the query.</param>
+        public Query(Array array) : this(array.Context(), array) { }
 
         /// <summary>
         /// Disposes this <see cref="Query"/>.

--- a/tests/TileDB.CSharp.Test/ArrayTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayTest.cs
@@ -147,7 +147,7 @@ namespace TileDB.CSharp.Test
                 using var array = new Array(context, uri);
                 array.Open(QueryType.Write);
 
-                using var query = new Query(context, array, QueryType.Write);
+                using var query = new Query(array, QueryType.Write);
                 query.SetDataBuffer("a1", a1Data);
                 query.SetDataBuffer("a2", a2Data);
                 query.SetOffsetsBuffer("a2", a2Offsets);

--- a/tests/TileDB.CSharp.Test/AttributeTest.cs
+++ b/tests/TileDB.CSharp.Test/AttributeTest.cs
@@ -211,7 +211,7 @@ namespace TileDB.CSharp.Test
             ulong[] a2_el_off = new ulong[16] { 0, 2, 4, 5, 6, 7, 9, 11, 14, 16, 17, 18, 20, 21, 24, 25};
             ulong[] a2_off = CoreUtil.ElementOffsetsToByteOffsets(a2_el_off, DataType.Int32);
 
-            var query_write = new Query(context, array_write);
+            var query_write = new Query(array_write);
             query_write.SetLayout(LayoutType.RowMajor);
             // using var subarray = new Subarray(array_write);
             // subarray.SetSubarray(new int[] { 1, 4, 4, 4 });
@@ -239,7 +239,7 @@ namespace TileDB.CSharp.Test
             Assert.IsNotNull(array_read);
             array_read.Open(QueryType.Read);
 
-            var query_read = new Query(context, array_read);
+            var query_read = new Query(array_read);
 
             // Slice only rows 1,2 and cols 2,3,4
             using var subarray = new Subarray(array_read);

--- a/tests/TileDB.CSharp.Test/DeletesTest.cs
+++ b/tests/TileDB.CSharp.Test/DeletesTest.cs
@@ -50,7 +50,7 @@ namespace TileDB.CSharp.Test
         {
             // Delete multiple cells at once
             array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(ctx, array, QueryType.Delete);
+            using var deleteQuery = new Query(array, QueryType.Delete);
             using var notCondition = QueryCondition.Create(ctx, "cols", 3, QueryConditionOperatorType.NotEqual);
             using var andCondition = QueryCondition.Create(ctx, "cols", 2, QueryConditionOperatorType.GreaterThan);
             using var queryCondition = notCondition & andCondition;
@@ -127,7 +127,7 @@ namespace TileDB.CSharp.Test
 
             // Delete one cell
             array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(ctx, array, QueryType.Delete);
+            using var deleteQuery = new Query(array, QueryType.Delete);
             using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
             using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
             using var andCondition = colsCondition & rowsCondition;
@@ -180,7 +180,7 @@ namespace TileDB.CSharp.Test
 
             // Delete 1 cell
             array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(ctx, array, QueryType.Delete);
+            using var deleteQuery = new Query(array, QueryType.Delete);
             using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
             using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
             using var andCondition = colsCondition & rowsCondition;
@@ -203,7 +203,7 @@ namespace TileDB.CSharp.Test
             // + The OR condition overlaps on (3, 4)
             // + (3, 2) was deleted by a previous delete query
             array.Open(QueryType.Delete);
-            using var deleteQuery2 = new Query(ctx, array, QueryType.Delete);
+            using var deleteQuery2 = new Query(array, QueryType.Delete);
             using var colsCondition2 = QueryCondition.Create(ctx, "cols", 4, QueryConditionOperatorType.Equal);
             using var rowsCondition2 = QueryCondition.Create(ctx, "rows", 3, QueryConditionOperatorType.Equal);
             using var orCondition = colsCondition2 | rowsCondition2;
@@ -246,7 +246,7 @@ namespace TileDB.CSharp.Test
 
             // Delete single cell
             array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(ctx, array, QueryType.Delete);
+            using var deleteQuery = new Query(array, QueryType.Delete);
             using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
             using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
             using var andCondition = rowsCondition & colsCondition;
@@ -437,7 +437,7 @@ namespace TileDB.CSharp.Test
             delArray.SetOpenTimestampStart(deleteTime);
             delArray.SetOpenTimestampEnd(deleteTime);
             delArray.Open(QueryType.Delete);
-            using var deleteQuery = new Query(ctx, delArray, QueryType.Delete);
+            using var deleteQuery = new Query(delArray, QueryType.Delete);
             using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
             using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
             using var andCondition = rowsCondition & colsCondition;
@@ -577,7 +577,7 @@ namespace TileDB.CSharp.Test
 
             // Make a delete condition on an attribute
             array.Open(QueryType.Delete);
-            using var deleteQuery2 = new Query(ctx, array, QueryType.Delete);
+            using var deleteQuery2 = new Query(array, QueryType.Delete);
             using var attrCondition = QueryCondition.Create(ctx, "a1", 10, QueryConditionOperatorType.LessThan);
             deleteQuery2.SetCondition(attrCondition);
             deleteQuery2.Submit();
@@ -672,7 +672,7 @@ namespace TileDB.CSharp.Test
             array.SetOpenTimestampEnd(writeTime.Item1);
             array.Open(QueryType.Delete);
             Logger.LogMessage($"Array opened at between {array.OpenTimestampStart()} and {array.OpenTimestampEnd()}");
-            using var deleteQuery = new Query(ctx, array, QueryType.Delete);
+            using var deleteQuery = new Query(array, QueryType.Delete);
             using var attrCondition = QueryCondition.Create(ctx, "a1", 17, QueryConditionOperatorType.Equal);
             deleteQuery.SetCondition(attrCondition);
             deleteQuery.Submit();
@@ -765,7 +765,7 @@ namespace TileDB.CSharp.Test
             }
 
             array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(ctx, array, QueryType.Delete);
+            using var deleteQuery = new Query(array, QueryType.Delete);
             using var attrCondition = QueryCondition.Create(ctx, "a0", 4, QueryConditionOperatorType.Equal);
             deleteQuery.SetCondition(attrCondition);
             deleteQuery.Submit();
@@ -858,7 +858,7 @@ namespace TileDB.CSharp.Test
             }
 
             array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(ctx, array, QueryType.Delete);
+            using var deleteQuery = new Query(array, QueryType.Delete);
             using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
             deleteQuery.SetCondition(colsCondition);
             deleteQuery.Submit();

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -427,7 +427,7 @@ namespace TileDB.CSharp.Test
 
             using Array array = new Array(_ctx, arrayUri);
             array.Open(QueryType.Write);
-            using Query query = new Query(_ctx, array);
+            using Query query = new Query(array);
             query.SetDataBuffer("a", data);
             using Subarray subarray = new Subarray(array);
             subarray.SetSubarray(1, 2, 1, 4);
@@ -463,7 +463,7 @@ namespace TileDB.CSharp.Test
 
             using Array array = new Array(_ctx, arrayUri);
             array.Open(QueryType.Write);
-            using Query query = new Query(_ctx, array);
+            using Query query = new Query(array);
             query.SetLayout(LayoutType.GlobalOrder);
 
             query.SetDataBuffer("d1", dData);
@@ -529,7 +529,7 @@ namespace TileDB.CSharp.Test
 
             void WriteImpl(long[] d1, long[] d2, int[] a1)
             {
-                using Query query = new Query(_ctx, a);
+                using Query query = new Query(a);
                 query.SetLayout(LayoutType.Unordered);
                 query.SetDataBuffer("d1", d1);
                 query.SetDataBuffer("d2", d2);
@@ -551,7 +551,7 @@ namespace TileDB.CSharp.Test
 
             void WriteImpl(int[] d1, int[] d2, int[] a1)
             {
-                using Query query = new Query(_ctx, a);
+                using Query query = new Query(a);
                 query.SetLayout(LayoutType.Unordered);
                 query.SetDataBuffer("d1", d1);
                 query.SetDataBuffer("d2", d2);
@@ -588,7 +588,7 @@ namespace TileDB.CSharp.Test
 
             using Array array = new Array(_ctx, arrayUri);
             array.Open(QueryType.Write);
-            using Query query = new Query(_ctx, array);
+            using Query query = new Query(array);
             query.SetLayout(LayoutType.Unordered);
 
             query.SetDataBuffer("d", dData);

--- a/tests/TileDB.CSharp.Test/IncompleteQueryTest.cs
+++ b/tests/TileDB.CSharp.Test/IncompleteQueryTest.cs
@@ -42,7 +42,7 @@ namespace TileDB.CSharp.Test
             using (var array_write = new Array(Ctx, path))
             {
                 array_write.Open(QueryType.Write);
-                var query_write = new Query(Ctx, array_write);
+                var query_write = new Query(array_write);
                 query_write.SetLayout(LayoutType.Unordered);
                 query_write.SetDataBuffer("rows", dim1_data_buffer);
                 query_write.SetDataBuffer("cols", dim2_data_buffer);
@@ -65,7 +65,7 @@ namespace TileDB.CSharp.Test
             using (var array_read = new Array(Ctx, path))
             {
                 array_read.Open(QueryType.Read);
-                var query_read = new Query(Ctx, array_read);
+                var query_read = new Query(array_read);
                 query_read.SetLayout(LayoutType.Unordered);
                 query_read.SetDataBuffer("rows", dim1_data_buffer_read);
                 query_read.SetDataBuffer("cols", dim2_data_buffer_read);

--- a/tests/TileDB.CSharp.Test/QueryConditionTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryConditionTest.cs
@@ -52,7 +52,7 @@ namespace TileDB.CSharp.Test
 
             array_write.Open(QueryType.Write);
 
-            using var query_write = new Query(context, array_write);
+            using var query_write = new Query(array_write);
 
             var attr1_data_buffer = new int[16] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
             query_write.SetDataBuffer("a1", attr1_data_buffer);
@@ -69,7 +69,7 @@ namespace TileDB.CSharp.Test
 
             array_read.Open(QueryType.Read);
 
-            using var query_read = new Query(context, array_read);
+            using var query_read = new Query(array_read);
 
             query_read.SetLayout(LayoutType.RowMajor);
 
@@ -130,7 +130,7 @@ namespace TileDB.CSharp.Test
 
             array_write.Open(QueryType.Write);
 
-            using var query_write = new Query(context, array_write);
+            using var query_write = new Query(array_write);
 
             var attr_data_buffer = new int[] { 1, 2, 3, 4, 5 };
             var attr_validity_buffer = new byte[] { 1, 1, 0, 1, 1 };
@@ -149,7 +149,7 @@ namespace TileDB.CSharp.Test
 
             array_read.Open(QueryType.Read);
 
-            using var query_read = new Query(context, array_read);
+            using var query_read = new Query(array_read);
 
             query_read.SetLayout(LayoutType.RowMajor);
 

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -44,7 +44,7 @@ namespace TileDB.CSharp.Test
             // Write array
             array.Open(QueryType.Write);
             Assert.IsTrue(array.IsOpen());
-            using var queryWrite = new Query(ctx, array);
+            using var queryWrite = new Query(array);
             queryWrite.SetLayout(layoutType);
             if (arrayType == ArrayType.Dense)
             {
@@ -74,7 +74,7 @@ namespace TileDB.CSharp.Test
             // Read array
             array.Open(QueryType.Read);
             Assert.IsTrue(array.IsOpen());
-            using var queryRead = new Query(ctx, array);
+            using var queryRead = new Query(array);
             // Initially allocate buffers for dense read
             var a1Read = new int[16];
             var rowsRead = new int[16];
@@ -176,7 +176,7 @@ namespace TileDB.CSharp.Test
 
             array.Open(QueryType.Write);
 
-            var query = new Query(context, array);
+            var query = new Query(array);
 
             using (var subarray = new Subarray(array))
             {
@@ -216,7 +216,7 @@ namespace TileDB.CSharp.Test
 
             array_read.Open(QueryType.Read);
 
-            var query_read = new Query(context, array_read);
+            var query_read = new Query(array_read);
 
             using (var subarray = new Subarray(array_read))
             {
@@ -310,7 +310,7 @@ namespace TileDB.CSharp.Test
 
                 array_write.Open(QueryType.Write);
 
-                var query_write = new Query(context, array_write);
+                var query_write = new Query(array_write);
 
                 query_write.SetLayout(LayoutType.Unordered);
 
@@ -339,7 +339,7 @@ namespace TileDB.CSharp.Test
 
                 array_read.Open(QueryType.Read);
 
-                var query_read = new Query(context, array_read);
+                var query_read = new Query(array_read);
 
                 query_read.SetLayout(LayoutType.RowMajor);
 
@@ -454,7 +454,7 @@ namespace TileDB.CSharp.Test
 
                 array_write.Open(QueryType.Write);
 
-                using var query_write = new Query(context, array_write);
+                using var query_write = new Query(array_write);
                 query_write.SetLayout(LayoutType.RowMajor);
 
                 query_write.SetDataBuffer("a1", a1_data_ptr, (ulong)a1_data.Length);
@@ -495,7 +495,7 @@ namespace TileDB.CSharp.Test
 
                 array_read.Open(QueryType.Read);
 
-                using var query_read = new Query(context, array_read);
+                using var query_read = new Query(array_read);
 
                 query_read.SetLayout(LayoutType.RowMajor);
                 using var subarray = new Subarray(array_read);
@@ -576,7 +576,7 @@ namespace TileDB.CSharp.Test
             array_write.Create(array_schema);
             array_write.Open(QueryType.Write);
 
-            var query_write = new Query(context, array_write);
+            var query_write = new Query(array_write);
             using (var subarray = new Subarray(array_write))
             {
                 subarray.SetSubarray(1, 2, 1, 2);
@@ -599,7 +599,7 @@ namespace TileDB.CSharp.Test
             Assert.IsNotNull(array_read);
             array_read.Open(QueryType.Read);
 
-            var query_read = new Query(context, array_read);
+            var query_read = new Query(array_read);
             using (var subarray = new Subarray(array_read))
             {
                 subarray.SetSubarray(1, 2, 1, 2);
@@ -619,7 +619,7 @@ namespace TileDB.CSharp.Test
             query_read.Dispose();
 
             // Read from array into byte[]
-            query_read = new Query(context, array_read);
+            query_read = new Query(array_read);
             using (var subarray = new Subarray(array_read))
             {
                 subarray.SetSubarray(1, 2, 1, 2);
@@ -670,14 +670,14 @@ namespace TileDB.CSharp.Test
             // From the documentation, the memory will be unpinned if:
 
             // the query is disposed,
-            using (var q = new Query(context, array))
+            using (var q = new Query(array))
             {
                 q.UnsafeSetDataBuffer("rows", disposalCanary.Memory.Pin(), 1 * sizeof(int));
             }
             Assert.AreEqual(1, disposalCanary.UnpinCount);
 
             // the buffer is reassigned,
-            using (var q = new Query(context, array))
+            using (var q = new Query(array))
             {
                 q.UnsafeSetDataBuffer("rows", disposalCanary.Memory.Pin(), 1 * sizeof(int));
                 q.SetDataBuffer("rows", new int[1]);
@@ -685,7 +685,7 @@ namespace TileDB.CSharp.Test
             }
 
             // or setting the buffer fails.
-            using (var q = new Query(context, array))
+            using (var q = new Query(array))
             {
                 Assert.ThrowsException<TileDBException>(() => q.UnsafeSetDataBuffer("foo", disposalCanary.Memory.Pin(), 1 * sizeof(int)));
                 Assert.AreEqual(3, disposalCanary.UnpinCount);

--- a/tests/TileDB.CSharp.Test/StatsTest.cs
+++ b/tests/TileDB.CSharp.Test/StatsTest.cs
@@ -25,7 +25,7 @@ namespace TileDB.CSharp.Test
 
             var array = new Array(ctx, ArrayUri);
             array.Open(QueryType.Write);
-            var query = new Query(ctx, array);
+            var query = new Query(array);
             query.SetLayout(LayoutType.RowMajor);
             var subarray = new Subarray(array);
             subarray.SetSubarray(1, 4, 1, 4);

--- a/tests/TileDB.CSharp.Test/TestUtil.cs
+++ b/tests/TileDB.CSharp.Test/TestUtil.cs
@@ -91,7 +91,7 @@ namespace TileDB.CSharp.Test
             // Use context if provided; Else get default context
             ctx ??= Context.GetDefault();
 
-            var writeQuery = new Query(ctx, array, QueryType.Write);
+            var writeQuery = new Query(array, QueryType.Write);
             // Sparse arrays can't write using row major; Can read using row-major, but not preferred for performance
             if (array.Schema().ArrayType() == ArrayType.Sparse && layout == LayoutType.RowMajor)
             {
@@ -165,7 +165,7 @@ namespace TileDB.CSharp.Test
             // Use context if provided; Else get default context
             ctx ??= Context.GetDefault();
 
-            var readQuery = new Query(ctx, array, QueryType.Read);
+            var readQuery = new Query(array, QueryType.Read);
             readQuery.SetLayout(layout);
             foreach (var buffer in buffers)
             {


### PR DESCRIPTION
They take the context of the array, like `Subarray`'s constructors, which never took a context. The existing constructors were hidden; it's not necessary to obsolete them.