### PR TITLE
Fix schema evolution delete test.

### DIFF
--- a/tests/TileDB.CSharp.Test/DeletesTest.cs
+++ b/tests/TileDB.CSharp.Test/DeletesTest.cs
@@ -492,6 +492,8 @@ namespace TileDB.CSharp.Test
             array.Evolve(schemaEvolution2);
             Logger.LogMessage($"Schema after removing attribute (a2)");
             TestUtil.PrintLocalSchema(array.Uri());
+            array.SetOpenTimestampStart(0);
+            array.SetOpenTimestampEnd(ulong.MaxValue);
             array.Open(QueryType.Read);
             Assert.IsFalse(array.Schema().HasAttribute("a2"));
             array.Close();


### PR DESCRIPTION
[SC-38119](https://app.shortcut.com/tiledb-inc/story/38119/dropping-an-attribute-seemingly-has-no-effect)

TileDB-Inc/TileDB#4549 fixed array time travelling to honor the starting and ending timestamps when opening the schema.
In the test the array's timestamp had been set by a previous call to `TestUtil.ReadArray` in a range that excluded the remaining attribute.

This PR resets the timestamp range before writing the array schema. The test has been verified to be fixed on my machine.

Fixes #334
Fixes #335
Fixes #337