### PR TITLE
Disable AVX2 on nightly builds.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         include:
-          - BOOTSTRAP: ../bootstrap --enable-s3 --enable-serialization --force-build-all-deps --enable-vcpkg
+          - BOOTSTRAP: ../bootstrap --enable-s3 --enable-serialization --disable-avx2 --enable-vcpkg
           - os: ubuntu-latest
             platform: linux-x86_64
           - os: macos-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
             platform: macos-x86_64
           - os: windows-latest
             platform: windows-x86_64
-            BOOTSTRAP: ../bootstrap.ps1 -EnableS3 -EnableSerialization -EnableBuildDeps -EnableVcpkg
+            BOOTSTRAP: ../bootstrap.ps1 -EnableS3 -EnableSerialization -EnableVcpkg
           - tag: dev
         tag: [release-2.18, dev]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Because building the Core and running the C# tests happens on separate jobs, they might run on a different machine. If the building machine supports AVX2 and the testing machine does not, the latter will fail with an invalid opcode error.

This is my latest theory on why the macOS nightly builds often fail, especially since nightly builds on other TileDB projects also fail on macOS. With this PR we always disable AVX2 when building the Core.

If this PR gets merged and we don't get a related nightly failure for two weeks, I will consider the failures fixed and will close all relevant issues.