### PR TITLE
Fix generic type validation to support datetimes and non-ASCII strings.

### DIFF
--- a/docs/obsoletions.md
+++ b/docs/obsoletions.md
@@ -7,7 +7,7 @@ Following [the deprecation policy of TileDB Embedded][core-deprecation], obsolet
 |Diagnostic codes|Deprecated in version|Removed in version|
 |----------------|---------------------|------------------|
 |[`TILEDB0001`](#TILEDB0001) …[`TILEDB0011`](#TILEDB0011)|5.3.0|5.5.0|
-|[`TILEDB0012`](#TILEDB0012) …[`TILEDB0012`](#TILEDB0012)|5.7.0|5.9.0|
+|[`TILEDB0012`](#TILEDB0012) …[`TILEDB0013`](#TILEDB0013)|5.7.0|5.9.0|
 
 ## `TILEDB0001` - Enum value names that start with `TILEDB_` were replaced with C#-friendly names.
 
@@ -320,3 +320,17 @@ The obsoleted APIs fall into the following categories:
 - Types with the name `tiledb_***_t` were made public again only to support the APIs of the safe handles above. They have little other use on their own. You should use APIs in the `TileDB.CSharp` namespace instead.
 
 [core-deprecation]: https://github.com/TileDB-Inc/TileDB/blob/dev/doc/policy/api_changes.md
+
+## `TILEDB0013` - The `EnumUtils.TypeToDataType` and `EnumUtils.DataTypeToType` methods are obsolete and will be removed in a future version.
+
+<a name="TILEDB0013"></a>
+
+The `EnumUtils.TypeToDataType` and `EnumUtils.DataTypeToType` methods convert between TileDB data types and .NET types. Given that there is no one-to-one correspondence between these two and for legacy reasons, these methods sometimes return wrong results and were obsoleted.
+
+### Version introduced
+
+5.7.0
+
+### Recommended action
+
+If you are performing queries on arrays of unknown schema, you can use the `Query.UnsafeSetDataBuffer` and `Query.UnsafeSetWriteDataBuffer` methods to set a data buffer to a query without type validation.

--- a/sources/TileDB.CSharp/Array.cs
+++ b/sources/TileDB.CSharp/Array.cs
@@ -501,15 +501,11 @@ namespace TileDB.CSharp
         /// <exception cref="ArgumentException"><typeparamref name="T"/> is not the dimension's type.</exception>
         public (T Start, T End, bool IsEmpty) NonEmptyDomain<T>(uint index) where T : struct
         {
-            var datatype = EnumUtil.TypeToDataType(typeof(T));
             using (var schema = Schema())
             using (var domain = schema.Domain())
             using (var dimension = domain.Dimension(index))
             {
-                if (datatype != dimension.Type())
-                {
-                    throw new ArgumentException("Array.NonEmptyDomain, not valid datatype!");
-                }
+                ErrorHandling.CheckDataType<T>(dimension.Type());
             }
 
             SequentialPair<T> data;
@@ -531,15 +527,11 @@ namespace TileDB.CSharp
         /// <exception cref="ArgumentException"><typeparamref name="T"/> is not the dimension's type.</exception>
         public (T Start, T End, bool IsEmpty) NonEmptyDomain<T>(string name) where T : struct
         {
-            var datatype = EnumUtil.TypeToDataType(typeof(T));
             using (var schema = Schema())
             using (var domain = schema.Domain())
             using (var dimension = domain.Dimension(name))
             {
-                if (datatype != dimension.Type())
-                {
-                    throw new ArgumentException("Array.NonEmptyDomain, not valid datatype!");
-                }
+                ErrorHandling.CheckDataType<T>(dimension.Type());
             }
 
             using var ms_name = new MarshaledString(name);

--- a/sources/TileDB.CSharp/ArrayMetadata.cs
+++ b/sources/TileDB.CSharp/ArrayMetadata.cs
@@ -300,7 +300,7 @@ namespace TileDB.CSharp
 
         private void put_metadata<T>(string key, T[] value, tiledb_datatype_t tiledb_datatype) where T : struct
         {
-            ErrorHandling.ThrowIfManagedType<T>();
+            ErrorHandling.CheckDataType<T>((DataType)tiledb_datatype);
             if (string.IsNullOrEmpty(key) || value.Length == 0)
             {
                 throw new ArgumentException("ArrayMetadata.put_metadata, null or empty key-value!");

--- a/sources/TileDB.CSharp/Attribute.cs
+++ b/sources/TileDB.CSharp/Attribute.cs
@@ -195,7 +195,7 @@ namespace TileDB.CSharp
         /// <param name="data">An array of values that will be used as the fill value.</param>
         private void SetFillValue<T>(T[] data) where T : struct
         {
-            ErrorHandling.ThrowIfManagedType<T>();
+            ErrorHandling.CheckDataType<T>(Type());
             if (data.Length == 0)
             {
                 throw new ArgumentException("Attribute.SetFillValue, data is empty!");

--- a/sources/TileDB.CSharp/Dimension.cs
+++ b/sources/TileDB.CSharp/Dimension.cs
@@ -146,7 +146,7 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public (T Start, T End) GetDomain<T>() where T : struct
         {
-            ErrorHandling.ThrowIfManagedType<T>();
+            ErrorHandling.CheckDataType<T>(Type());
             void* value_p;
 
             using var ctxHandle = _ctx.Handle.Acquire();
@@ -163,7 +163,7 @@ namespace TileDB.CSharp
         /// <returns></returns>
         public T TileExtent<T>() where T : struct
         {
-            ErrorHandling.ThrowIfManagedType<T>();
+            ErrorHandling.CheckDataType<T>(Type());
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             void* value_p;

--- a/sources/TileDB.CSharp/Enums.cs
+++ b/sources/TileDB.CSharp/Enums.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Text;
 using TileDB.Interop;
 
 namespace TileDB.CSharp
@@ -185,115 +186,217 @@ namespace TileDB.CSharp
         /// <summary>
         /// A signed 32-bit integer.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="int"/>.
+        /// </remarks>
         Int32 = tiledb_datatype_t.TILEDB_INT32,
         /// <summary>
         /// A signed 64-bit integer.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         Int64 = tiledb_datatype_t.TILEDB_INT64,
         /// <summary>
         /// A 32-bit floating-point number.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="float"/>.
+        /// </remarks>
         Float32 = tiledb_datatype_t.TILEDB_FLOAT32,
         /// <summary>
         /// A 64-bit floating-point number.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="double"/>.
+        /// </remarks>
         Float64 = tiledb_datatype_t.TILEDB_FLOAT64,
         /// <summary>
         /// A signed 8-bit integer.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="sbyte"/>.
+        /// </remarks>
         Int8 = tiledb_datatype_t.TILEDB_INT8,
         /// <summary>
         /// An unsigned 8-bit integer.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="byte"/>.
+        /// </remarks>
         UInt8 = tiledb_datatype_t.TILEDB_UINT8,
         /// <summary>
         /// A signed 16-bit integer.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="short"/>.
+        /// </remarks>
         Int16 = tiledb_datatype_t.TILEDB_INT16,
         /// <summary>
         /// An unsigned 16-bit integer.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="ushort"/>.
+        /// </remarks>
         UInt16 = tiledb_datatype_t.TILEDB_UINT16,
         /// <summary>
         /// An unsigned 32-bit integer.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="uint"/>.
+        /// </remarks>
         UInt32 = tiledb_datatype_t.TILEDB_UINT32,
         /// <summary>
         /// An unsigned 64-bit integer.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="ulong"/>.
+        /// </remarks>
         UInt64 = tiledb_datatype_t.TILEDB_UINT64,
         /// <summary>
         /// An ASCII string.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="byte"/>.
+        /// </remarks>
         StringAscii = tiledb_datatype_t.TILEDB_STRING_ASCII,
         /// <summary>
         /// A UTF-8 string.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="byte"/>.
+        /// </remarks>
         StringUtf8 = tiledb_datatype_t.TILEDB_STRING_UTF8,
         /// <summary>
         /// A UTF-16 string.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="ushort"/> or <see cref="char"/>.
+        /// </remarks>
         StringUtf16 = tiledb_datatype_t.TILEDB_STRING_UTF16,
         /// <summary>
         /// A UTF-32 string.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="uint"/>.
+        /// </remarks>
         StringUtf32 = tiledb_datatype_t.TILEDB_STRING_UTF32,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// years since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         DateTimeYear = tiledb_datatype_t.TILEDB_DATETIME_YEAR,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// months since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         DateTimeMonth = tiledb_datatype_t.TILEDB_DATETIME_MONTH,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// weeks since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         DateTimeWeek = tiledb_datatype_t.TILEDB_DATETIME_WEEK,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// days since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         DateTimeDay = tiledb_datatype_t.TILEDB_DATETIME_DAY,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// hours since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         DateTimeHour = tiledb_datatype_t.TILEDB_DATETIME_HR,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// minutes since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         DateTimeMinute = tiledb_datatype_t.TILEDB_DATETIME_MIN,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// seconds since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         DateTimeSecond = tiledb_datatype_t.TILEDB_DATETIME_SEC,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// milliseconds since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         DateTimeMillisecond = tiledb_datatype_t.TILEDB_DATETIME_MS,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// microseconds since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         DateTimeMicrosecond = tiledb_datatype_t.TILEDB_DATETIME_US,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// nanoseconds since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         DateTimeNanosecond = tiledb_datatype_t.TILEDB_DATETIME_NS,
         /// <summary>
         /// A date and time, counted as the signed 64-bit number of
         /// picoseconds since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
         /// <remarks>
+        /// <para>
         /// One second consists of one trillion picoseconds.
+        /// </para>
+        /// <para>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </para>
         /// </remarks>
         DateTimePicosecond = tiledb_datatype_t.TILEDB_DATETIME_PS,
         /// <summary>
@@ -301,7 +404,13 @@ namespace TileDB.CSharp
         /// femtoseconds since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
         /// <remarks>
+        /// <para>
         /// One second consists of one quadrillion femtoseconds.
+        /// </para>
+        /// <para>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </para>
         /// </remarks>
         DateTimeFemtosecond = tiledb_datatype_t.TILEDB_DATETIME_FS,
         /// <summary>
@@ -309,32 +418,62 @@ namespace TileDB.CSharp
         /// attoseconds since the Unix epoch (January 1 1970 at midnight).
         /// </summary>
         /// <remarks>
+        /// <para>
         /// One second consists of one quintillion attoseconds.
+        /// </para>
+        /// <para>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </para>
         /// </remarks>
         DateTimeAttosecond = tiledb_datatype_t.TILEDB_DATETIME_AS,
         /// <summary>
         /// A time of day counted in hours.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         TimeHour = tiledb_datatype_t.TILEDB_TIME_HR,
         /// <summary>
         /// A time of day counted in minutes.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         TimeMinute = tiledb_datatype_t.TILEDB_TIME_MIN,
         /// <summary>
         /// A time of day counted in seconds.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         TimeSecond = tiledb_datatype_t.TILEDB_TIME_SEC,
         /// <summary>
         /// A time of day counted in milliseconds.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         TimeMillisecond = tiledb_datatype_t.TILEDB_TIME_MS,
         /// <summary>
         /// A time of day counted in microseconds.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         TimeMicrosecond = tiledb_datatype_t.TILEDB_TIME_US,
         /// <summary>
         /// A time of day counted in nanoseconds.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="long"/>.
+        /// </remarks>
         TimeNanosecond = tiledb_datatype_t.TILEDB_TIME_NS,
         /// <summary>
         /// A time of day counted in picoseconds.
@@ -349,12 +488,20 @@ namespace TileDB.CSharp
         /// </summary>
         TimeAttosecond = tiledb_datatype_t.TILEDB_TIME_AS,
         /// <summary>
-        /// A binary blob.
+        /// Binary data.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="byte"/>.
+        /// </remarks>
         Blob = tiledb_datatype_t.TILEDB_BLOB,
         /// <summary>
         /// A boolean value.
         /// </summary>
+        /// <remarks>
+        /// On generic methods operating to objects of this datatype,
+        /// this datatype can be used with <see cref="byte"/> or <see cref="bool"/>.
+        /// </remarks>
         Boolean = tiledb_datatype_t.TILEDB_BOOL
     }
 
@@ -1025,6 +1172,15 @@ namespace TileDB.CSharp
             }
         }
 
+        /// <summary>
+        /// Gets the corresponding <see cref="Type"/> of a <see cref="DataType"/>.
+        /// </summary>
+        /// <param name="datatype">The datatype to convert.</param>
+        /// <remarks>
+        /// Some data types like <see cref="DataType.Boolean"/> and <see cref="DataType.StringUtf16"/>
+        /// correspond to both a numeric type like <see cref="ushort"/> and a non-numeric type like <see cref="char"/>.
+        /// This method will return the numeric type.
+        /// </remarks>
         public static Type DataTypeToType(DataType datatype)
         {
             switch (datatype)
@@ -1056,10 +1212,12 @@ namespace TileDB.CSharp
                 case DataType.Int8:
                     return typeof(sbyte);
                 case DataType.StringAscii:
-                case DataType.StringUtf16:
-                case DataType.StringUtf32:
                 case DataType.StringUtf8:
-                    return typeof(sbyte);
+                    return typeof(byte);
+                case DataType.StringUtf16:
+                    return typeof(ushort);
+                case DataType.StringUtf32:
+                    return typeof(uint);
                 case DataType.TimeAttosecond:
                 case DataType.TimeFemtosecond:
                 case DataType.TimeHour:

--- a/sources/TileDB.CSharp/Enums.cs
+++ b/sources/TileDB.CSharp/Enums.cs
@@ -1115,6 +1115,7 @@ namespace TileDB.CSharp
         /// </summary>
         /// <param name="t">The type to convert.</param>
         /// <exception cref="NotSupportedException"><paramref name="t"/> is unsupported.</exception>
+        [Obsolete(Obsoletions.DataTypeTypeConversionsMessage, DiagnosticId = Obsoletions.DataTypeTypeConversionsDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static DataType TypeToDataType(Type t)
         {
             if (t == typeof(int))
@@ -1172,16 +1173,71 @@ namespace TileDB.CSharp
             }
         }
 
-        /// <summary>
-        /// Gets the corresponding <see cref="Type"/> of a <see cref="DataType"/>.
-        /// </summary>
-        /// <param name="datatype">The datatype to convert.</param>
-        /// <remarks>
-        /// Some data types like <see cref="DataType.Boolean"/> and <see cref="DataType.StringUtf16"/>
-        /// correspond to both a numeric type like <see cref="ushort"/> and a non-numeric type like <see cref="char"/>.
-        /// This method will return the numeric type.
-        /// </remarks>
+        [Obsolete(Obsoletions.DataTypeTypeConversionsMessage, DiagnosticId = Obsoletions.DataTypeTypeConversionsDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
         public static Type DataTypeToType(DataType datatype)
+        {
+            switch (datatype)
+            {
+                case DataType.DateTimeAttosecond:
+                case DataType.DateTimeDay:
+                case DataType.DateTimeFemtosecond:
+                case DataType.DateTimeHour:
+                case DataType.DateTimeMinute:
+                case DataType.DateTimeMonth:
+                case DataType.DateTimeMillisecond:
+                case DataType.DateTimeNanosecond:
+                case DataType.DateTimePicosecond:
+                case DataType.DateTimeSecond:
+                case DataType.DateTimeMicrosecond:
+                case DataType.DateTimeWeek:
+                case DataType.DateTimeYear:
+                    return typeof(long);
+                case DataType.Float32:
+                    return typeof(float);
+                case DataType.Float64:
+                    return typeof(double);
+                case DataType.Int16:
+                    return typeof(short);
+                case DataType.Int32:
+                    return typeof(int);
+                case DataType.Int64:
+                    return typeof(long);
+                case DataType.Int8:
+                    return typeof(sbyte);
+                case DataType.StringAscii:
+                case DataType.StringUtf16:
+                case DataType.StringUtf32:
+                case DataType.StringUtf8:
+                    return typeof(sbyte);
+                case DataType.TimeAttosecond:
+                case DataType.TimeFemtosecond:
+                case DataType.TimeHour:
+                case DataType.TimeMinute:
+                case DataType.TimeMillisecond:
+                case DataType.TimeNanosecond:
+                case DataType.TimePicosecond:
+                case DataType.TimeSecond:
+                case DataType.TimeMicrosecond:
+                    return typeof(long);
+                case DataType.UInt16:
+                    return typeof(ushort);
+                case DataType.UInt32:
+                    return typeof(uint);
+                case DataType.UInt64:
+                    return typeof(ulong);
+                case DataType.UInt8:
+                    return typeof(byte);
+                case DataType.Blob:
+                    return typeof(byte);
+                case DataType.Boolean:
+                    return typeof(byte);
+                default:
+                    return typeof(byte);
+            }
+        }
+
+        // Same with DataTypeToType, but returns the correct corresponding numeric type for strings.
+        internal static Type DataTypeToNumericType(DataType datatype)
         {
             switch (datatype)
             {

--- a/sources/TileDB.CSharp/ErrorHandling.cs
+++ b/sources/TileDB.CSharp/ErrorHandling.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
+using System.Text;
 using TileDB.Interop;
 
 namespace TileDB.CSharp
@@ -53,6 +54,40 @@ namespace TileDB.CSharp
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 ThrowHelpers.ThrowManagedType();
+            }
+        }
+
+        /// <summary>
+        /// Returns whether values of type <typeparamref name="T"/> can be stored or
+        /// retrieved from a TileDB buffer of type <paramref name="dataType"/>.
+        /// </summary>
+        private static unsafe bool AreTypesCompatible<T>(DataType dataType)
+        {
+            if (EnumUtil.DataTypeToType(dataType) == typeof(T))
+            {
+                return true;
+            }
+            if (typeof(T) == typeof(bool) && dataType == DataType.Boolean)
+            {
+                return true;
+            }
+            if (typeof(T) == typeof(char) && dataType == DataType.StringUtf16)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Throws if values of type <typeparamref name="T"/> cannot be stored or
+        /// retrieved from a TileDB buffer of type <paramref name="dataType"/>.
+        /// </summary>
+        public static void CheckDataType<T>(DataType dataType)
+        {
+            ThrowIfManagedType<T>();
+            if (!AreTypesCompatible<T>(dataType))
+            {
+                ThrowHelpers.ThrowTypeMismatch(dataType);
             }
         }
     }

--- a/sources/TileDB.CSharp/ErrorHandling.cs
+++ b/sources/TileDB.CSharp/ErrorHandling.cs
@@ -63,7 +63,7 @@ namespace TileDB.CSharp
         /// </summary>
         private static unsafe bool AreTypesCompatible<T>(DataType dataType)
         {
-            if (EnumUtil.DataTypeToType(dataType) == typeof(T))
+            if (EnumUtil.DataTypeToNumericType(dataType) == typeof(T))
             {
                 return true;
             }

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -411,13 +411,13 @@ namespace TileDB.CSharp
             DataType dataType = GetDimensionType(fragmentIndex, dimensionIndex);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                if (typeof(T) == typeof(string))
+                if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
                 {
                     (string startStr, string endStr) =
                         GetStringMinimumBoundedRectangle(fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, dataType);
                     return ((T)(object)startStr, (T)(object)endStr);
                 }
-                ThrowHelpers.ThrowTypeNotSupported();
+                ThrowHelpers.ThrowTypeMismatch(dataType);
                 return default;
             }
             ValidateDomainType<T>(dataType);
@@ -450,13 +450,13 @@ namespace TileDB.CSharp
             DataType dataType = GetDimensionType(fragmentIndex, dimensionName);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                if (typeof(T) == typeof(string))
+                if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
                 {
                     (string startStr, string endStr) =
                         GetStringMinimumBoundedRectangle(fragmentIndex, minimumBoundedRectangleIndex, dimensionName, dataType);
                     return ((T)(object)startStr, (T)(object)endStr);
                 }
-                ThrowHelpers.ThrowTypeNotSupported();
+                ThrowHelpers.ThrowTypeMismatch(dataType);
                 return default;
             }
             ValidateDomainType<T>(dataType);
@@ -536,12 +536,12 @@ namespace TileDB.CSharp
             DataType dataType = GetDimensionType(fragmentIndex, dimensionIndex);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                if (typeof(T) == typeof(string))
+                if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
                 {
                     (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionIndex, dataType);
                     return ((T)(object)startStr, (T)(object)endStr);
                 }
-                ThrowHelpers.ThrowTypeNotSupported();
+                ThrowHelpers.ThrowTypeMismatch(dataType);
                 return default;
             }
             ValidateDomainType<T>(dataType);
@@ -574,12 +574,12 @@ namespace TileDB.CSharp
             DataType dataType = GetDimensionType(fragmentIndex, dimensionName);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
-                if (typeof(T) == typeof(string))
+                if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
                 {
                     (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionName, dataType);
                     return ((T)(object)startStr, (T)(object)endStr);
                 }
-                ThrowHelpers.ThrowTypeNotSupported();
+                ThrowHelpers.ThrowTypeMismatch(dataType);
                 return default;
             }
             ValidateDomainType<T>(dataType);

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -409,7 +409,6 @@ namespace TileDB.CSharp
         public (T Start, T End) GetMinimumBoundedRectangle<T>(uint fragmentIndex, uint minimumBoundedRectangleIndex, uint dimensionIndex)
         {
             DataType dataType = GetDimensionType(fragmentIndex, dimensionIndex);
-            ValidateDomainType<T>(dataType);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 if (typeof(T) == typeof(string))
@@ -421,6 +420,7 @@ namespace TileDB.CSharp
                 ThrowHelpers.ThrowTypeNotSupported();
                 return default;
             }
+            ValidateDomainType<T>(dataType);
 
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -448,7 +448,6 @@ namespace TileDB.CSharp
         public (T Start, T End) GetMinimumBoundedRectangle<T>(uint fragmentIndex, uint minimumBoundedRectangleIndex, string dimensionName)
         {
             DataType dataType = GetDimensionType(fragmentIndex, dimensionName);
-            ValidateDomainType<T>(dataType);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 if (typeof(T) == typeof(string))
@@ -460,6 +459,7 @@ namespace TileDB.CSharp
                 ThrowHelpers.ThrowTypeNotSupported();
                 return default;
             }
+            ValidateDomainType<T>(dataType);
 
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -534,7 +534,6 @@ namespace TileDB.CSharp
         public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, uint dimensionIndex)
         {
             DataType dataType = GetDimensionType(fragmentIndex, dimensionIndex);
-            ValidateDomainType<T>(dataType);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 if (typeof(T) == typeof(string))
@@ -545,6 +544,7 @@ namespace TileDB.CSharp
                 ThrowHelpers.ThrowTypeNotSupported();
                 return default;
             }
+            ValidateDomainType<T>(dataType);
 
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -572,7 +572,6 @@ namespace TileDB.CSharp
         public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, string dimensionName)
         {
             DataType dataType = GetDimensionType(fragmentIndex, dimensionName);
-            ValidateDomainType<T>(dataType);
             if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
             {
                 if (typeof(T) == typeof(string))
@@ -583,6 +582,7 @@ namespace TileDB.CSharp
                 ThrowHelpers.ThrowTypeNotSupported();
                 return default;
             }
+            ValidateDomainType<T>(dataType);
 
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
@@ -653,10 +653,7 @@ namespace TileDB.CSharp
             {
                 ThrowHelpers.ThrowStringTypeMismatch(dataType);
             }
-            if (dataType != EnumUtil.TypeToDataType(typeof(T)))
-            {
-                ThrowHelpers.ThrowTypeMismatch(dataType);
-            }
+            ErrorHandling.CheckDataType<T>(dataType);
         }
 
         private DataType GetDimensionType(uint fragmentIndex, uint dimensionIndex)

--- a/sources/TileDB.CSharp/GroupMetadata.cs
+++ b/sources/TileDB.CSharp/GroupMetadata.cs
@@ -330,7 +330,7 @@ namespace TileDB.CSharp
         #region Private methods
         private void put_metadata<T>(string key, T[] value, tiledb_datatype_t tiledb_datatype) where T : struct
         {
-            ErrorHandling.ThrowIfManagedType<T>();
+            ErrorHandling.CheckDataType<T>((DataType)tiledb_datatype);
             if (string.IsNullOrEmpty(key) || value.Length == 0)
             {
                 throw new ArgumentException("ArrayMetadata.put_metadata, null or empty key-value!");

--- a/sources/TileDB.CSharp/Interop/SpanExtensions.cs
+++ b/sources/TileDB.CSharp/Interop/SpanExtensions.cs
@@ -8,7 +8,7 @@ using TileDB.CSharp;
 
 namespace TileDB.Interop
 {
-    [Obsolete(Obsoletions.TileDBInteropMessage, DiagnosticId = Obsoletions.TileDBInteropDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+    [Obsolete(Obsoletions.TileDBInterop2Message, DiagnosticId = Obsoletions.TileDBInterop2DiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static unsafe class SpanExtensions
     {

--- a/sources/TileDB.CSharp/Marshalling/MarshaledStringOut.cs
+++ b/sources/TileDB.CSharp/Marshalling/MarshaledStringOut.cs
@@ -5,7 +5,7 @@ using TileDB.CSharp;
 
 namespace TileDB.Interop
 {
-    [Obsolete(Obsoletions.TileDBInteropMessage, DiagnosticId = Obsoletions.TileDBInteropDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+    [Obsolete(Obsoletions.TileDBInterop2Message, DiagnosticId = Obsoletions.TileDBInterop2DiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
     [EditorBrowsable(EditorBrowsableState.Never)]
     public unsafe class LibC
     {

--- a/sources/TileDB.CSharp/Obsoletions.cs
+++ b/sources/TileDB.CSharp/Obsoletions.cs
@@ -41,5 +41,8 @@ namespace TileDB.CSharp
 
         public const string TileDBInterop2Message = "Members of the TileDB.Interop namespace should not be used by user code and will become internal in a future version.";
         public const string TileDBInterop2DiagId = "TILEDB0012";
+
+        public const string DataTypeTypeConversionsMessage = "The EnumUtils.TypeToDataType and EnumUtils.DataTypeToType methods are obsolete and will be removed in a future version.";
+        public const string DataTypeTypeConversionsDiagId = "TILEDB0013";
     }
 }

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -285,7 +285,7 @@ namespace TileDB.CSharp
             using (var schema = _array.Schema())
             using (var domain = schema.Domain())
             {
-                CheckDataType<T>(GetDataType(name, schema, domain));
+                ErrorHandling.CheckDataType<T>(GetDataType(name, schema, domain));
             }
 
             if (data.IsEmpty)
@@ -321,7 +321,7 @@ namespace TileDB.CSharp
             using (var schema = _array.Schema())
             using (var domain = schema.Domain())
             {
-                CheckDataType<T>(GetDataType(name, schema, domain));
+                ErrorHandling.CheckDataType<T>(GetDataType(name, schema, domain));
             }
 
             UnsafeSetDataBuffer(name, new MemoryHandle(data), size * (ulong)sizeof(T), sizeof(T));
@@ -929,18 +929,6 @@ namespace TileDB.CSharp
             ulong t2;
             _ctx.handle_error(Methods.tiledb_query_get_fragment_timestamp_range(ctxHandle, handle, idx, &t1, &t2));
             return new Tuple<ulong, ulong>(t1, t2);
-        }
-
-        private void CheckDataType<T>(DataType dataType)
-        {
-            if (EnumUtil.TypeToDataType(typeof(T)) != dataType)
-            {
-                if (!(dataType== DataType.StringAscii && (typeof(T)==typeof(byte) || typeof(T) == typeof(sbyte) || typeof(T) == typeof(string)))
-                   && !(dataType == DataType.Boolean && typeof(T) == typeof(byte)))
-                {
-                    throw new ArgumentException("T " + typeof(T).Name + " doesnot match " + dataType.ToString());
-                }
-            }
         }
 
         private static DataType GetDataType(string name, ArraySchema schema, Domain domain)

--- a/sources/TileDB.CSharp/Subarray.cs
+++ b/sources/TileDB.CSharp/Subarray.cs
@@ -118,13 +118,9 @@ namespace TileDB.CSharp
         public void SetSubarray<T>(ReadOnlySpan<T> data) where T : struct
         {
             ErrorHandling.ThrowIfManagedType<T>();
-            var dataType = EnumUtil.TypeToDataType(typeof(T));
             (var domainType, var nDim) = GetDomainInfo();
 
-            if (dataType != domainType)
-            {
-                ThrowHelpers.ThrowTypeMismatch(dataType);
-            }
+            ErrorHandling.CheckDataType<T>(domainType);
             if (data.Length != nDim * 2)
             {
                 ThrowHelpers.ThrowSubarrayLengthMismatch(nameof(data));
@@ -141,27 +137,19 @@ namespace TileDB.CSharp
         private void ValidateType<T>(string name) where T : struct
         {
             ErrorHandling.ThrowIfManagedType<T>();
-            var dataType = EnumUtil.TypeToDataType(typeof(T));
             using var schema = _array.Schema();
             using var domain = schema.Domain();
             using var dimension = domain.Dimension(name);
-            if (dimension.Type() != dataType)
-            {
-                ThrowHelpers.ThrowTypeMismatch(dataType);
-            }
+            ErrorHandling.CheckDataType<T>(dimension.Type());
         }
 
         private void ValidateType<T>(uint index) where T : struct
         {
             ErrorHandling.ThrowIfManagedType<T>();
-            var dataType = EnumUtil.TypeToDataType(typeof(T));
             using var schema = _array.Schema();
             using var domain = schema.Domain();
             using var dimension = domain.Dimension(index);
-            if (dimension.Type() != dataType)
-            {
-                ThrowHelpers.ThrowTypeMismatch(dataType);
-            }
+            ErrorHandling.CheckDataType<T>(dimension.Type());
         }
 
         /// <summary>

--- a/sources/TileDB.CSharp/ThrowHelpers.cs
+++ b/sources/TileDB.CSharp/ThrowHelpers.cs
@@ -17,11 +17,11 @@ namespace TileDB.CSharp
         // We don't have to specify the type in the type argument, it can be seen from the stacktrace.
         [DoesNotReturn]
         public static void ThrowTypeMismatch(DataType type) =>
-            throw new InvalidOperationException($"Type is not compatible with data type {type}.");
+            throw new ArgumentException($"Type is not compatible with data type {type}.");
 
         [DoesNotReturn]
         public static void ThrowStringTypeMismatch(DataType type) =>
-            throw new InvalidOperationException($"Cannot encode data type {type} into strings.");
+            throw new ArgumentException($"Cannot encode data type {type} into strings.");
 
         [DoesNotReturn]
         public static void ThrowTooBigSize(ulong size, [CallerArgumentExpression(nameof(size))] string? paramName = null) =>

--- a/sources/TileDB.CSharp/TileDB.CSharp.csproj
+++ b/sources/TileDB.CSharp/TileDB.CSharp.csproj
@@ -12,7 +12,7 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageValidationBaselineVersion>5.6.0</PackageValidationBaselineVersion>
-    <NoWarn>$(NoWarn);TILEDB0012</NoWarn>
+    <NoWarn>$(NoWarn);TILEDB0012;TILEDB0013</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -172,11 +172,11 @@ namespace TileDB.CSharp.Test
             Assert.AreEqual(("a", "bb"), info.GetMinimumBoundedRectangle<string>(0, 0, 0));
             Assert.AreEqual(("c", "ddd"), info.GetMinimumBoundedRectangle<string>(0, 1, "d"));
 
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<int>(0, 0, 0));
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<long>(0, 0, 0));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(0, 0, 0));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(0, 0, 0));
             Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<int>(0, 1, "d"));
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<long>(0, 1, "d"));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(0, 1, "d"));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(0, 1, "d"));
             Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 1, "d"));
         }
 
@@ -199,11 +199,11 @@ namespace TileDB.CSharp.Test
             Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<long>(0, 0, 0));
             Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<long>(1, 1, "d1"));
 
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<int>(0, 0, 0));
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<string>(0, 0, 0));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(0, 0, 0));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(0, 0, 0));
             Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<string>(1, 1, "d1"));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(1, 1, "d1"));
             Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(1, 1, "d1"));
         }
 
@@ -226,11 +226,11 @@ namespace TileDB.CSharp.Test
             Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<int>(0, 0, 0));
             Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
 
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<long>(0, 0, 0));
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<string>(0, 0, 0));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(0, 0, 0));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(0, 0, 0));
             Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<long>(1, 1, "d1"));
-            Assert.ThrowsException<InvalidOperationException>(() => info.GetMinimumBoundedRectangle<string>(1, 1, "d1"));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(1, 1, "d1"));
+            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(1, 1, "d1"));
             Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(1, 1, "d1"));
         }
 
@@ -268,8 +268,8 @@ namespace TileDB.CSharp.Test
                         (int Start, int End, _) => (Start, End)
                     };
                     Assert.AreEqual(expectedNonEmptyDomain, actualNonEmptyDomain);
-                    Assert.ThrowsException<InvalidOperationException>(() => info.GetNonEmptyDomain<long>(i, dim));
-                    Assert.ThrowsException<InvalidOperationException>(() => info.GetNonEmptyDomain<string>(i, dim));
+                    Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<long>(i, dim));
+                    Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<string>(i, dim));
                     Assert.ThrowsException<NotSupportedException>(() => info.GetNonEmptyDomain<Guid>(i, dim));
 
                     string name = d.Name();
@@ -279,8 +279,8 @@ namespace TileDB.CSharp.Test
                         (int Start, int End, _) => (Start, End)
                     };
                     Assert.AreEqual(expectedNonEmptyDomain, actualNonEmptyDomain);
-                    Assert.ThrowsException<InvalidOperationException>(() => info.GetNonEmptyDomain<long>(i, name));
-                    Assert.ThrowsException<InvalidOperationException>(() => info.GetNonEmptyDomain<string>(i, name));
+                    Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<long>(i, name));
+                    Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<string>(i, name));
                     Assert.ThrowsException<NotSupportedException>(() => info.GetNonEmptyDomain<Guid>(i, name));
                 }
             }

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -50,13 +50,13 @@ namespace TileDB.CSharp.Test
             {
                 using var subarray = new Subarray(array);
                 subarray.AddRange("rows", 1, 4);
-                Assert.ThrowsException<InvalidOperationException>(() => subarray.AddRange<long>("rows", 1, 4));
+                Assert.ThrowsException<ArgumentException>(() => subarray.AddRange<long>("rows", 1, 4));
                 Assert.AreEqual((1, 4), subarray.GetRange<int>("rows", 0));
-                Assert.ThrowsException<InvalidOperationException>(() => subarray.GetRange<long>("rows", 0));
+                Assert.ThrowsException<ArgumentException>(() => subarray.GetRange<long>("rows", 0));
                 subarray.AddRange(1, 1, 2); // cols
-                Assert.ThrowsException<InvalidOperationException>(() => subarray.AddRange<long>(1, 1, 2));
+                Assert.ThrowsException<ArgumentException>(() => subarray.AddRange<long>(1, 1, 2));
                 Assert.AreEqual((1, 2), subarray.GetRange<int>(1, 0));
-                Assert.ThrowsException<InvalidOperationException>(() => subarray.GetRange<long>(1, 0));
+                Assert.ThrowsException<ArgumentException>(() => subarray.GetRange<long>(1, 0));
                 queryWrite.SetSubarray(subarray);
                 queryWrite.SetDataReadOnlyBuffer<int>("a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8 }.AsMemory());
             }
@@ -181,8 +181,8 @@ namespace TileDB.CSharp.Test
             using (var subarray = new Subarray(array))
             {
                 subarray.SetSubarray<sbyte>(0, 1);
-                Assert.ThrowsException<InvalidOperationException>(() => subarray.SetSubarray(0, 1));
-                Assert.ThrowsException<InvalidOperationException>(() => subarray.SetSubarray(0));
+                Assert.ThrowsException<ArgumentException>(() => subarray.SetSubarray(0, 1));
+                Assert.ThrowsException<ArgumentException>(() => subarray.SetSubarray(0));
                 query.SetSubarray(subarray);
             }
 


### PR DESCRIPTION
[SC-24612](https://app.shortcut.com/tiledb-inc/story/26412/reconsider-the-rules-of-generic-type-validation)

The C# API's rules around type validation in its generic methods have some defects that prevent datetime types and non-ASCII strings from being used. This PR improves the type validation to fix these cases.

### Summary of changes

* When performing type validation, instead of converting the .NET `Type` to a TileDB `DataType` and compare them, we do the opposite. This happens because (with few exceptions), the mapping between .NET types and TileDB data types is one-to-many, and so by "narrowing down" we can validate that datetime data types match with `long`, while `long` maps to `DataType.Int64`.
  * The validation logic was centralized in the `ErrorHandling.CheckDataType`. It accepts a generic type parameter and a `DataType` regular parameter, and fails if they are incompatible.
* There are two special cases for validation: `DataType.Boolean` and `StringUtf16`. Besides `byte` and `ushort`, they can also match with `bool` and `char` (in .NET it's 2 bytes long) respectively.
  * We could do the same with `StringUtf32` and `System.Text.Rune`, but the Core must validate that UTF-32 strings contain valid Unicode codepoints (if it already does, please let me know).
* _Behavior breaking change:_ The `EnumUtil.DataTypeToType` method mapped all string `DataType`s to `sbyte`, which is an obviously wrong behavior, and inconsistent with what the C++ API does. This PR changes it to map ASCII and UTF-8 strings to `byte`, UTF-16 strings to `ushort`, and UTF-32 strings to `uint`.
  * In case of `DataType`s with multiple valid types (like `StringUtf16` and `Boolean`), `DataTypeToType` returns the matching _numeric_ type.
* _Minor behavior breaking change:_ Some generic methods throw `ArgumentException` which is more appropriate than `InvalidOperationException`. Not commonly expected to hit, but worth mentioning.