### PR TITLE
Add more overloads to set query data buffers without type validation.

### DIFF
--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -372,6 +372,23 @@ namespace TileDB.CSharp
         }
 
         /// <summary>
+        /// Sets the data buffer for an attribute or dimension to a
+        /// byte buffer without performing type validation.
+        /// </summary>
+        /// <param name="name">The name of the attribute or the dimension.</param>
+        /// <param name="data">A <see cref="Memory{T}"/> of bytes pointing to the buffer.</param>
+        /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+        public void UnsafeSetDataBuffer(string name, Memory<byte> data)
+        {
+            if (data.IsEmpty)
+            {
+                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(data));
+            }
+
+            UnsafeSetDataBuffer(name, data.Pin(), (ulong)data.Length, 0);
+        }
+
+        /// <summary>
         /// Sets the data buffer for an attribute or dimension
         /// to a pinned memory buffer pointed by a <see cref="MemoryHandle"/>.
         /// This method does not perform type validation.
@@ -421,6 +438,25 @@ namespace TileDB.CSharp
                     handle?.Dispose();
                 }
             }
+        }
+
+        /// <summary>
+        /// Sets the data buffer for an attribute or dimension to a
+        /// read-only byte buffer without performing type validation.
+        /// Not supported for <see cref="QueryType.Read"/> queries.
+        /// </summary>
+        /// <param name="name">The name of the attribute or the dimension.</param>
+        /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> of bytes pointing to the buffer.</param>
+        /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+        /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
+        public void UnsafeSetDataReadOnlyBuffer(string name, ReadOnlyMemory<byte> data)
+        {
+            if (QueryType() == CSharp.QueryType.Read)
+            {
+                ThrowHelpers.ThrowOperationNotAllowedOnReadQueries();
+            }
+
+            UnsafeSetDataBuffer(name, MemoryMarshal.AsMemory(data));
         }
 
         private void SetDataBufferCore(string name, void* data, ulong* size)

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -368,7 +368,7 @@ namespace TileDB.CSharp
                 ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(byteSize));
             }
 
-            UnsafeSetDataBuffer(name, new MemoryHandle(data), byteSize);
+            UnsafeSetDataBuffer(name, new MemoryHandle(data), byteSize, 0);
         }
 
         /// <summary>
@@ -390,8 +390,15 @@ namespace TileDB.CSharp
         /// <item>This method call throws an exception.</item>
         /// </list></para>
         /// </remarks>
-        public void UnsafeSetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize) =>
+        public void UnsafeSetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize)
+        {
+            if (byteSize == 0)
+            {
+                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(byteSize));
+            }
+
             UnsafeSetDataBuffer(name, memoryHandle, byteSize, 0);
+        }
 
         private void UnsafeSetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize, int elementSize)
         {

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -509,7 +509,8 @@ namespace TileDB.CSharp.Test
                 query_read.SetOffsetsBuffer("a2", a2_off_read);
                 query_read.SetValidityBuffer("a2", a2_validity_read);
 
-                query_read.UnsafeSetDataBuffer("a3", a3_data_read.AsMemory().Pin(), (ulong)a3_data_read.Length * sizeof(byte));
+                query_read.UnsafeSetDataBuffer("a3", a3_data_read.AsMemory());
+                Assert.ThrowsException<ArgumentException>(() => query_read.UnsafeSetDataBuffer("a3", default(MemoryHandle), 0));
                 query_read.SetOffsetsBuffer("a3", a3_off_read);
                 query_read.SetValidityBuffer("a3", a3_validity_read);
 

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -459,6 +459,7 @@ namespace TileDB.CSharp.Test
 
                 query_write.SetDataBuffer("a1", a1_data_ptr, (ulong)a1_data.Length);
                 query_write.SetValidityBuffer("a1", a1_validity);
+                Assert.ThrowsException<ArgumentException>(() => query_write.UnsafeSetDataReadOnlyBuffer("a1", ReadOnlyMemory<byte>.Empty));
 
                 query_write.UnsafeSetDataBuffer("a2", (void*)a2_data_ptr, (ulong)a2_data.Length * sizeof(int));
                 query_write.SetOffsetsBuffer("a2", a2_off_ptr, (ulong)a2_off.Length);


### PR DESCRIPTION
The existing overloads of `Query.UnsafeSetDataBuffer` are memory-unsafe because they deal with raw pointers or their equivalents (`MemoryHandle`). This PR adds overloads that accept a `Memory<byte>` and `ReadOnlyMemory<byte>` (the latter for write queries only). They pin the buffers and pass them to the Core, without performing type validation.