### PR TITLE
Assert only that MemFS is supported.

### DIFF
--- a/tests/TileDB.CSharp.Test/ContextTest.cs
+++ b/tests/TileDB.CSharp.Test/ContextTest.cs
@@ -58,10 +58,9 @@ namespace TileDB.CSharp.Test
         {
             using var ctx = new Context();
             Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.InMemory));
-            Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.S3));
-            Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.Azure));
-            Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.GoogleCloudStorage));
-            Assert.AreEqual(!OperatingSystem.IsWindows(), ctx.IsFileSystemSupported(FileSystemType.Hdfs));
+            // While the release binaries support all other filesystems (except for
+            // HDFS), binaries from nightly builds and other custom builds may not.
+            // MemFS is the only filesystem that is known to be always supported.
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes nightly build failures when the Core is not built with cloud backends enabled.

Fixes #348.
Fixes #349.
Fixes #350.