### PR TITLE
Enable package validation.

### DIFF
--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -9,6 +9,28 @@ on:
   workflow_call:
 
 jobs:
+  Validate-Package:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks out repository
+      - uses: actions/checkout@v3
+
+      - name: Remove existing .NET versions
+        shell: bash
+        run: |
+          rm -rf $DOTNET_ROOT
+
+      - name: Set up .NET SDK from global.json
+        uses: actions/setup-dotnet@v3
+
+      - name: Display .NET versions
+        run: dotnet --info
+
+      # Package validation runs as part of packing.
+      - name: Dotnet pack for TileDB.CSharp
+        run: |
+          dotnet pack -c Release sources/TileDB.CSharp
+
   Run-Tests:
     strategy:
       fail-fast: false

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -241,13 +241,12 @@ namespace TileDB.CSharp
         /// Gets the name of a fragment.
         /// </summary>
         /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <param name="test">A dummy parameter to test the package validator.</param>
         /// <remarks>
         /// The maximum value <paramref name="fragmentIndex"/> can take
         /// is determined by the <see cref="FragmentCount"/> property.
         /// </remarks>
         /// <seealso cref="Array.ConsolidateFragments"/>
-        public string GetFragmentName(uint fragmentIndex, int test = 0)
+        public string GetFragmentName(uint fragmentIndex)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -241,12 +241,13 @@ namespace TileDB.CSharp
         /// Gets the name of a fragment.
         /// </summary>
         /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+        /// <param name="test">A dummy parameter to test the package validator.</param>
         /// <remarks>
         /// The maximum value <paramref name="fragmentIndex"/> can take
         /// is determined by the <see cref="FragmentCount"/> property.
         /// </remarks>
         /// <seealso cref="Array.ConsolidateFragments"/>
-        public string GetFragmentName(uint fragmentIndex)
+        public string GetFragmentName(uint fragmentIndex, int test = 0)
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();

--- a/sources/TileDB.CSharp/TileDB.CSharp.csproj
+++ b/sources/TileDB.CSharp/TileDB.CSharp.csproj
@@ -10,6 +10,8 @@
     <Description>C# wrapper of the TileDB Embedded universal data engine.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>5.5.0</PackageValidationBaselineVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR uses [the .NET SDK's package validation feature](https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview) to validate that `TileDB.CSharp` does not have any backwards-incompatible changes, compared to a published version of the package (currently 5.5.0). If we need to introduce a breaking change, we will have to [explicitly suppress the error](https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/overview#suppress-compatibility-errors).

I created an additional CI job that runs `dotnet pack` which will trigger the analysis, and will test it by trying to introduce a breaking change in the PR.