### PR TITLE
Update to the .NET 8 SDK and use some new C# features.

### DIFF
--- a/examples/TileDB.CSharp.Example/ExampleAggregateQuery.cs
+++ b/examples/TileDB.CSharp.Example/ExampleAggregateQuery.cs
@@ -48,8 +48,8 @@ namespace TileDB.CSharp.Examples
 
         private static void ReadArray()
         {
-            ulong[] count = { 0 };
-            long[] sum = { 0 };
+            ulong[] count = [0];
+            long[] sum = [0];
 
             using (var array_read = new Array(Ctx, ArrayPath))
             {

--- a/examples/TileDB.CSharp.Example/ExampleAggregateQuery.cs
+++ b/examples/TileDB.CSharp.Example/ExampleAggregateQuery.cs
@@ -1,84 +1,83 @@
 using System;
 using System.IO;
 
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+static class ExampleAggregateQuery
 {
-    static class ExampleAggregateQuery
+    private static readonly string ArrayPath = ExampleUtil.MakeExamplePath("aggregate-array");
+    private static readonly Context Ctx = Context.GetDefault();
+
+    private static void CreateArray()
     {
-        private static readonly string ArrayPath = ExampleUtil.MakeExamplePath("aggregate-array");
-        private static readonly Context Ctx = Context.GetDefault();
+        // Create array
+        var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 4, extent: 4);
+        var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 4, extent: 4);
+        var domain = new Domain(Ctx);
+        domain.AddDimension(dim1);
+        domain.AddDimension(dim2);
+        var array_schema = new ArraySchema(Ctx, ArrayType.Sparse);
+        var attr = new Attribute(Ctx, "a", DataType.Int32);
+        array_schema.AddAttribute(attr);
+        array_schema.SetDomain(domain);
+        array_schema.Check();
 
-        private static void CreateArray()
+        Array.Create(Ctx, ArrayPath, array_schema);
+    }
+
+    private static void WriteArray()
+    {
+        using (var array_write = new Array(Ctx, ArrayPath))
         {
-            // Create array
-            var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 4, extent: 4);
-            var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 4, extent: 4);
-            var domain = new Domain(Ctx);
-            domain.AddDimension(dim1);
-            domain.AddDimension(dim2);
-            var array_schema = new ArraySchema(Ctx, ArrayType.Sparse);
-            var attr = new Attribute(Ctx, "a", DataType.Int32);
-            array_schema.AddAttribute(attr);
-            array_schema.SetDomain(domain);
-            array_schema.Check();
-
-            Array.Create(Ctx, ArrayPath, array_schema);
-        }
-
-        private static void WriteArray()
-        {
-            using (var array_write = new Array(Ctx, ArrayPath))
+            array_write.Open(QueryType.Write);
+            using (var query_write = new Query(array_write))
             {
-                array_write.Open(QueryType.Write);
-                using (var query_write = new Query(array_write))
-                {
-                    query_write.SetLayout(LayoutType.GlobalOrder);
-                    query_write.SetDataBuffer("rows", new int[] { 1, 2 });
-                    query_write.SetDataBuffer("cols", new int[] { 1, 4 });
-                    query_write.SetDataBuffer("a", new int[] { 1, 2 });
-                    query_write.Submit();
-                    query_write.SetDataBuffer("rows", new int[] { 3 });
-                    query_write.SetDataBuffer("cols", new int[] { 3 });
-                    query_write.SetDataBuffer("a", new int[] { 3 });
-                    query_write.SubmitAndFinalize();
-                }
-                array_write.Close();
+                query_write.SetLayout(LayoutType.GlobalOrder);
+                query_write.SetDataBuffer("rows", new int[] { 1, 2 });
+                query_write.SetDataBuffer("cols", new int[] { 1, 4 });
+                query_write.SetDataBuffer("a", new int[] { 1, 2 });
+                query_write.Submit();
+                query_write.SetDataBuffer("rows", new int[] { 3 });
+                query_write.SetDataBuffer("cols", new int[] { 3 });
+                query_write.SetDataBuffer("a", new int[] { 3 });
+                query_write.SubmitAndFinalize();
             }
+            array_write.Close();
         }
+    }
 
-        private static void ReadArray()
+    private static void ReadArray()
+    {
+        ulong[] count = [0];
+        long[] sum = [0];
+
+        using (var array_read = new Array(Ctx, ArrayPath))
         {
-            ulong[] count = [0];
-            long[] sum = [0];
-
-            using (var array_read = new Array(Ctx, ArrayPath))
-            {
-                array_read.Open(QueryType.Read);
-                using var query_read = new Query(array_read);
-                query_read.SetLayout(LayoutType.Unordered);
-                using var channel = query_read.GetDefaultChannel();
-                channel.ApplyAggregate(AggregateOperation.Count, "Count");
-                channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.Sum, "a"), "Sum");
-                query_read.SetDataBuffer("Count", count);
-                query_read.SetDataBuffer("Sum", sum);
-                query_read.Submit();
-                array_read.Close();
-            }
-
-            Console.WriteLine($"Count: {count[0]}");
-            Console.WriteLine($"Sum: {sum[0]}");
+            array_read.Open(QueryType.Read);
+            using var query_read = new Query(array_read);
+            query_read.SetLayout(LayoutType.Unordered);
+            using var channel = query_read.GetDefaultChannel();
+            channel.ApplyAggregate(AggregateOperation.Count, "Count");
+            channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.Sum, "a"), "Sum");
+            query_read.SetDataBuffer("Count", count);
+            query_read.SetDataBuffer("Sum", sum);
+            query_read.Submit();
+            array_read.Close();
         }
 
-        public static void Run()
+        Console.WriteLine($"Count: {count[0]}");
+        Console.WriteLine($"Sum: {sum[0]}");
+    }
+
+    public static void Run()
+    {
+        if (Directory.Exists(ArrayPath))
         {
-            if (Directory.Exists(ArrayPath))
-            {
-                Directory.Delete(ArrayPath, true);
-            }
-
-            CreateArray();
-            WriteArray();
-            ReadArray();
+            Directory.Delete(ArrayPath, true);
         }
+
+        CreateArray();
+        WriteArray();
+        ReadArray();
     }
 }

--- a/examples/TileDB.CSharp.Example/ExampleDataframe.cs
+++ b/examples/TileDB.CSharp.Example/ExampleDataframe.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -18,9 +18,17 @@ namespace TileDB.CSharp.Examples
             }
             CreateArray(ctx, arrayUri);
 
-            string[] names = { "Adam", "Bree", "Charles", "Dianna", "Evan", "Fiona", "Gabe", "Hannah", "Isidore", "Julia" };
-            DateTime[] dobs = { new DateTime(1990, 1, 1), new DateTime(1991, 2, 2), new DateTime(1992, 3, 3), new DateTime(1993, 4, 4), new DateTime(1994, 5, 5),
-                new DateTime(1995, 6, 6), new DateTime(1996, 7, 7), new DateTime(1997, 8, 8), new DateTime(1998, 9, 9), new DateTime(1999, 10, 10) };
+            string[] names = ["Adam", "Bree", "Charles", "Dianna", "Evan", "Fiona", "Gabe", "Hannah", "Isidore", "Julia"];
+            DateTime[] dobs = [new DateTime(1990, 1, 1),
+                new DateTime(1991, 2, 2),
+                new DateTime(1992, 3, 3),
+                new DateTime(1993, 4, 4),
+                new DateTime(1994, 5, 5),
+                new DateTime(1995, 6, 6),
+                new DateTime(1996, 7, 7),
+                new DateTime(1997, 8, 8),
+                new DateTime(1998, 9, 9),
+                new DateTime(1999, 10, 10)];
             Write(ctx, arrayUri, 0, names, dobs);
 
             foreach (var x in Read(ctx, arrayUri, 0, 9))

--- a/examples/TileDB.CSharp.Example/ExampleDataframe.cs
+++ b/examples/TileDB.CSharp.Example/ExampleDataframe.cs
@@ -4,124 +4,123 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S6562:Always set the \"DateTimeKind\" when creating new \"DateTime\" instances", Justification = "Excessive for this example; the dates' kind will not be converted")]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S6588:Use the \"UnixEpoch\" field instead of creating \"DateTime\" instances that point to the beginning of the Unix epoch", Justification = "DateTime.UnixEpoch is unavailable in .NET 5")]
+internal static class ExampleDataframe
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S6562:Always set the \"DateTimeKind\" when creating new \"DateTime\" instances", Justification = "Excessive for this example; the dates' kind will not be converted")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S6588:Use the \"UnixEpoch\" field instead of creating \"DateTime\" instances that point to the beginning of the Unix epoch", Justification = "DateTime.UnixEpoch is unavailable in .NET 5")]
-    internal static class ExampleDataframe
+    public static void Run()
     {
-        public static void Run()
+        using var ctx = new Context();
+        const string arrayUri = "dataframe_array";
+        if (Directory.Exists(arrayUri))
         {
-            using var ctx = new Context();
-            const string arrayUri = "dataframe_array";
-            if (Directory.Exists(arrayUri))
-            {
-                Directory.Delete(arrayUri, true);
-            }
-            CreateArray(ctx, arrayUri);
-
-            string[] names = ["Adam", "Bree", "Charles", "Dianna", "Evan", "Fiona", "Gabe", "Hannah", "Isidore", "Julia"];
-            DateTime[] dobs = [new DateTime(1990, 1, 1),
-                new DateTime(1991, 2, 2),
-                new DateTime(1992, 3, 3),
-                new DateTime(1993, 4, 4),
-                new DateTime(1994, 5, 5),
-                new DateTime(1995, 6, 6),
-                new DateTime(1996, 7, 7),
-                new DateTime(1997, 8, 8),
-                new DateTime(1998, 9, 9),
-                new DateTime(1999, 10, 10)];
-            Write(ctx, arrayUri, 0, names, dobs);
-
-            foreach (var x in Read(ctx, arrayUri, 0, 9))
-            {
-                Console.WriteLine($"ID: {x.Id}, Name: {x.Name}, Date of birth: {x.DateOfBirth:d}");
-            }
+            Directory.Delete(arrayUri, true);
         }
+        CreateArray(ctx, arrayUri);
 
-        static void CreateArray(Context ctx, string uri)
+        string[] names = ["Adam", "Bree", "Charles", "Dianna", "Evan", "Fiona", "Gabe", "Hannah", "Isidore", "Julia"];
+        DateTime[] dobs = [new DateTime(1990, 1, 1),
+            new DateTime(1991, 2, 2),
+            new DateTime(1992, 3, 3),
+            new DateTime(1993, 4, 4),
+            new DateTime(1994, 5, 5),
+            new DateTime(1995, 6, 6),
+            new DateTime(1996, 7, 7),
+            new DateTime(1997, 8, 8),
+            new DateTime(1998, 9, 9),
+            new DateTime(1999, 10, 10)];
+        Write(ctx, arrayUri, 0, names, dobs);
+
+        foreach (var x in Read(ctx, arrayUri, 0, 9))
         {
-            using var schema = new ArraySchema(ctx, ArrayType.Dense);
-            using var domain = new Domain(ctx);
-            using var dimension = Dimension.Create<ulong>(ctx, "id", 0, ulong.MaxValue - 1, 1);
-            domain.AddDimension(dimension);
-            schema.SetDomain(domain);
-            using var attrName = new Attribute(ctx, "name", DataType.StringUtf8);
-            attrName.SetCellValNum(Attribute.VariableSized);
-            using var attrDob = new Attribute(ctx, "dob", DataType.DateTimeDay);
-            schema.AddAttributes(attrName);
-            schema.AddAttributes(attrDob);
-            Array.Create(ctx, uri, schema);
+            Console.WriteLine($"ID: {x.Id}, Name: {x.Name}, Date of birth: {x.DateOfBirth:d}");
         }
+    }
 
-        static void Write(Context ctx, string uri, ulong idStart, string[] names, DateTime[] dobs)
+    static void CreateArray(Context ctx, string uri)
+    {
+        using var schema = new ArraySchema(ctx, ArrayType.Dense);
+        using var domain = new Domain(ctx);
+        using var dimension = Dimension.Create<ulong>(ctx, "id", 0, ulong.MaxValue - 1, 1);
+        domain.AddDimension(dimension);
+        schema.SetDomain(domain);
+        using var attrName = new Attribute(ctx, "name", DataType.StringUtf8);
+        attrName.SetCellValNum(Attribute.VariableSized);
+        using var attrDob = new Attribute(ctx, "dob", DataType.DateTimeDay);
+        schema.AddAttributes(attrName);
+        schema.AddAttributes(attrDob);
+        Array.Create(ctx, uri, schema);
+    }
+
+    static void Write(Context ctx, string uri, ulong idStart, string[] names, DateTime[] dobs)
+    {
+        using var array = new Array(ctx, uri);
+        array.Open(QueryType.Write);
+        using var query = new Query(array);
+        query.SetLayout(LayoutType.RowMajor);
+        using var subarray = new Subarray(array);
+        subarray.AddRange(0, idStart, idStart + (ulong)names.Length - 1);
+        query.SetSubarray(subarray);
+        var (nameData, nameOffsets) = CoreUtil.PackStringArray(names);
+        query.SetDataBuffer("name", nameData);
+        query.SetOffsetsBuffer("name", nameOffsets);
+        query.SetDataBuffer("dob", dobs.Select(x => (long)(x - new DateTime(1970, 1, 1)).Days).ToArray());
+        query.Submit();
+    }
+
+    static IEnumerable<(ulong Id, string Name, DateTime DateOfBirth)> Read(Context ctx, string uri, ulong idStart, ulong count)
+    {
+        using var array = new Array(ctx, uri);
+        array.Open(QueryType.Read);
+        (ulong minElement, ulong maxElement, bool isEmpty) = array.NonEmptyDomain<ulong>("id");
+        if (isEmpty)
         {
-            using var array = new Array(ctx, uri);
-            array.Open(QueryType.Write);
-            using var query = new Query(array);
-            query.SetLayout(LayoutType.RowMajor);
-            using var subarray = new Subarray(array);
-            subarray.AddRange(0, idStart, idStart + (ulong)names.Length - 1);
-            query.SetSubarray(subarray);
-            var (nameData, nameOffsets) = CoreUtil.PackStringArray(names);
-            query.SetDataBuffer("name", nameData);
-            query.SetOffsetsBuffer("name", nameOffsets);
-            query.SetDataBuffer("dob", dobs.Select(x => (long)(x - new DateTime(1970, 1, 1)).Days).ToArray());
+            yield break;
+        }
+        idStart = Math.Max(idStart, minElement);
+        ulong idEnd = Math.Min(idStart + count, maxElement);
+        using var query = new Query(array);
+        query.SetLayout(LayoutType.RowMajor);
+        using var subarray = new Subarray(array);
+        subarray.AddRange(0, idStart, idEnd);
+        query.SetSubarray(subarray);
+
+        byte[] nameData = new byte[512];
+        ulong[] nameOffsets = new ulong[16];
+        long[] dobs = new long[16];
+        query.SetDataBuffer("name", nameData);
+        query.SetOffsetsBuffer("name", nameOffsets);
+        query.SetDataBuffer("dob", dobs);
+        ulong currentId = idStart;
+        // Loop until the query completes or fails.
+        while (query.Status() is not (QueryStatus.Failed or QueryStatus.Completed))
+        {
             query.Submit();
-        }
-
-        static IEnumerable<(ulong Id, string Name, DateTime DateOfBirth)> Read(Context ctx, string uri, ulong idStart, ulong count)
-        {
-            using var array = new Array(ctx, uri);
-            array.Open(QueryType.Read);
-            (ulong minElement, ulong maxElement, bool isEmpty) = array.NonEmptyDomain<ulong>("id");
-            if (isEmpty)
+            var dataCount = (int)query.GetResultDataBytes("name");
+            // The count of offsets for the variable-length attribute "name"
+            // essentially tells us how many cells were returned.
+            var offsetCount = (int)query.GetResultOffsets("name");
+            // If zero cells were returned, check if the reason was that the
+            // buffers were too small, resize them, and try again.
+            if (offsetCount == 0 && query.GetStatusDetails().Reason == QueryStatusDetailsReason.UserBufferSize)
             {
-                yield break;
+                System.Array.Resize(ref nameData, nameData.Length * 2);
+                System.Array.Resize(ref nameOffsets, nameOffsets.Length * 2);
+                System.Array.Resize(ref dobs, dobs.Length * 2);
+                query.SetDataBuffer("name", nameData);
+                query.SetOffsetsBuffer("name", nameOffsets);
+                query.SetDataBuffer("dob", dobs);
+                continue;
             }
-            idStart = Math.Max(idStart, minElement);
-            ulong idEnd = Math.Min(idStart + count, maxElement);
-            using var query = new Query(array);
-            query.SetLayout(LayoutType.RowMajor);
-            using var subarray = new Subarray(array);
-            subarray.AddRange(0, idStart, idEnd);
-            query.SetSubarray(subarray);
-
-            byte[] nameData = new byte[512];
-            ulong[] nameOffsets = new ulong[16];
-            long[] dobs = new long[16];
-            query.SetDataBuffer("name", nameData);
-            query.SetOffsetsBuffer("name", nameOffsets);
-            query.SetDataBuffer("dob", dobs);
-            ulong currentId = idStart;
-            // Loop until the query completes or fails.
-            while (query.Status() is not (QueryStatus.Failed or QueryStatus.Completed))
+            for (int i = 0; i < offsetCount; i++)
             {
-                query.Submit();
-                var dataCount = (int)query.GetResultDataBytes("name");
-                // The count of offsets for the variable-length attribute "name"
-                // essentially tells us how many cells were returned.
-                var offsetCount = (int)query.GetResultOffsets("name");
-                // If zero cells were returned, check if the reason was that the
-                // buffers were too small, resize them, and try again.
-                if (offsetCount == 0 && query.GetStatusDetails().Reason == QueryStatusDetailsReason.UserBufferSize)
-                {
-                    System.Array.Resize(ref nameData, nameData.Length * 2);
-                    System.Array.Resize(ref nameOffsets, nameOffsets.Length * 2);
-                    System.Array.Resize(ref dobs, dobs.Length * 2);
-                    query.SetDataBuffer("name", nameData);
-                    query.SetOffsetsBuffer("name", nameOffsets);
-                    query.SetDataBuffer("dob", dobs);
-                    continue;
-                }
-                for (int i = 0; i < offsetCount; i++)
-                {
-                    var offset = (int)nameOffsets[i];
-                    var offsetOfNext = i < offsetCount - 1 ? (int)nameOffsets[i + 1] : dataCount;
-                    var name = Encoding.ASCII.GetString(nameData.AsSpan(offset, offsetOfNext - offset));
-                    var dob = new DateTime(1970, 1, 1).AddDays(dobs[i]);
-                    yield return (currentId++, name, dob);
-                }
+                var offset = (int)nameOffsets[i];
+                var offsetOfNext = i < offsetCount - 1 ? (int)nameOffsets[i + 1] : dataCount;
+                var name = Encoding.ASCII.GetString(nameData.AsSpan(offset, offsetOfNext - offset));
+                var dob = new DateTime(1970, 1, 1).AddDays(dobs[i]);
+                yield return (currentId++, name, dob);
             }
         }
     }

--- a/examples/TileDB.CSharp.Example/ExampleDataframe.cs
+++ b/examples/TileDB.CSharp.Example/ExampleDataframe.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,6 +6,8 @@ using System.Text;
 
 namespace TileDB.CSharp.Examples
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S6562:Always set the \"DateTimeKind\" when creating new \"DateTime\" instances", Justification = "Excessive for this example; the dates' kind will not be converted")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Minor Code Smell", "S6588:Use the \"UnixEpoch\" field instead of creating \"DateTime\" instances that point to the beginning of the Unix epoch", Justification = "DateTime.UnixEpoch is unavailable in .NET 5")]
     internal static class ExampleDataframe
     {
         public static void Run()

--- a/examples/TileDB.CSharp.Example/ExampleFile.cs
+++ b/examples/TileDB.CSharp.Example/ExampleFile.cs
@@ -2,130 +2,129 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+public class ExampleFile
 {
-    public class ExampleFile
+    private readonly Context _ctx;
+    private readonly string _nameSpace;
+
+    // Local access
+    public ExampleFile()
     {
-        private readonly Context _ctx;
-        private readonly string _nameSpace;
+        _ctx = Context.GetDefault();
+        _nameSpace = String.Empty;
+    }
 
-        // Local access
-        public ExampleFile()
+    // S3 access
+    public ExampleFile(string key, string secret)
+    {
+        var config = new Config();
+        config.Set("vfs.s3.aws_access_key_id", key);
+        config.Set("vfs.s3.aws_secret_access_key", secret);
+        _ctx = new Context(config);
+        _nameSpace = String.Empty;
+    }
+
+    // TileDB Cloud access with token
+    public ExampleFile(string host, string token, string nameSpace)
+    {
+        var config = new Config();
+        config.Set("rest.server_address", host);
+        config.Set("rest.token", token);
+        _ctx = new Context(config);
+        _nameSpace = nameSpace;
+    }
+
+    // TileDB Cloud access with basic authentication
+    public ExampleFile(string host, string username, string password, string nameSpace)
+    {
+        var config = new Config();
+        config.Set("rest.server_address", host);
+        config.Set("rest.username", username);
+        config.Set("rest.password", password);
+        _ctx = new Context(config);
+        _nameSpace = nameSpace;
+    }
+
+    public void SaveFileToArray(string pathOrBucket, string arrayName, string fileToSave)
+    {
+        var arrayURI = string.Join("/", new List<string>(new string[] {pathOrBucket, arrayName}));
+
+        // If no fileToSave exists, create one with some text data
+        if (!System.IO.File.Exists(fileToSave))
         {
-            _ctx = Context.GetDefault();
-            _nameSpace = String.Empty;
+            System.IO.File.WriteAllText(fileToSave, "Some text data");
         }
 
-        // S3 access
-        public ExampleFile(string key, string secret)
+        if (_nameSpace == String.Empty)
         {
-            var config = new Config();
-            config.Set("vfs.s3.aws_access_key_id", key);
-            config.Set("vfs.s3.aws_secret_access_key", secret);
-            _ctx = new Context(config);
-            _nameSpace = String.Empty;
-        }
-
-        // TileDB Cloud access with token
-        public ExampleFile(string host, string token, string nameSpace)
-        {
-            var config = new Config();
-            config.Set("rest.server_address", host);
-            config.Set("rest.token", token);
-            _ctx = new Context(config);
-            _nameSpace = nameSpace;
-        }
-
-        // TileDB Cloud access with basic authentication
-        public ExampleFile(string host, string username, string password, string nameSpace)
-        {
-            var config = new Config();
-            config.Set("rest.server_address", host);
-            config.Set("rest.username", username);
-            config.Set("rest.password", password);
-            _ctx = new Context(config);
-            _nameSpace = nameSpace;
-        }
-
-        public void SaveFileToArray(string pathOrBucket, string arrayName, string fileToSave)
-        {
-            var arrayURI = string.Join("/", new List<string>(new string[] {pathOrBucket, arrayName}));
-
-            // If no fileToSave exists, create one with some text data
-            if (!System.IO.File.Exists(fileToSave))
+            // If exported array exists, recreate it
+            if (Directory.Exists(arrayURI))
             {
-                System.IO.File.WriteAllText(fileToSave, "Some text data");
+                Directory.Delete(arrayURI, true);
             }
 
-            if (_nameSpace == String.Empty)
-            {
-                // If exported array exists, recreate it
-                if (Directory.Exists(arrayURI))
-                {
-                    Directory.Delete(arrayURI, true);
-                }
-
-                FileStoreUtil.SaveFileToArray(_ctx, arrayURI, fileToSave);
-                return;
-            }
-
-            FileStoreUtil.SaveFileToCloudArray(_ctx, _nameSpace, arrayURI, fileToSave);
+            FileStoreUtil.SaveFileToArray(_ctx, arrayURI, fileToSave);
+            return;
         }
 
-        public void ExportArrayToFile(string fileToExport, string arrayName, string pathOrBucket="")
+        FileStoreUtil.SaveFileToCloudArray(_ctx, _nameSpace, arrayURI, fileToSave);
+    }
+
+    public void ExportArrayToFile(string fileToExport, string arrayName, string pathOrBucket="")
+    {
+        string uriToAccess;
+        if (_nameSpace == String.Empty)
         {
-            string uriToAccess;
-            if (_nameSpace == String.Empty)
-            {
-                uriToAccess = string.Join("/", new List<string>(new string[] {pathOrBucket, arrayName}));
-            }
-            else
-            {
-                uriToAccess = string.Format("tiledb://{0}/{1}", _nameSpace, arrayName);
-            }
-
-            FileStoreUtil.ExportArrayToFile(_ctx, fileToExport, uriToAccess);
+            uriToAccess = string.Join("/", new List<string>(new string[] {pathOrBucket, arrayName}));
         }
-
-        public static void RunLocal()
+        else
         {
-            var localPath = ExampleUtil.MakeExamplePath("file-local");
-            var localOutputFile = Path.Join(localPath, "local_out_file");
-            var localFile = Path.Join(localPath, "local_file");
-            var localArrayName = "array_name";
-            if (!Directory.Exists(localPath))
-            {
-                Directory.CreateDirectory(localPath);
-            }
-
-            var exampleFile = new ExampleFile();
-            // Import localFile to new TileDB Array
-            exampleFile.SaveFileToArray(localPath, localArrayName, localFile);
-            // Export TileDB Array to new localOutputFile
-            exampleFile.ExportArrayToFile(localOutputFile, localArrayName, localPath);
+            uriToAccess = string.Format("tiledb://{0}/{1}", _nameSpace, arrayName);
         }
 
-        public static void RunCloud(string token, string nameSpace, string cloudArrayName, string s3Bucket,
-            string host = "https://api.tiledb.com")
+        FileStoreUtil.ExportArrayToFile(_ctx, fileToExport, uriToAccess);
+    }
+
+    public static void RunLocal()
+    {
+        var localPath = ExampleUtil.MakeExamplePath("file-local");
+        var localOutputFile = Path.Join(localPath, "local_out_file");
+        var localFile = Path.Join(localPath, "local_file");
+        var localArrayName = "array_name";
+        if (!Directory.Exists(localPath))
         {
-            var localPath = ExampleUtil.MakeExamplePath("file-cloud");
-            if (!Directory.Exists(localPath))
-            {
-                Directory.CreateDirectory(localPath);
-            }
-            // Local file to import to new TileDB Cloud Array
-            var localFile = Path.Join(localPath, "local_file");
-            // Local file to store exported TileDB Cloud Array
-            var localOutputFileFromCloud = Path.Join(localPath, "local_out_cloud_file");
-
-            // Convert a local file to new TileDB Cloud Array
-            // + Creates TileDB Array: tiledb://<nameSpace>/<cloudArrayName>
-            // + Stored on S3: <s3bucket>/<cloudArrayName>
-            var exampleFile = new ExampleFile(host, token, nameSpace);
-            // Import localFile to new TileDB Cloud Array
-            exampleFile.SaveFileToArray(s3Bucket, cloudArrayName, localFile);
-            // Export TileDB Cloud Array to new local file
-            exampleFile.ExportArrayToFile(localOutputFileFromCloud, cloudArrayName);
+            Directory.CreateDirectory(localPath);
         }
+
+        var exampleFile = new ExampleFile();
+        // Import localFile to new TileDB Array
+        exampleFile.SaveFileToArray(localPath, localArrayName, localFile);
+        // Export TileDB Array to new localOutputFile
+        exampleFile.ExportArrayToFile(localOutputFile, localArrayName, localPath);
+    }
+
+    public static void RunCloud(string token, string nameSpace, string cloudArrayName, string s3Bucket,
+        string host = "https://api.tiledb.com")
+    {
+        var localPath = ExampleUtil.MakeExamplePath("file-cloud");
+        if (!Directory.Exists(localPath))
+        {
+            Directory.CreateDirectory(localPath);
+        }
+        // Local file to import to new TileDB Cloud Array
+        var localFile = Path.Join(localPath, "local_file");
+        // Local file to store exported TileDB Cloud Array
+        var localOutputFileFromCloud = Path.Join(localPath, "local_out_cloud_file");
+
+        // Convert a local file to new TileDB Cloud Array
+        // + Creates TileDB Array: tiledb://<nameSpace>/<cloudArrayName>
+        // + Stored on S3: <s3bucket>/<cloudArrayName>
+        var exampleFile = new ExampleFile(host, token, nameSpace);
+        // Import localFile to new TileDB Cloud Array
+        exampleFile.SaveFileToArray(s3Bucket, cloudArrayName, localFile);
+        // Export TileDB Cloud Array to new local file
+        exampleFile.ExportArrayToFile(localOutputFileFromCloud, cloudArrayName);
     }
 }

--- a/examples/TileDB.CSharp.Example/ExampleGroup.cs
+++ b/examples/TileDB.CSharp.Example/ExampleGroup.cs
@@ -2,123 +2,122 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+public class ExampleGroup
 {
-    public class ExampleGroup
+    private readonly Context _ctx;
+    private readonly string _nameSpace;
+
+    // Local access
+    public ExampleGroup()
     {
-        private readonly Context _ctx;
-        private readonly string _nameSpace;
+        _ctx = Context.GetDefault();
+        _nameSpace = String.Empty;
+    }
 
-        // Local access
-        public ExampleGroup()
+    // S3 access
+    public ExampleGroup(string key, string secret)
+    {
+        var config = new Config();
+        config.Set("vfs.s3.aws_access_key_id", key);
+        config.Set("vfs.s3.aws_secret_access_key", secret);
+        _ctx = new Context(config);
+        _nameSpace = String.Empty;
+    }
+
+    // TileDB Cloud access with token
+    public ExampleGroup(string host, string token, string nameSpace)
+    {
+        var config = new Config();
+        config.Set("rest.server_address", host);
+        config.Set("rest.token", token);
+        _ctx = new Context(config);
+        _nameSpace = nameSpace;
+    }
+
+    // TileDB Cloud access with basic authentication
+    public ExampleGroup(string host, string username, string password, string nameSpace)
+    {
+        var config = new Config();
+        config.Set("rest.server_address", host);
+        config.Set("rest.username", username);
+        config.Set("rest.password", password);
+        _ctx = new Context(config);
+        _nameSpace = nameSpace;
+    }
+
+    public void CreateGroups(string pathOrBucket, string groupName1, string groupName2)
+    {
+        var groupURI1 = string.Join("/", new List<string>(new string[] {pathOrBucket, groupName1}));
+        var groupURI2 = string.Join("/", new List<string>(new string[] { pathOrBucket, groupName2 }));
+
+        if (_nameSpace == String.Empty)
         {
-            _ctx = Context.GetDefault();
-            _nameSpace = String.Empty;
-        }
-
-        // S3 access
-        public ExampleGroup(string key, string secret)
-        {
-            var config = new Config();
-            config.Set("vfs.s3.aws_access_key_id", key);
-            config.Set("vfs.s3.aws_secret_access_key", secret);
-            _ctx = new Context(config);
-            _nameSpace = String.Empty;
-        }
-
-        // TileDB Cloud access with token
-        public ExampleGroup(string host, string token, string nameSpace)
-        {
-            var config = new Config();
-            config.Set("rest.server_address", host);
-            config.Set("rest.token", token);
-            _ctx = new Context(config);
-            _nameSpace = nameSpace;
-        }
-
-        // TileDB Cloud access with basic authentication
-        public ExampleGroup(string host, string username, string password, string nameSpace)
-        {
-            var config = new Config();
-            config.Set("rest.server_address", host);
-            config.Set("rest.username", username);
-            config.Set("rest.password", password);
-            _ctx = new Context(config);
-            _nameSpace = nameSpace;
-        }
-
-        public void CreateGroups(string pathOrBucket, string groupName1, string groupName2)
-        {
-            var groupURI1 = string.Join("/", new List<string>(new string[] {pathOrBucket, groupName1}));
-            var groupURI2 = string.Join("/", new List<string>(new string[] { pathOrBucket, groupName2 }));
-
-            if (_nameSpace == String.Empty)
+            if (Directory.Exists(groupURI1))
             {
-                if (Directory.Exists(groupURI1))
-                {
-                    Directory.Delete(groupURI1, true);
-                }
-                Group.Create(_ctx, groupURI1);
-
-                if (Directory.Exists(groupURI2))
-                {
-                    Directory.Delete(groupURI2, true);
-                }
-                Group.Create(_ctx, groupURI2);
-                return;
+                Directory.Delete(groupURI1, true);
             }
+            Group.Create(_ctx, groupURI1);
 
-            var groupURIToCreate1 = string.Format("tiledb://{0}/{1}", _nameSpace, groupURI1);
-            Group.Create(_ctx, groupURIToCreate1);
-            var groupURIToCreate2 = string.Format("tiledb://{0}/{1}", _nameSpace, groupURI2);
-            Group.Create(_ctx, groupURIToCreate2);
-        }
-
-        public void NestGroup(string pathOrBucket, string parentGroupName, string childGroupName)
-        {
-            string parentGroupURI;
-            string childGroupURI;
-            if (_nameSpace == String.Empty)
+            if (Directory.Exists(groupURI2))
             {
-                parentGroupURI = string.Join("/", new List<string>(new string[] { pathOrBucket, parentGroupName }));
-                childGroupURI = string.Join("/", new List<string>(new string[] { pathOrBucket, childGroupName }));
+                Directory.Delete(groupURI2, true);
             }
-            else
-            {
-                parentGroupURI = string.Format("tiledb://{0}/{1}", _nameSpace, parentGroupName);
-                childGroupURI = string.Format("tiledb://{0}/{1}", _nameSpace, childGroupName);
-            }
-
-            var parentGroup = new Group(_ctx, parentGroupURI);
-            parentGroup.Open(QueryType.Write);
-            parentGroup.AddMember(childGroupURI, false, "groupMember2");
-            parentGroup.Close();
+            Group.Create(_ctx, groupURI2);
+            return;
         }
 
-        public static void RunLocal()
+        var groupURIToCreate1 = string.Format("tiledb://{0}/{1}", _nameSpace, groupURI1);
+        Group.Create(_ctx, groupURIToCreate1);
+        var groupURIToCreate2 = string.Format("tiledb://{0}/{1}", _nameSpace, groupURI2);
+        Group.Create(_ctx, groupURIToCreate2);
+    }
+
+    public void NestGroup(string pathOrBucket, string parentGroupName, string childGroupName)
+    {
+        string parentGroupURI;
+        string childGroupURI;
+        if (_nameSpace == String.Empty)
         {
-            var localGroupPath = ExampleUtil.MakeExamplePath("groups-local");
-            if (!Directory.Exists(localGroupPath))
-            {
-                Directory.CreateDirectory(localGroupPath);
-            }
-            var localGroupName1 = "group1";
-            var localGroupName2 = "group2";
-
-            var exampleGroup = new ExampleGroup();
-            exampleGroup.CreateGroups(localGroupPath, localGroupName1, localGroupName2);
-            exampleGroup.NestGroup(localGroupPath, localGroupName1, localGroupName2);
+            parentGroupURI = string.Join("/", new List<string>(new string[] { pathOrBucket, parentGroupName }));
+            childGroupURI = string.Join("/", new List<string>(new string[] { pathOrBucket, childGroupName }));
         }
-
-        public static void RunCloud(string token, string nameSpace, string s3BucketPrefix,
-            string host = "https://api.tiledb.com")
+        else
         {
-            var cloudGroupName1 = "cloud_group1";
-            var cloudGroupName2 = "cloud_group2";
-
-            var exampleGroup = new ExampleGroup(host, token, nameSpace);
-            exampleGroup.CreateGroups(s3BucketPrefix, cloudGroupName1, cloudGroupName2);
-            exampleGroup.NestGroup(s3BucketPrefix, cloudGroupName1, cloudGroupName2);
+            parentGroupURI = string.Format("tiledb://{0}/{1}", _nameSpace, parentGroupName);
+            childGroupURI = string.Format("tiledb://{0}/{1}", _nameSpace, childGroupName);
         }
+
+        var parentGroup = new Group(_ctx, parentGroupURI);
+        parentGroup.Open(QueryType.Write);
+        parentGroup.AddMember(childGroupURI, false, "groupMember2");
+        parentGroup.Close();
+    }
+
+    public static void RunLocal()
+    {
+        var localGroupPath = ExampleUtil.MakeExamplePath("groups-local");
+        if (!Directory.Exists(localGroupPath))
+        {
+            Directory.CreateDirectory(localGroupPath);
+        }
+        var localGroupName1 = "group1";
+        var localGroupName2 = "group2";
+
+        var exampleGroup = new ExampleGroup();
+        exampleGroup.CreateGroups(localGroupPath, localGroupName1, localGroupName2);
+        exampleGroup.NestGroup(localGroupPath, localGroupName1, localGroupName2);
+    }
+
+    public static void RunCloud(string token, string nameSpace, string s3BucketPrefix,
+        string host = "https://api.tiledb.com")
+    {
+        var cloudGroupName1 = "cloud_group1";
+        var cloudGroupName2 = "cloud_group2";
+
+        var exampleGroup = new ExampleGroup(host, token, nameSpace);
+        exampleGroup.CreateGroups(s3BucketPrefix, cloudGroupName1, cloudGroupName2);
+        exampleGroup.NestGroup(s3BucketPrefix, cloudGroupName1, cloudGroupName2);
     }
 }

--- a/examples/TileDB.CSharp.Example/ExampleIncompleteQuery.cs
+++ b/examples/TileDB.CSharp.Example/ExampleIncompleteQuery.cs
@@ -3,115 +3,114 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+public static class ExampleIncompleteQuery
 {
-    public static class ExampleIncompleteQuery
+    static readonly string ArrayPath = ExampleUtil.MakeExamplePath("sparse-incomplete-query");
+    private static readonly Context Ctx = Context.GetDefault();
+
+    private static void CreateArray()
     {
-        static readonly string ArrayPath = ExampleUtil.MakeExamplePath("sparse-incomplete-query");
-        private static readonly Context Ctx = Context.GetDefault();
+        var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 10, extent: 4);
+        var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 10, extent: 4);
 
-        private static void CreateArray()
+        var domain = new Domain(Ctx);
+        domain.AddDimension(dim1);
+        domain.AddDimension(dim2);
+
+        var schema = new ArraySchema(Ctx, ArrayType.Sparse);
+        schema.SetDomain(domain);
+
+        var attr = new Attribute(Ctx, "a1", DataType.Int32);
+        schema.AddAttribute(attr);
+        schema.Check();
+
+        Array.Create(Ctx, ArrayPath, schema);
+    }
+
+    private static void WriteArray()
+    {
+        // Produce columns iteratively
+        List<int> colsList = new();
+        for (int i = 0; i < 10; i++)
         {
-            var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 10, extent: 4);
-            var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 10, extent: 4);
-
-            var domain = new Domain(Ctx);
-            domain.AddDimension(dim1);
-            domain.AddDimension(dim2);
-
-            var schema = new ArraySchema(Ctx, ArrayType.Sparse);
-            schema.SetDomain(domain);
-
-            var attr = new Attribute(Ctx, "a1", DataType.Int32);
-            schema.AddAttribute(attr);
-            schema.Check();
-
-            Array.Create(Ctx, ArrayPath, schema);
+            colsList.AddRange(Enumerable.Range(1, 10));
         }
+        int[] colsData = colsList.ToArray();
 
-        private static void WriteArray()
+        // Produce rows using LINQ
+        int[] rowsData =
+            (from a in Enumerable.Range(1, 10)
+            from b in Enumerable.Range(1, 10)
+            select a).ToArray();
+
+        // Write a1 attribute with values 1-100
+        int[] attrData = Enumerable.Range(1, 100).ToArray();
+        using (var arrayWrite = new Array(Ctx, ArrayPath))
         {
-            // Produce columns iteratively
-            List<int> colsList = new();
-            for (int i = 0; i < 10; i++)
+            arrayWrite.Open(QueryType.Write);
+
+            var queryWrite = new Query(arrayWrite);
+            queryWrite.SetLayout(LayoutType.Unordered);
+            queryWrite.SetDataBuffer("rows", rowsData);
+            queryWrite.SetDataBuffer("cols", colsData);
+            queryWrite.SetDataBuffer("a1", attrData);
+            queryWrite.Submit();
+
+            Console.WriteLine($"Write query status: {queryWrite.Status()}");
+            arrayWrite.Close();
+        }
+    }
+
+    private static void ReadArray()
+    {
+        // Allocate buffers for 10 values per batch read
+        var rowsRead = new int[10];
+        var colsRead = new int[10];
+        var attrRead = new int[10];
+
+        using (var arrayRead = new Array(Ctx, ArrayPath))
+        {
+            arrayRead.Open(QueryType.Read);
+            var queryRead = new Query(arrayRead);
+            queryRead.SetLayout(LayoutType.Unordered);
+
+            queryRead.SetDataBuffer("rows", rowsRead);
+            queryRead.SetDataBuffer("cols", colsRead);
+            queryRead.SetDataBuffer("a1", attrRead);
+
+            int batchNum = 1;
+            do
             {
-                colsList.AddRange(Enumerable.Range(1, 10));
-            }
-            int[] colsData = colsList.ToArray();
+                queryRead.Submit();
 
-            // Produce rows using LINQ
-            int[] rowsData =
-                (from a in Enumerable.Range(1, 10)
-                from b in Enumerable.Range(1, 10)
-                select a).ToArray();
+                // Zip (row, col) together for pretty printing
+                var coordList =
+                    rowsRead.Zip(colsRead, (row, col) => new Tuple<int, int>(row, col));
+                // Zip (coordinate, value) together for pretty printing
+                var resultList =
+                    coordList.Zip(attrRead, (coord, val) => new Tuple<Tuple<int, int>, int>(coord, val));
+                // Output read data as list of ((row, col), value)
+                Console.WriteLine($"Batch #{batchNum++}: {string.Join(", ", resultList)}");
 
-            // Write a1 attribute with values 1-100
-            int[] attrData = Enumerable.Range(1, 100).ToArray();
-            using (var arrayWrite = new Array(Ctx, ArrayPath))
-            {
-                arrayWrite.Open(QueryType.Write);
+                // If read is still incomplete, submit query again using allocated buffers
+            } while (queryRead.Status() == QueryStatus.Incomplete);
 
-                var queryWrite = new Query(arrayWrite);
-                queryWrite.SetLayout(LayoutType.Unordered);
-                queryWrite.SetDataBuffer("rows", rowsData);
-                queryWrite.SetDataBuffer("cols", colsData);
-                queryWrite.SetDataBuffer("a1", attrData);
-                queryWrite.Submit();
-
-                Console.WriteLine($"Write query status: {queryWrite.Status()}");
-                arrayWrite.Close();
-            }
+            Console.WriteLine($"Final read query status: {queryRead.Status()}");
+            arrayRead.Close();
         }
+    }
 
-        private static void ReadArray()
-        {
-            // Allocate buffers for 10 values per batch read
-            var rowsRead = new int[10];
-            var colsRead = new int[10];
-            var attrRead = new int[10];
+    public static void Run()
+    {
+         if (Directory.Exists(ArrayPath))
+         {
+             Directory.Delete(ArrayPath, true);
+         }
 
-            using (var arrayRead = new Array(Ctx, ArrayPath))
-            {
-                arrayRead.Open(QueryType.Read);
-                var queryRead = new Query(arrayRead);
-                queryRead.SetLayout(LayoutType.Unordered);
-
-                queryRead.SetDataBuffer("rows", rowsRead);
-                queryRead.SetDataBuffer("cols", colsRead);
-                queryRead.SetDataBuffer("a1", attrRead);
-
-                int batchNum = 1;
-                do
-                {
-                    queryRead.Submit();
-
-                    // Zip (row, col) together for pretty printing
-                    var coordList =
-                        rowsRead.Zip(colsRead, (row, col) => new Tuple<int, int>(row, col));
-                    // Zip (coordinate, value) together for pretty printing
-                    var resultList =
-                        coordList.Zip(attrRead, (coord, val) => new Tuple<Tuple<int, int>, int>(coord, val));
-                    // Output read data as list of ((row, col), value)
-                    Console.WriteLine($"Batch #{batchNum++}: {string.Join(", ", resultList)}");
-
-                    // If read is still incomplete, submit query again using allocated buffers
-                } while (queryRead.Status() == QueryStatus.Incomplete);
-
-                Console.WriteLine($"Final read query status: {queryRead.Status()}");
-                arrayRead.Close();
-            }
-        }
-
-        public static void Run()
-        {
-             if (Directory.Exists(ArrayPath))
-             {
-                 Directory.Delete(ArrayPath, true);
-             }
-
-             CreateArray();
-             WriteArray();
-             ReadArray();
-        }
+         CreateArray();
+         WriteArray();
+         ReadArray();
     }
 }

--- a/examples/TileDB.CSharp.Example/ExampleIncompleteQueryStringDimensions.cs
+++ b/examples/TileDB.CSharp.Example/ExampleIncompleteQueryStringDimensions.cs
@@ -4,147 +4,146 @@ using System.IO;
 using System.Linq;
 using System.Text;
 
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+public static class ExampleIncompleteQueryStringDimensions
 {
-    public static class ExampleIncompleteQueryStringDimensions
+    static readonly string ArrayPath = ExampleUtil.MakeExamplePath("sparse-incomplete-query-string-dimensions");
+    private static readonly Context Ctx = Context.GetDefault();
+
+    private static void CreateArray()
     {
-        static readonly string ArrayPath = ExampleUtil.MakeExamplePath("sparse-incomplete-query-string-dimensions");
-        private static readonly Context Ctx = Context.GetDefault();
+        var rows = Dimension.CreateString(Ctx, "rows");
+        var cols = Dimension.CreateString(Ctx, "cols");
 
-        private static void CreateArray()
+        var domain = new Domain(Ctx);
+        domain.AddDimensions(rows, cols);
+
+        var schema = new ArraySchema(Ctx, ArrayType.Sparse);
+        schema.SetDomain(domain);
+
+        var attr = new Attribute(Ctx, "a1", DataType.Int32);
+        schema.AddAttribute(attr);
+        schema.Check();
+
+        Array.Create(Ctx, ArrayPath, schema);
+    }
+
+    private static void WriteArray()
+    {
+        var rowsData = Encoding.ASCII.GetBytes("abbcccddddeeeee");
+        var colsData = Encoding.ASCII.GetBytes("jjjjjiiiihhhggf");
+
+        var rowsOffsets = new ulong[] { 0, 1, 3, 6, 10 };
+        var colsOffsets = new ulong[] { 0, 5, 9, 12, 14 };
+
+        int[] attrData = Enumerable.Range(1, 5).ToArray();
+
+        using (var arrayWrite = new Array(Ctx, ArrayPath))
         {
-            var rows = Dimension.CreateString(Ctx, "rows");
-            var cols = Dimension.CreateString(Ctx, "cols");
+            arrayWrite.Open(QueryType.Write);
 
-            var domain = new Domain(Ctx);
-            domain.AddDimensions(rows, cols);
+            var queryWrite = new Query(arrayWrite);
+            queryWrite.SetLayout(LayoutType.Unordered);
+            queryWrite.SetDataBuffer("rows", rowsData);
+            queryWrite.SetOffsetsBuffer("rows", rowsOffsets);
+            queryWrite.SetDataBuffer("cols", colsData);
+            queryWrite.SetOffsetsBuffer("cols", colsOffsets);
+            queryWrite.SetDataBuffer("a1", attrData);
+            queryWrite.Submit();
 
-            var schema = new ArraySchema(Ctx, ArrayType.Sparse);
-            schema.SetDomain(domain);
-
-            var attr = new Attribute(Ctx, "a1", DataType.Int32);
-            schema.AddAttribute(attr);
-            schema.Check();
-
-            Array.Create(Ctx, ArrayPath, schema);
+            Console.WriteLine($"Write query status: {queryWrite.Status()}");
+            arrayWrite.Close();
         }
+    }
 
-        private static void WriteArray()
+    private static void ReadArray()
+    {
+        using (var arrayRead = new Array(Ctx, ArrayPath))
         {
-            var rowsData = Encoding.ASCII.GetBytes("abbcccddddeeeee");
-            var colsData = Encoding.ASCII.GetBytes("jjjjjiiiihhhggf");
+            arrayRead.Open(QueryType.Read);
+            var queryRead = new Query(arrayRead);
+            queryRead.SetLayout(LayoutType.Unordered);
+            var subarray = new Subarray(arrayRead);
+            subarray.AddRange("rows", "a", "eeeee");
+            subarray.AddRange("cols", "f", "jjjjj");
+            queryRead.SetSubarray(subarray);
 
-            var rowsOffsets = new ulong[] { 0, 1, 3, 6, 10 };
-            var colsOffsets = new ulong[] { 0, 5, 9, 12, 14 };
+            var attrRead = new int[5];
+            queryRead.SetDataBuffer("a1", attrRead);
 
-            int[] attrData = Enumerable.Range(1, 5).ToArray();
+            var rowsRead = new byte[15];
+            var rowsReadOffsets = new ulong[2];
+            queryRead.SetDataBuffer("rows", rowsRead);
+            queryRead.SetOffsetsBuffer("rows", rowsReadOffsets);
 
-            using (var arrayWrite = new Array(Ctx, ArrayPath))
+            var colsRead = new byte[15];
+            var colsReadOffsets = new ulong[2];
+            queryRead.SetDataBuffer("cols", colsRead);
+            queryRead.SetOffsetsBuffer("cols", colsReadOffsets);
+
+            int batchNum = 1;
+            do
             {
-                arrayWrite.Open(QueryType.Write);
+                queryRead.Submit();
 
-                var queryWrite = new Query(arrayWrite);
-                queryWrite.SetLayout(LayoutType.Unordered);
-                queryWrite.SetDataBuffer("rows", rowsData);
-                queryWrite.SetOffsetsBuffer("rows", rowsOffsets);
-                queryWrite.SetDataBuffer("cols", colsData);
-                queryWrite.SetOffsetsBuffer("cols", colsOffsets);
-                queryWrite.SetDataBuffer("a1", attrData);
-                queryWrite.Submit();
+                var rowDataElements = (int)queryRead.GetResultDataElements("rows");
+                var rowOffsetElements = (int)queryRead.GetResultOffsets("rows");
 
-                Console.WriteLine($"Write query status: {queryWrite.Status()}");
-                arrayWrite.Close();
-            }
-        }
+                var colDataElements = (int)queryRead.GetResultDataElements("cols");
+                var colOffsetElements = (int)queryRead.GetResultOffsets("cols");
 
-        private static void ReadArray()
-        {
-            using (var arrayRead = new Array(Ctx, ArrayPath))
-            {
-                arrayRead.Open(QueryType.Read);
-                var queryRead = new Query(arrayRead);
-                queryRead.SetLayout(LayoutType.Unordered);
-                var subarray = new Subarray(arrayRead);
-                subarray.AddRange("rows", "a", "eeeee");
-                subarray.AddRange("cols", "f", "jjjjj");
-                queryRead.SetSubarray(subarray);
-
-                var attrRead = new int[5];
-                queryRead.SetDataBuffer("a1", attrRead);
-
-                var rowsRead = new byte[15];
-                var rowsReadOffsets = new ulong[2];
-                queryRead.SetDataBuffer("rows", rowsRead);
-                queryRead.SetOffsetsBuffer("rows", rowsReadOffsets);
-
-                var colsRead = new byte[15];
-                var colsReadOffsets = new ulong[2];
-                queryRead.SetDataBuffer("cols", colsRead);
-                queryRead.SetOffsetsBuffer("cols", colsReadOffsets);
-
-                int batchNum = 1;
-                do
+                // Copy rows data into string buffer
+                List<string> rowsData = new();
+                for (int i = 0; i < rowOffsetElements; i++)
                 {
-                    queryRead.Submit();
+                    // Final offset value should be handled differently
+                    // + We consume the rest of the data buffer beginning at index rowsReadOffsets[i]
+                    int cellSize = i == rowOffsetElements - 1 ?
+                        rowDataElements - (int)rowsReadOffsets[i]
+                        : (int)rowsReadOffsets[i + 1] - (int)rowsReadOffsets[i];
 
-                    var rowDataElements = (int)queryRead.GetResultDataElements("rows");
-                    var rowOffsetElements = (int)queryRead.GetResultOffsets("rows");
+                    string result = new(Encoding.ASCII.GetChars(rowsRead, (int)rowsReadOffsets[i], cellSize));
+                    rowsData.Add(result);
+                }
 
-                    var colDataElements = (int)queryRead.GetResultDataElements("cols");
-                    var colOffsetElements = (int)queryRead.GetResultOffsets("cols");
+                List<string> colsData = new();
+                for (int i = 0; i < colOffsetElements; i++)
+                {
+                    int cellSize = i == colOffsetElements - 1 ?
+                        colDataElements - (int)colsReadOffsets[i]
+                        : (int)colsReadOffsets[i + 1] - (int)colsReadOffsets[i];
 
-                    // Copy rows data into string buffer
-                    List<string> rowsData = new();
-                    for (int i = 0; i < rowOffsetElements; i++)
-                    {
-                        // Final offset value should be handled differently
-                        // + We consume the rest of the data buffer beginning at index rowsReadOffsets[i]
-                        int cellSize = i == rowOffsetElements - 1 ?
-                            rowDataElements - (int)rowsReadOffsets[i]
-                            : (int)rowsReadOffsets[i + 1] - (int)rowsReadOffsets[i];
+                    string result = new(Encoding.ASCII.GetChars(colsRead, (int)colsReadOffsets[i], cellSize));
+                    colsData.Add(result);
+                }
 
-                        string result = new(Encoding.ASCII.GetChars(rowsRead, (int)rowsReadOffsets[i], cellSize));
-                        rowsData.Add(result);
-                    }
+                // Zip (row, col) together
+                var coordList = rowsData.Zip(colsData, (row, col) =>
+                    new Tuple<string, string>(row, col));
+                // Zip (coordinate, value) together
+                var resultList = coordList.Zip(attrRead, (coord, val) =>
+                        new Tuple<Tuple<string, string>, int>(coord, val));
+                // Output read data as list of ((row, col), value)
+                Console.WriteLine($"Batch #{batchNum++}: {string.Join(", ", resultList)}");
 
-                    List<string> colsData = new();
-                    for (int i = 0; i < colOffsetElements; i++)
-                    {
-                        int cellSize = i == colOffsetElements - 1 ?
-                            colDataElements - (int)colsReadOffsets[i]
-                            : (int)colsReadOffsets[i + 1] - (int)colsReadOffsets[i];
+                // If read is still incomplete, submit query again using allocated buffers
+            } while (queryRead.Status() == QueryStatus.Incomplete);
 
-                        string result = new(Encoding.ASCII.GetChars(colsRead, (int)colsReadOffsets[i], cellSize));
-                        colsData.Add(result);
-                    }
-
-                    // Zip (row, col) together
-                    var coordList = rowsData.Zip(colsData, (row, col) =>
-                        new Tuple<string, string>(row, col));
-                    // Zip (coordinate, value) together
-                    var resultList = coordList.Zip(attrRead, (coord, val) =>
-                            new Tuple<Tuple<string, string>, int>(coord, val));
-                    // Output read data as list of ((row, col), value)
-                    Console.WriteLine($"Batch #{batchNum++}: {string.Join(", ", resultList)}");
-
-                    // If read is still incomplete, submit query again using allocated buffers
-                } while (queryRead.Status() == QueryStatus.Incomplete);
-
-                Console.WriteLine($"Final read query status: {queryRead.Status()}");
-                arrayRead.Close();
-            }
+            Console.WriteLine($"Final read query status: {queryRead.Status()}");
+            arrayRead.Close();
         }
+    }
 
-        public static void Run()
-        {
-             if (Directory.Exists(ArrayPath))
-             {
-                 Directory.Delete(ArrayPath, true);
-             }
+    public static void Run()
+    {
+         if (Directory.Exists(ArrayPath))
+         {
+             Directory.Delete(ArrayPath, true);
+         }
 
-             CreateArray();
-             WriteArray();
-             ReadArray();
-        }
+         CreateArray();
+         WriteArray();
+         ReadArray();
     }
 }

--- a/examples/TileDB.CSharp.Example/ExampleIncompleteQueryVariableSize.cs
+++ b/examples/TileDB.CSharp.Example/ExampleIncompleteQueryVariableSize.cs
@@ -2,125 +2,124 @@ using System;
 using System.IO;
 using System.Linq;
 
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+public static class ExampleIncompleteQueryVariableSize
 {
-    public static class ExampleIncompleteQueryVariableSize
+    static readonly string ArrayPath = ExampleUtil.MakeExamplePath("sparse-incomplete-query-variable-size");
+    private static readonly Context Ctx = Context.GetDefault();
+
+    private static void CreateArray()
     {
-        static readonly string ArrayPath = ExampleUtil.MakeExamplePath("sparse-incomplete-query-variable-size");
-        private static readonly Context Ctx = Context.GetDefault();
+        var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 10, extent: 4);
+        var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 10, extent: 4);
+        var domain = new Domain(Ctx);
+        domain.AddDimension(dim1);
+        domain.AddDimension(dim2);
+        var array_schema = new ArraySchema(Ctx, ArrayType.Sparse);
+        var attr = new Attribute(Ctx, "a", DataType.Int32);
+        attr.SetCellValNum(Attribute.VariableSized);
 
-        private static void CreateArray()
+        array_schema.AddAttribute(attr);
+        array_schema.SetDomain(domain);
+        array_schema.Check();
+
+        Array.Create(Ctx, ArrayPath, array_schema);
+    }
+
+    private static void WriteArray()
+    {
+        var dim1_data_buffer = new int[] { 1, 2, 3, 4 };
+        var dim2_data_buffer = new int[] { 1, 3, 4, 5 };
+        var attr_data_buffer = new int[] { 1, 2, 20, 3, 30, 300, 4, 40, 400, 4000 };
+        var attr_data_offsets_buffer = new ulong[] { 0, 1 * sizeof(int), 3 * sizeof(int), 6 * sizeof(int) };
+
+        using (var array_write = new Array(Ctx, ArrayPath))
         {
-            var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 10, extent: 4);
-            var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 10, extent: 4);
-            var domain = new Domain(Ctx);
-            domain.AddDimension(dim1);
-            domain.AddDimension(dim2);
-            var array_schema = new ArraySchema(Ctx, ArrayType.Sparse);
-            var attr = new Attribute(Ctx, "a", DataType.Int32);
-            attr.SetCellValNum(Attribute.VariableSized);
-
-            array_schema.AddAttribute(attr);
-            array_schema.SetDomain(domain);
-            array_schema.Check();
-
-            Array.Create(Ctx, ArrayPath, array_schema);
+            array_write.Open(QueryType.Write);
+            var query_write = new Query(array_write);
+            query_write.SetLayout(LayoutType.Unordered);
+            query_write.SetDataBuffer("rows", dim1_data_buffer);
+            query_write.SetDataBuffer("cols", dim2_data_buffer);
+            query_write.SetDataBuffer("a", attr_data_buffer);
+            query_write.SetOffsetsBuffer("a", attr_data_offsets_buffer);
+            query_write.Submit();
+            array_write.Close();
         }
+    }
 
-        private static void WriteArray()
+    private static void ReadArray()
+    {
+        var dim1_data_buffer_read = new int[1];
+        var dim2_data_buffer_read = new int[1];
+        var attr_data_buffer_read = new int[1];
+        var attr_data_offsets_buffer = new ulong[1];
+
+        using (var array_read = new Array(Ctx, ArrayPath))
         {
-            var dim1_data_buffer = new int[] { 1, 2, 3, 4 };
-            var dim2_data_buffer = new int[] { 1, 3, 4, 5 };
-            var attr_data_buffer = new int[] { 1, 2, 20, 3, 30, 300, 4, 40, 400, 4000 };
-            var attr_data_offsets_buffer = new ulong[] { 0, 1 * sizeof(int), 3 * sizeof(int), 6 * sizeof(int) };
+            array_read.Open(QueryType.Read);
+            var query_read = new Query(array_read);
+            query_read.SetLayout(LayoutType.Unordered);
+            query_read.SetDataBuffer("rows", dim1_data_buffer_read);
+            query_read.SetDataBuffer("cols", dim2_data_buffer_read);
+            query_read.SetDataBuffer("a", attr_data_buffer_read);
+            query_read.SetOffsetsBuffer("a", attr_data_offsets_buffer);
 
-            using (var array_write = new Array(Ctx, ArrayPath))
+            int batchNum = 1;
+            QueryStatus status;
+            do
             {
-                array_write.Open(QueryType.Write);
-                var query_write = new Query(array_write);
-                query_write.SetLayout(LayoutType.Unordered);
-                query_write.SetDataBuffer("rows", dim1_data_buffer);
-                query_write.SetDataBuffer("cols", dim2_data_buffer);
-                query_write.SetDataBuffer("a", attr_data_buffer);
-                query_write.SetOffsetsBuffer("a", attr_data_offsets_buffer);
-                query_write.Submit();
-                array_write.Close();
-            }
-        }
+                query_read.Submit();
 
-        private static void ReadArray()
-        {
-            var dim1_data_buffer_read = new int[1];
-            var dim2_data_buffer_read = new int[1];
-            var attr_data_buffer_read = new int[1];
-            var attr_data_offsets_buffer = new ulong[1];
+                status = query_read.Status();
 
-            using (var array_read = new Array(Ctx, ArrayPath))
-            {
-                array_read.Open(QueryType.Read);
-                var query_read = new Query(array_read);
-                query_read.SetLayout(LayoutType.Unordered);
-                query_read.SetDataBuffer("rows", dim1_data_buffer_read);
-                query_read.SetDataBuffer("cols", dim2_data_buffer_read);
-                query_read.SetDataBuffer("a", attr_data_buffer_read);
-                query_read.SetOffsetsBuffer("a", attr_data_offsets_buffer);
+                var resultNum = (int)query_read.GetResultDataElements("rows");
+                var attrNum = (int)query_read.GetResultDataElements("a");
 
-                int batchNum = 1;
-                QueryStatus status;
-                do
+                Console.WriteLine($"Batch #{batchNum++}");
+
+                if (status == QueryStatus.Incomplete && resultNum == 0 && query_read.GetStatusDetails().Reason == QueryStatusDetailsReason.UserBufferSize)
                 {
-                    query_read.Submit();
+                    Console.WriteLine("Resizing buffers...");
+                    dim1_data_buffer_read = new int[dim1_data_buffer_read.Length * 2];
+                    query_read.SetDataBuffer("rows", dim1_data_buffer_read);
 
-                    status = query_read.Status();
+                    dim2_data_buffer_read = new int[dim2_data_buffer_read.Length * 2];
+                    query_read.SetDataBuffer("cols", dim2_data_buffer_read);
 
-                    var resultNum = (int)query_read.GetResultDataElements("rows");
-                    var attrNum = (int)query_read.GetResultDataElements("a");
+                    attr_data_buffer_read = new int[attr_data_buffer_read.Length * 2];
+                    query_read.SetDataBuffer("a", attr_data_buffer_read);
 
-                    Console.WriteLine($"Batch #{batchNum++}");
-
-                    if (status == QueryStatus.Incomplete && resultNum == 0 && query_read.GetStatusDetails().Reason == QueryStatusDetailsReason.UserBufferSize)
+                    attr_data_offsets_buffer = new ulong[attr_data_offsets_buffer.Length * 2];
+                    query_read.SetOffsetsBuffer("a", attr_data_offsets_buffer);
+                }
+                else
+                {
+                    for (int i = 0; i < resultNum; i++)
                     {
-                        Console.WriteLine("Resizing buffers...");
-                        dim1_data_buffer_read = new int[dim1_data_buffer_read.Length * 2];
-                        query_read.SetDataBuffer("rows", dim1_data_buffer_read);
-
-                        dim2_data_buffer_read = new int[dim2_data_buffer_read.Length * 2];
-                        query_read.SetDataBuffer("cols", dim2_data_buffer_read);
-
-                        attr_data_buffer_read = new int[attr_data_buffer_read.Length * 2];
-                        query_read.SetDataBuffer("a", attr_data_buffer_read);
-
-                        attr_data_offsets_buffer = new ulong[attr_data_offsets_buffer.Length * 2];
-                        query_read.SetOffsetsBuffer("a", attr_data_offsets_buffer);
-                    }
-                    else
-                    {
-                        for (int i = 0; i < resultNum; i++)
-                        {
-                            var attrOffsetStart = (int)attr_data_offsets_buffer[i] / sizeof(int);
-                            var attrOffsetEnd = i == resultNum - 1 ? attrNum : (int)attr_data_offsets_buffer[i + 1] / sizeof(int);
-                            var attrLength = attrOffsetEnd - attrOffsetStart;
-                            var attrData = string.Join(", ", attr_data_buffer_read.Skip(attrOffsetStart).Take(attrLength));
-                            Console.WriteLine($"Cell ({dim1_data_buffer_read[i]}, {dim2_data_buffer_read[i]}) = [{attrData}]");
-                        }
+                        var attrOffsetStart = (int)attr_data_offsets_buffer[i] / sizeof(int);
+                        var attrOffsetEnd = i == resultNum - 1 ? attrNum : (int)attr_data_offsets_buffer[i + 1] / sizeof(int);
+                        var attrLength = attrOffsetEnd - attrOffsetStart;
+                        var attrData = string.Join(", ", attr_data_buffer_read.Skip(attrOffsetStart).Take(attrLength));
+                        Console.WriteLine($"Cell ({dim1_data_buffer_read[i]}, {dim2_data_buffer_read[i]}) = [{attrData}]");
                     }
                 }
-                while (status == QueryStatus.Incomplete);
-
-                array_read.Close();
             }
-        }
+            while (status == QueryStatus.Incomplete);
 
-        public static void Run()
+            array_read.Close();
+        }
+    }
+
+    public static void Run()
+    {
+        if (Directory.Exists(ArrayPath))
         {
-            if (Directory.Exists(ArrayPath))
-            {
-                Directory.Delete(ArrayPath, true);
-            }
-
-            CreateArray();
-            WriteArray();
-            ReadArray();
+            Directory.Delete(ArrayPath, true);
         }
+
+        CreateArray();
+        WriteArray();
+        ReadArray();
     }
 }

--- a/examples/TileDB.CSharp.Example/ExampleQuery.cs
+++ b/examples/TileDB.CSharp.Example/ExampleQuery.cs
@@ -1,82 +1,81 @@
 using System;
 using System.IO;
 using TileDB.CSharp;
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+static class ExampleQuery
 {
-    static class ExampleQuery
+    private static readonly string ArrayPath = ExampleUtil.MakeExamplePath("sparse-array");
+    private static readonly Context Ctx = Context.GetDefault();
+
+    private static void CreateArray()
     {
-        private static readonly string ArrayPath = ExampleUtil.MakeExamplePath("sparse-array");
-        private static readonly Context Ctx = Context.GetDefault();
+        // Create array
+        var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 4, extent: 4);
+        var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 4, extent: 4);
+        var domain = new Domain(Ctx);
+        domain.AddDimension(dim1);
+        domain.AddDimension(dim2);
+        var array_schema = new ArraySchema(Ctx, ArrayType.Sparse);
+        var attr = new Attribute(Ctx, "a", DataType.Int32);
+        array_schema.AddAttribute(attr);
+        array_schema.SetDomain(domain);
+        array_schema.Check();
 
-        private static void CreateArray()
+        Array.Create(Ctx, ArrayPath, array_schema);
+    }
+
+    private static void WriteArray()
+    {
+        var dim1_data_buffer = new int[3] { 1, 2, 3 };
+        var dim2_data_buffer = new int[3] { 1, 3, 4 };
+        var attr_data_buffer = new int[3] { 1, 2, 3 };
+
+        using (var array_write = new Array(Ctx, ArrayPath))
         {
-            // Create array
-            var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 4, extent: 4);
-            var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 4, extent: 4);
-            var domain = new Domain(Ctx);
-            domain.AddDimension(dim1);
-            domain.AddDimension(dim2);
-            var array_schema = new ArraySchema(Ctx, ArrayType.Sparse);
-            var attr = new Attribute(Ctx, "a", DataType.Int32);
-            array_schema.AddAttribute(attr);
-            array_schema.SetDomain(domain);
-            array_schema.Check();
+            array_write.Open(QueryType.Write);
+            var query_write = new Query(array_write);
+            query_write.SetLayout(LayoutType.Unordered);
+            query_write.SetDataBuffer("rows", dim1_data_buffer);
+            query_write.SetDataBuffer("cols", dim2_data_buffer);
+            query_write.SetDataBuffer("a", attr_data_buffer);
+            query_write.Submit();
+            array_write.Close();
+        }
+    }
 
-            Array.Create(Ctx, ArrayPath, array_schema);
+    private static void ReadArray()
+    {
+        var dim1_data_buffer_read = new int[3];
+        var dim2_data_buffer_read = new int[3];
+        var attr_data_buffer_read = new int[3];
+
+        using (var array_read = new Array(Ctx, ArrayPath))
+        {
+            array_read.Open(QueryType.Read);
+            var query_read = new Query(array_read);
+            query_read.SetLayout(LayoutType.RowMajor);
+            query_read.SetDataBuffer("rows", dim1_data_buffer_read);
+            query_read.SetDataBuffer("cols", dim2_data_buffer_read);
+            query_read.SetDataBuffer("a", attr_data_buffer_read);
+            query_read.Submit();
+            array_read.Close();
         }
 
-        private static void WriteArray()
-        {
-            var dim1_data_buffer = new int[3] { 1, 2, 3 };
-            var dim2_data_buffer = new int[3] { 1, 3, 4 };
-            var attr_data_buffer = new int[3] { 1, 2, 3 };
+        Console.WriteLine("dim1:{0},{1},{2}", dim1_data_buffer_read[0], dim1_data_buffer_read[1], dim1_data_buffer_read[2]);
+        Console.WriteLine("dim2:{0},{1},{2}", dim2_data_buffer_read[0], dim2_data_buffer_read[1], dim2_data_buffer_read[2]);
+        Console.WriteLine("attr:{0},{1},{2}", attr_data_buffer_read[0], attr_data_buffer_read[1], attr_data_buffer_read[2]);
+    }
 
-            using (var array_write = new Array(Ctx, ArrayPath))
-            {
-                array_write.Open(QueryType.Write);
-                var query_write = new Query(array_write);
-                query_write.SetLayout(LayoutType.Unordered);
-                query_write.SetDataBuffer("rows", dim1_data_buffer);
-                query_write.SetDataBuffer("cols", dim2_data_buffer);
-                query_write.SetDataBuffer("a", attr_data_buffer);
-                query_write.Submit();
-                array_write.Close();
-            }
+    public static void Run()
+    {
+        if (Directory.Exists(ArrayPath))
+        {
+            Directory.Delete(ArrayPath, true);
         }
 
-        private static void ReadArray()
-        {
-            var dim1_data_buffer_read = new int[3];
-            var dim2_data_buffer_read = new int[3];
-            var attr_data_buffer_read = new int[3];
-
-            using (var array_read = new Array(Ctx, ArrayPath))
-            {
-                array_read.Open(QueryType.Read);
-                var query_read = new Query(array_read);
-                query_read.SetLayout(LayoutType.RowMajor);
-                query_read.SetDataBuffer("rows", dim1_data_buffer_read);
-                query_read.SetDataBuffer("cols", dim2_data_buffer_read);
-                query_read.SetDataBuffer("a", attr_data_buffer_read);
-                query_read.Submit();
-                array_read.Close();
-            }
-
-            Console.WriteLine("dim1:{0},{1},{2}", dim1_data_buffer_read[0], dim1_data_buffer_read[1], dim1_data_buffer_read[2]);
-            Console.WriteLine("dim2:{0},{1},{2}", dim2_data_buffer_read[0], dim2_data_buffer_read[1], dim2_data_buffer_read[2]);
-            Console.WriteLine("attr:{0},{1},{2}", attr_data_buffer_read[0], attr_data_buffer_read[1], attr_data_buffer_read[2]);
-        }
-
-        public static void Run()
-        {
-            if (Directory.Exists(ArrayPath))
-            {
-                Directory.Delete(ArrayPath, true);
-            }
-
-            CreateArray();
-            WriteArray();
-            ReadArray();
-        }
+        CreateArray();
+        WriteArray();
+        ReadArray();
     }
 }

--- a/examples/TileDB.CSharp.Example/ExampleUtil.cs
+++ b/examples/TileDB.CSharp.Example/ExampleUtil.cs
@@ -1,31 +1,30 @@
 using System.IO;
 
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+public static class ExampleUtil
 {
-    public static class ExampleUtil
+    static ExampleUtil()
     {
-        static ExampleUtil()
+        if (!Directory.Exists(MakeExamplePath("")))
         {
-            if (!Directory.Exists(MakeExamplePath("")))
-            {
-                Directory.CreateDirectory(MakeExamplePath(""));
-            }
+            Directory.CreateDirectory(MakeExamplePath(""));
         }
-
-        /// <summary>
-        /// Normalizes temp directory
-        /// </summary>
-        /// <param name="tempFile">Name of file to create temp path</param>
-        /// <returns>A full path to the local tempFile</returns>
-        public static string MakeTempPath(string tempFile) =>
-            Path.Join(Path.Join(Path.GetTempPath(), "tiledb-csharp-temp"), tempFile);
-
-        /// <summary>
-        /// Normalizes temp directory for all examples
-        /// </summary>
-        /// <param name="fileName">Name of file to create temp path</param>
-        /// <returns>A full path to a local temp directory using provided fileName</returns>
-        public static string MakeExamplePath(string fileName) =>
-            Path.Join(MakeTempPath("examples"), fileName);
     }
+
+    /// <summary>
+    /// Normalizes temp directory
+    /// </summary>
+    /// <param name="tempFile">Name of file to create temp path</param>
+    /// <returns>A full path to the local tempFile</returns>
+    public static string MakeTempPath(string tempFile) =>
+        Path.Join(Path.Join(Path.GetTempPath(), "tiledb-csharp-temp"), tempFile);
+
+    /// <summary>
+    /// Normalizes temp directory for all examples
+    /// </summary>
+    /// <param name="fileName">Name of file to create temp path</param>
+    /// <returns>A full path to a local temp directory using provided fileName</returns>
+    public static string MakeExamplePath(string fileName) =>
+        Path.Join(MakeTempPath("examples"), fileName);
 }

--- a/examples/TileDB.CSharp.Example/ExampleWritingDenseGlobal.cs
+++ b/examples/TileDB.CSharp.Example/ExampleWritingDenseGlobal.cs
@@ -1,85 +1,84 @@
 using System;
 using System.IO;
 
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+public static class ExampleWritingDenseGlobal
 {
-    public static class ExampleWritingDenseGlobal
+    private static readonly string ArrayPath = ExampleUtil.MakeExamplePath("writing-dense-global");
+    private static readonly Context Ctx = Context.GetDefault();
+
+    private static void CreateArray()
     {
-        private static readonly string ArrayPath = ExampleUtil.MakeExamplePath("writing-dense-global");
-        private static readonly Context Ctx = Context.GetDefault();
+        using var domain = new Domain(Ctx);
+        // Create a 4x4 array with 2x2 tile dimensions; Total of 16 cells, 4 tiles, 4 cells each tile
+        // + Same layout seen here: https://docs.tiledb.com/main/background/key-concepts-and-data-format#indexing
+        domain.AddDimension(Dimension.Create(Ctx, "rows", 1, 4, 2));
+        domain.AddDimension(Dimension.Create(Ctx, "cols", 1, 4, 2));
 
-        private static void CreateArray()
+        using var schema = new ArraySchema(Ctx, ArrayType.Dense);
+        Console.WriteLine($"Tile order: {schema.TileOrder()}; Cell order: {schema.CellOrder()}");
+        schema.SetDomain(domain);
+        schema.AddAttribute(Attribute.Create<int>(Ctx, "a1"));
+
+        Array.Create(Ctx, ArrayPath, schema);
+    }
+
+    private static void WriteArray()
+    {
+        using var array = new Array(Ctx, ArrayPath);
+        array.Open(QueryType.Write);
+
+        using var queryWrite = new Query(array, QueryType.Write);
+        queryWrite.SetLayout(LayoutType.GlobalOrder);
+        // Slice rows 1-4, columns 1-2 for a total of 8 cells
+        using var subarray = new Subarray(array);
+        subarray.AddRange("rows", 1, 4);
+        subarray.AddRange("cols", 1, 2);
+        queryWrite.SetSubarray(subarray);
+
+        // Write 4 cells
+        queryWrite.SetDataBuffer("a1", new[] { 1, 2, 3, 4 });
+        queryWrite.Submit();
+        Console.WriteLine($"Write query #1 status: {queryWrite.Status()}");
+
+        // Write 4 more cells before we finalize the query
+        queryWrite.SetDataBuffer("a1", new[] { 5, 6, 7, 8});
+        queryWrite.Submit();
+        Console.WriteLine($"Write query #2 status: {queryWrite.Status()}");
+
+        // Important: Global order writes must call Query.FinalizeQuery()
+        queryWrite.FinalizeQuery();
+        array.Close();
+    }
+
+    private static void ReadArray()
+    {
+        using var array = new Array(Ctx, ArrayPath);
+        array.Open(QueryType.Read);
+        using var readQuery = new Query(array, QueryType.Read);
+        using var subarray = new Subarray(array);
+        subarray.SetSubarray(1, 4, 1, 4);
+        readQuery.SetSubarray(subarray);
+
+        var a1Read = new int[16];
+        readQuery.SetDataBuffer("a1", a1Read);
+        readQuery.Submit();
+        Console.WriteLine($"Read query status: {readQuery.Status()}");
+        Console.WriteLine($"a1 data: {string.Join(", ", a1Read)}");
+
+        array.Close();
+    }
+
+    public static void Run()
+    {
+        if (Directory.Exists(ArrayPath))
         {
-            using var domain = new Domain(Ctx);
-            // Create a 4x4 array with 2x2 tile dimensions; Total of 16 cells, 4 tiles, 4 cells each tile
-            // + Same layout seen here: https://docs.tiledb.com/main/background/key-concepts-and-data-format#indexing
-            domain.AddDimension(Dimension.Create(Ctx, "rows", 1, 4, 2));
-            domain.AddDimension(Dimension.Create(Ctx, "cols", 1, 4, 2));
-
-            using var schema = new ArraySchema(Ctx, ArrayType.Dense);
-            Console.WriteLine($"Tile order: {schema.TileOrder()}; Cell order: {schema.CellOrder()}");
-            schema.SetDomain(domain);
-            schema.AddAttribute(Attribute.Create<int>(Ctx, "a1"));
-
-            Array.Create(Ctx, ArrayPath, schema);
+            Directory.Delete(ArrayPath, true);
         }
 
-        private static void WriteArray()
-        {
-            using var array = new Array(Ctx, ArrayPath);
-            array.Open(QueryType.Write);
-
-            using var queryWrite = new Query(array, QueryType.Write);
-            queryWrite.SetLayout(LayoutType.GlobalOrder);
-            // Slice rows 1-4, columns 1-2 for a total of 8 cells
-            using var subarray = new Subarray(array);
-            subarray.AddRange("rows", 1, 4);
-            subarray.AddRange("cols", 1, 2);
-            queryWrite.SetSubarray(subarray);
-
-            // Write 4 cells
-            queryWrite.SetDataBuffer("a1", new[] { 1, 2, 3, 4 });
-            queryWrite.Submit();
-            Console.WriteLine($"Write query #1 status: {queryWrite.Status()}");
-
-            // Write 4 more cells before we finalize the query
-            queryWrite.SetDataBuffer("a1", new[] { 5, 6, 7, 8});
-            queryWrite.Submit();
-            Console.WriteLine($"Write query #2 status: {queryWrite.Status()}");
-
-            // Important: Global order writes must call Query.FinalizeQuery()
-            queryWrite.FinalizeQuery();
-            array.Close();
-        }
-
-        private static void ReadArray()
-        {
-            using var array = new Array(Ctx, ArrayPath);
-            array.Open(QueryType.Read);
-            using var readQuery = new Query(array, QueryType.Read);
-            using var subarray = new Subarray(array);
-            subarray.SetSubarray(1, 4, 1, 4);
-            readQuery.SetSubarray(subarray);
-
-            var a1Read = new int[16];
-            readQuery.SetDataBuffer("a1", a1Read);
-            readQuery.Submit();
-            Console.WriteLine($"Read query status: {readQuery.Status()}");
-            Console.WriteLine($"a1 data: {string.Join(", ", a1Read)}");
-
-            array.Close();
-        }
-
-        public static void Run()
-        {
-            if (Directory.Exists(ArrayPath))
-            {
-                Directory.Delete(ArrayPath, true);
-            }
-
-            CreateArray();
-            WriteArray();
-            ReadArray();
-        }
+        CreateArray();
+        WriteArray();
+        ReadArray();
     }
 }

--- a/examples/TileDB.CSharp.Example/ExampleWritingSparseGlobal.cs
+++ b/examples/TileDB.CSharp.Example/ExampleWritingSparseGlobal.cs
@@ -2,91 +2,90 @@ using System;
 using System.IO;
 using System.Linq;
 
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+public static class ExampleWritingSparseGlobal
 {
-    public static class ExampleWritingSparseGlobal
+    private static readonly string ArrayPath = ExampleUtil.MakeExamplePath("writing-sparse-global");
+    private static readonly Context Ctx = Context.GetDefault();
+
+    private static void CreateArray()
     {
-        private static readonly string ArrayPath = ExampleUtil.MakeExamplePath("writing-sparse-global");
-        private static readonly Context Ctx = Context.GetDefault();
+        using var domain = new Domain(Ctx);
+        // Create a 4x4 array with 2x2 tile dimensions; Total of 16 cells, 4 tiles, 4 cells each tile
+        // + Same layout seen here: https://docs.tiledb.com/main/background/key-concepts-and-data-format#indexing
+        domain.AddDimension(Dimension.Create(Ctx, "rows", 1, 4, 2));
+        domain.AddDimension(Dimension.Create(Ctx, "cols", 1, 4, 2));
 
-        private static void CreateArray()
+        using var schema = new ArraySchema(Ctx, ArrayType.Sparse);
+        Console.WriteLine($"Tile order: {schema.TileOrder()}; Cell order: {schema.CellOrder()}");
+        schema.SetDomain(domain);
+        schema.AddAttribute(Attribute.Create<int>(Ctx, "a1"));
+
+        Array.Create(Ctx, ArrayPath, schema);
+    }
+
+    private static void WriteArray()
+    {
+        using var array = new Array(Ctx, ArrayPath);
+        array.Open(QueryType.Write);
+        using var queryWrite = new Query(array, QueryType.Write);
+        queryWrite.SetLayout(LayoutType.GlobalOrder);
+
+        // Coordinates for global order writes must be provided in-order
+        // + We may not write to (2, 1) before (1, 1); (2, 1) comes after (1, 1) in global order
+        // + We will write 3 values at (1, 1), (2, 1), (2, 4)
+        queryWrite.SetDataBuffer("rows", new[] { 1, 2, 2 });
+        queryWrite.SetDataBuffer("cols", new[] { 1, 1, 4 });
+        queryWrite.SetDataBuffer("a1", new[] { 1, 2, 3 });
+        queryWrite.Submit();
+        Console.WriteLine($"Write query #1 status: {queryWrite.Status()}");
+
+        // Write 3 more value at coordinates (3, 1), (4, 1), and (4, 4)
+        queryWrite.SetDataBuffer("rows", new[] { 3, 4, 4 });
+        queryWrite.SetDataBuffer("cols", new[] { 1, 1, 4 });
+        queryWrite.SetDataBuffer("a1", new[] { 4, 5, 6 });
+        queryWrite.Submit();
+        Console.WriteLine($"Write query #2 status: {queryWrite.Status()}");
+
+        // Important: Global order writes must call Query.FinalizeQuery()
+        queryWrite.FinalizeQuery();
+        array.Close();
+    }
+
+    private static void ReadArray()
+    {
+        using var array = new Array(Ctx, ArrayPath);
+        array.Open(QueryType.Read);
+        using var readQuery = new Query(array, QueryType.Read);
+        using var subarray = new Subarray(array);
+        subarray.SetSubarray(1, 4, 1, 4);
+        readQuery.SetSubarray(subarray);
+
+        var rowsRead = new int[6];
+        var colsRead = new int[6];
+        var a1Read = new int[6];
+        readQuery.SetDataBuffer("rows", rowsRead);
+        readQuery.SetDataBuffer("cols", colsRead);
+        readQuery.SetDataBuffer("a1", a1Read);
+        readQuery.Submit();
+        Console.WriteLine($"Read query status: {readQuery.Status()}");
+        var coordsRead = rowsRead.Zip(colsRead);
+        var dataRead = coordsRead.Zip(a1Read);
+        Console.WriteLine($"a1 data: {string.Join(", ", dataRead)}");
+
+        array.Close();
+    }
+
+    public static void Run()
+    {
+        if (Directory.Exists(ArrayPath))
         {
-            using var domain = new Domain(Ctx);
-            // Create a 4x4 array with 2x2 tile dimensions; Total of 16 cells, 4 tiles, 4 cells each tile
-            // + Same layout seen here: https://docs.tiledb.com/main/background/key-concepts-and-data-format#indexing
-            domain.AddDimension(Dimension.Create(Ctx, "rows", 1, 4, 2));
-            domain.AddDimension(Dimension.Create(Ctx, "cols", 1, 4, 2));
-
-            using var schema = new ArraySchema(Ctx, ArrayType.Sparse);
-            Console.WriteLine($"Tile order: {schema.TileOrder()}; Cell order: {schema.CellOrder()}");
-            schema.SetDomain(domain);
-            schema.AddAttribute(Attribute.Create<int>(Ctx, "a1"));
-
-            Array.Create(Ctx, ArrayPath, schema);
+            Directory.Delete(ArrayPath, true);
         }
 
-        private static void WriteArray()
-        {
-            using var array = new Array(Ctx, ArrayPath);
-            array.Open(QueryType.Write);
-            using var queryWrite = new Query(array, QueryType.Write);
-            queryWrite.SetLayout(LayoutType.GlobalOrder);
-
-            // Coordinates for global order writes must be provided in-order
-            // + We may not write to (2, 1) before (1, 1); (2, 1) comes after (1, 1) in global order
-            // + We will write 3 values at (1, 1), (2, 1), (2, 4)
-            queryWrite.SetDataBuffer("rows", new[] { 1, 2, 2 });
-            queryWrite.SetDataBuffer("cols", new[] { 1, 1, 4 });
-            queryWrite.SetDataBuffer("a1", new[] { 1, 2, 3 });
-            queryWrite.Submit();
-            Console.WriteLine($"Write query #1 status: {queryWrite.Status()}");
-
-            // Write 3 more value at coordinates (3, 1), (4, 1), and (4, 4)
-            queryWrite.SetDataBuffer("rows", new[] { 3, 4, 4 });
-            queryWrite.SetDataBuffer("cols", new[] { 1, 1, 4 });
-            queryWrite.SetDataBuffer("a1", new[] { 4, 5, 6 });
-            queryWrite.Submit();
-            Console.WriteLine($"Write query #2 status: {queryWrite.Status()}");
-
-            // Important: Global order writes must call Query.FinalizeQuery()
-            queryWrite.FinalizeQuery();
-            array.Close();
-        }
-
-        private static void ReadArray()
-        {
-            using var array = new Array(Ctx, ArrayPath);
-            array.Open(QueryType.Read);
-            using var readQuery = new Query(array, QueryType.Read);
-            using var subarray = new Subarray(array);
-            subarray.SetSubarray(1, 4, 1, 4);
-            readQuery.SetSubarray(subarray);
-
-            var rowsRead = new int[6];
-            var colsRead = new int[6];
-            var a1Read = new int[6];
-            readQuery.SetDataBuffer("rows", rowsRead);
-            readQuery.SetDataBuffer("cols", colsRead);
-            readQuery.SetDataBuffer("a1", a1Read);
-            readQuery.Submit();
-            Console.WriteLine($"Read query status: {readQuery.Status()}");
-            var coordsRead = rowsRead.Zip(colsRead);
-            var dataRead = coordsRead.Zip(a1Read);
-            Console.WriteLine($"a1 data: {string.Join(", ", dataRead)}");
-
-            array.Close();
-        }
-
-        public static void Run()
-        {
-            if (Directory.Exists(ArrayPath))
-            {
-                Directory.Delete(ArrayPath, true);
-            }
-
-            CreateArray();
-            WriteArray();
-            ReadArray();
-        }
+        CreateArray();
+        WriteArray();
+        ReadArray();
     }
 }

--- a/examples/TileDB.CSharp.Example/Program.cs
+++ b/examples/TileDB.CSharp.Example/Program.cs
@@ -1,28 +1,27 @@
 ﻿using System;
 using System.IO;
 using TileDB.CSharp;
-namespace TileDB.CSharp.Examples
+namespace TileDB.CSharp.Examples;
+
+static class Program
 {
-    static class Program
+    static void Main(string[] args)
     {
-        static void Main(string[] args)
-        {
-            Console.WriteLine("TileDB Core Version: {0}", CoreUtil.GetCoreLibVersion());
+        Console.WriteLine("TileDB Core Version: {0}", CoreUtil.GetCoreLibVersion());
 
-            ExampleQuery.Run();
-            ExampleIncompleteQuery.Run();
-            ExampleIncompleteQueryStringDimensions.Run();
-            ExampleIncompleteQueryVariableSize.Run();
-            ExampleWritingDenseGlobal.Run();
-            ExampleWritingSparseGlobal.Run();
-            ExampleDataframe.Run();
-            ExampleAggregateQuery.Run();
+        ExampleQuery.Run();
+        ExampleIncompleteQuery.Run();
+        ExampleIncompleteQueryStringDimensions.Run();
+        ExampleIncompleteQueryVariableSize.Run();
+        ExampleWritingDenseGlobal.Run();
+        ExampleWritingSparseGlobal.Run();
+        ExampleDataframe.Run();
+        ExampleAggregateQuery.Run();
 
-            ExampleFile.RunLocal();
-            // ExampleFile.RunCloud("tiledb_api_token", "tiledb_namespace", "new_cloud_array_name", "s3://bucket/prefix/");
+        ExampleFile.RunLocal();
+        // ExampleFile.RunCloud("tiledb_api_token", "tiledb_namespace", "new_cloud_array_name", "s3://bucket/prefix/");
 
-            ExampleGroup.RunLocal();
-            // ExampleGroup.RunCloud("tiledb_api_token", "tiledb_namespace", "s3://bucket/prefix");
-        }
+        ExampleGroup.RunLocal();
+        // ExampleGroup.RunCloud("tiledb_api_token", "tiledb_namespace", "s3://bucket/prefix");
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.305"
+    "version": "8.0.100",
+    "rollForward": "major"
   }
 }

--- a/sources/TileDB.CSharp/Array.cs
+++ b/sources/TileDB.CSharp/Array.cs
@@ -9,824 +9,823 @@ using ArrayHandle = TileDB.CSharp.Marshalling.SafeHandles.ArrayHandle;
 using ArraySchemaHandle = TileDB.CSharp.Marshalling.SafeHandles.ArraySchemaHandle;
 using ConfigHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents the non-empty domain of all dimensions of an <see cref="Array"/>.
+/// </summary>
+public class NonEmptyDomain
 {
+    private readonly Dictionary<string, object> _dict = new();
+
     /// <summary>
-    /// Represents the non-empty domain of all dimensions of an <see cref="Array"/>.
+    /// Adds a value to the <see cref="NonEmptyDomain"/>.
     /// </summary>
-    public class NonEmptyDomain
+    /// <typeparam name="T">The dimension's type. Usually is <see cref="Tuple{T1, T2}"/>
+    /// of a primitive integer type or <see cref="string"/>.</typeparam>
+    /// <param name="key">The dimension's name.</param>
+    /// <param name="value">The dimension's non-empty domain.</param>
+    public void Add<T>(string key, T? value)
     {
-        private readonly Dictionary<string, object> _dict = new();
-
-        /// <summary>
-        /// Adds a value to the <see cref="NonEmptyDomain"/>.
-        /// </summary>
-        /// <typeparam name="T">The dimension's type. Usually is <see cref="Tuple{T1, T2}"/>
-        /// of a primitive integer type or <see cref="string"/>.</typeparam>
-        /// <param name="key">The dimension's name.</param>
-        /// <param name="value">The dimension's non-empty domain.</param>
-        public void Add<T>(string key, T? value)
-        {
-            if (value != null) _dict.Add(key, value);
-        }
-
-        /// <summary>
-        /// Gets the non-empty domain of a dimension.
-        /// </summary>
-        /// <typeparam name="T">The dimension's type. Usually is <see cref="Tuple{T1, T2}"/>
-        /// of a primitive integer type or <see cref="string"/>.</typeparam>
-        /// <param name="key">The dimension's name.</param>
-        public T Get<T>(string key)
-        {
-            return (T)_dict[key];
-        }
-
-        /// <summary>
-        /// Tries to get the non-empty domain of a dimension, if it exists.
-        /// </summary>
-        /// <typeparam name="T">The dimension's type. Usually is <see cref="Tuple{T1, T2}"/>
-        /// of a primitive integer type or <see cref="string"/>.</typeparam>
-        /// <param name="key">The dimension's name.</param>
-        /// <param name="value">A reference where the dimension's non-empty domain will be written to.</param>
-        /// <returns>Whether a dimension named <paramref name="key"/> has a non-empty domain.</returns>
-        public bool TryGet<T>(string key, [NotNullWhen(true)] out T? value)
-        {
-            if (_dict.TryGetValue(key, out var result) && result is T value1)
-            {
-                value = value1;
-                return true;
-            }
-            value = default;
-            return false;
-        }
+        if (value != null) _dict.Add(key, value);
     }
 
     /// <summary>
-    /// Represents a TileDB array object.
+    /// Gets the non-empty domain of a dimension.
     /// </summary>
-    public sealed unsafe class Array : IDisposable
+    /// <typeparam name="T">The dimension's type. Usually is <see cref="Tuple{T1, T2}"/>
+    /// of a primitive integer type or <see cref="string"/>.</typeparam>
+    /// <param name="key">The dimension's name.</param>
+    public T Get<T>(string key)
     {
-        private readonly ArrayHandle _handle;
-        private readonly Context _ctx;
-        private readonly string _uri;
+        return (T)_dict[key];
+    }
 
-        private readonly ArrayMetadata _metadata;
-
-        /// <summary>
-        /// Creates an <see cref="Array"/>.
-        /// </summary>
-        /// <param name="ctx">The <see cref="CSharp.Context"/> associated with the array.</param>
-        /// <param name="uri">The array's URI.</param>
-        public Array(Context ctx, string uri)
+    /// <summary>
+    /// Tries to get the non-empty domain of a dimension, if it exists.
+    /// </summary>
+    /// <typeparam name="T">The dimension's type. Usually is <see cref="Tuple{T1, T2}"/>
+    /// of a primitive integer type or <see cref="string"/>.</typeparam>
+    /// <param name="key">The dimension's name.</param>
+    /// <param name="value">A reference where the dimension's non-empty domain will be written to.</param>
+    /// <returns>Whether a dimension named <paramref name="key"/> has a non-empty domain.</returns>
+    public bool TryGet<T>(string key, [NotNullWhen(true)] out T? value)
+    {
+        if (_dict.TryGetValue(key, out var result) && result is T value1)
         {
-            _ctx = ctx;
-            _uri = uri;
-            using var ms_uri = new MarshaledString(_uri);
-            _handle = ArrayHandle.Create(_ctx, ms_uri);
-            _metadata = new ArrayMetadata(this);
+            value = value1;
+            return true;
         }
+        value = default;
+        return false;
+    }
+}
 
-        internal Array(Context ctx, ArrayHandle handle)
-        {
-            _ctx = ctx;
-            _handle = handle;
-            _uri = Uri();
-            _metadata = new ArrayMetadata(this);
-        }
+/// <summary>
+/// Represents a TileDB array object.
+/// </summary>
+public sealed unsafe class Array : IDisposable
+{
+    private readonly ArrayHandle _handle;
+    private readonly Context _ctx;
+    private readonly string _uri;
 
-        /// <summary>
-        /// Disposes the <see cref="Array"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            _handle.Dispose();
-        }
+    private readonly ArrayMetadata _metadata;
 
-        internal ArrayHandle Handle => _handle;
+    /// <summary>
+    /// Creates an <see cref="Array"/>.
+    /// </summary>
+    /// <param name="ctx">The <see cref="CSharp.Context"/> associated with the array.</param>
+    /// <param name="uri">The array's URI.</param>
+    public Array(Context ctx, string uri)
+    {
+        _ctx = ctx;
+        _uri = uri;
+        using var ms_uri = new MarshaledString(_uri);
+        _handle = ArrayHandle.Create(_ctx, ms_uri);
+        _metadata = new ArrayMetadata(this);
+    }
 
-        /// <summary>
-        /// Gets the <see cref="CSharp.Context"/> associated with this <see cref="Array"/>.
-        /// </summary>
-        public Context Context()
-        {
-            return _ctx;
-        }
+    internal Array(Context ctx, ArrayHandle handle)
+    {
+        _ctx = ctx;
+        _handle = handle;
+        _uri = Uri();
+        _metadata = new ArrayMetadata(this);
+    }
 
-        /// <summary>
-        /// Gets the <see cref="ArrayMetadata"/> object for this <see cref="Array"/>.
-        /// </summary>
-        public ArrayMetadata Metadata()
-        {
-            return _metadata;
-        }
+    /// <summary>
+    /// Disposes the <see cref="Array"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
 
-        /// <summary>
-        /// Sets the starting timestamp to use when <see cref="Open"/>ing (and <see cref="Reopen"/>ing) the <see cref="Array"/>.
-        /// </summary>
-        /// <param name="timestampStart">The starting timestamp, inclusive.</param>
-        /// <remarks>
-        /// If not set, the default value is zero.
-        /// </remarks>
-        /// <seealso cref="OpenTimestampStart"/>
-        public void SetOpenTimestampStart(ulong timestampStart)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_set_open_timestamp_start(ctxHandle, handle, timestampStart));
-        }
+    internal ArrayHandle Handle => _handle;
 
-        /// <summary>
-        /// Sets the ending timestamp to use when <see cref="Open"/>ing (and <see cref="Reopen"/>ing) the <see cref="Array"/>.
-        /// </summary>
-        /// <param name="timestampEnd">The ending timestamp, inclusive.</param>
-        /// <remarks>
-        /// If not set, the default value is <see cref="ulong.MaxValue"/> which signifies the current time.
-        /// </remarks>
-        /// <seealso cref="OpenTimestampEnd"/>
-        public void SetOpenTimestampEnd(ulong timestampEnd)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_set_open_timestamp_end(ctxHandle, handle, timestampEnd));
-        }
+    /// <summary>
+    /// Gets the <see cref="CSharp.Context"/> associated with this <see cref="Array"/>.
+    /// </summary>
+    public Context Context()
+    {
+        return _ctx;
+    }
 
-        /// <summary>
-        /// Gets the starting timestamp to use when <see cref="Open"/>ing (and <see cref="Reopen"/>ing) the <see cref="Array"/>.
-        /// </summary>
-        /// <seealso cref="SetOpenTimestampStart"/>
-        public ulong OpenTimestampStart()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong timestamp;
-            _ctx.handle_error(Methods.tiledb_array_get_open_timestamp_start(ctxHandle, handle, &timestamp));
-            return timestamp;
-        }
+    /// <summary>
+    /// Gets the <see cref="ArrayMetadata"/> object for this <see cref="Array"/>.
+    /// </summary>
+    public ArrayMetadata Metadata()
+    {
+        return _metadata;
+    }
 
-        /// <summary>
-        /// Sets the ending timestamp to use when <see cref="Open"/>ing (and <see cref="Reopen"/>ing) the <see cref="Array"/>.
-        /// </summary>
-        /// <seealso cref="SetOpenTimestampEnd"/>
-        public ulong OpenTimestampEnd()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong timestamp;
-            _ctx.handle_error(Methods.tiledb_array_get_open_timestamp_end(ctxHandle, handle, &timestamp));
-            return timestamp;
-        }
+    /// <summary>
+    /// Sets the starting timestamp to use when <see cref="Open"/>ing (and <see cref="Reopen"/>ing) the <see cref="Array"/>.
+    /// </summary>
+    /// <param name="timestampStart">The starting timestamp, inclusive.</param>
+    /// <remarks>
+    /// If not set, the default value is zero.
+    /// </remarks>
+    /// <seealso cref="OpenTimestampStart"/>
+    public void SetOpenTimestampStart(ulong timestampStart)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_set_open_timestamp_start(ctxHandle, handle, timestampStart));
+    }
 
-        /// <summary>
-        /// Opens the <see cref="Array"/>.
-        /// </summary>
-        /// <param name="queryType">The default query type if <see cref="Query(CSharp.Context, Array)"/> is called with this array.</param>
-        public void Open(QueryType queryType)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            var tiledb_query_type = (tiledb_query_type_t)queryType;
-            _ctx.handle_error(Methods.tiledb_array_open(ctxHandle, handle, tiledb_query_type));
-        }
+    /// <summary>
+    /// Sets the ending timestamp to use when <see cref="Open"/>ing (and <see cref="Reopen"/>ing) the <see cref="Array"/>.
+    /// </summary>
+    /// <param name="timestampEnd">The ending timestamp, inclusive.</param>
+    /// <remarks>
+    /// If not set, the default value is <see cref="ulong.MaxValue"/> which signifies the current time.
+    /// </remarks>
+    /// <seealso cref="OpenTimestampEnd"/>
+    public void SetOpenTimestampEnd(ulong timestampEnd)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_set_open_timestamp_end(ctxHandle, handle, timestampEnd));
+    }
 
-        /// <summary>
-        /// Reopens the <see cref="Array"/>.
-        /// </summary>
-        public void Reopen()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_reopen(ctxHandle, handle));
-        }
+    /// <summary>
+    /// Gets the starting timestamp to use when <see cref="Open"/>ing (and <see cref="Reopen"/>ing) the <see cref="Array"/>.
+    /// </summary>
+    /// <seealso cref="SetOpenTimestampStart"/>
+    public ulong OpenTimestampStart()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong timestamp;
+        _ctx.handle_error(Methods.tiledb_array_get_open_timestamp_start(ctxHandle, handle, &timestamp));
+        return timestamp;
+    }
 
-        /// <summary>
-        /// Checks whether the <see cref="Array"/> is open or not.
-        /// </summary>
-        public bool IsOpen()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            int int_open;
-            _ctx.handle_error(Methods.tiledb_array_is_open(ctxHandle, handle, &int_open));
-            return int_open > 0;
-        }
+    /// <summary>
+    /// Sets the ending timestamp to use when <see cref="Open"/>ing (and <see cref="Reopen"/>ing) the <see cref="Array"/>.
+    /// </summary>
+    /// <seealso cref="SetOpenTimestampEnd"/>
+    public ulong OpenTimestampEnd()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong timestamp;
+        _ctx.handle_error(Methods.tiledb_array_get_open_timestamp_end(ctxHandle, handle, &timestamp));
+        return timestamp;
+    }
 
-        /// <summary>
-        /// Sets the <see cref="CSharp.Config"/> to the <see cref="Array"/>.
-        /// </summary>
-        /// <param name="config">The config to use</param>
-        public void SetConfig(Config config)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var configHandle = config.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_set_config(ctxHandle, handle, configHandle));
-        }
+    /// <summary>
+    /// Opens the <see cref="Array"/>.
+    /// </summary>
+    /// <param name="queryType">The default query type if <see cref="Query(CSharp.Context, Array)"/> is called with this array.</param>
+    public void Open(QueryType queryType)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        var tiledb_query_type = (tiledb_query_type_t)queryType;
+        _ctx.handle_error(Methods.tiledb_array_open(ctxHandle, handle, tiledb_query_type));
+    }
 
-        /// <summary>
-        /// Gets the <see cref="CSharp.Config"/> of the <see cref="Array"/>.
-        /// </summary>
-        public Config Config()
-        {
-            var handle = new ConfigHandle();
-            tiledb_config_t* config = null;
-            var successful = false;
-            try
-            {
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var arrayHandle = _handle.Acquire();
-                _ctx.handle_error(Methods.tiledb_array_get_config(ctxHandle, arrayHandle, &config));
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(config);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-            return new Config(handle);
-        }
+    /// <summary>
+    /// Reopens the <see cref="Array"/>.
+    /// </summary>
+    public void Reopen()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_reopen(ctxHandle, handle));
+    }
 
-        /// <summary>
-        /// Closes the <see cref="Array"/>.
-        /// </summary>
-        public void Close()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_close(ctxHandle, handle));
-        }
+    /// <summary>
+    /// Checks whether the <see cref="Array"/> is open or not.
+    /// </summary>
+    public bool IsOpen()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        int int_open;
+        _ctx.handle_error(Methods.tiledb_array_is_open(ctxHandle, handle, &int_open));
+        return int_open > 0;
+    }
 
-        /// <summary>
-        /// Gets the <see cref="Array"/>'s <see cref="ArraySchema"/>.
-        /// </summary>
-        public ArraySchema Schema()
-        {
-            var handle = new ArraySchemaHandle();
-            var successful = false;
-            tiledb_array_schema_t* array_schema_p = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var arrayHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_array_get_schema(ctxHandle, arrayHandle, &array_schema_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(array_schema_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-            return new ArraySchema(_ctx, handle);
-        }
+    /// <summary>
+    /// Sets the <see cref="CSharp.Config"/> to the <see cref="Array"/>.
+    /// </summary>
+    /// <param name="config">The config to use</param>
+    public void SetConfig(Config config)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var configHandle = config.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_set_config(ctxHandle, handle, configHandle));
+    }
 
-        /// <summary>
-        /// Gets the <see cref="CSharp.QueryType"/> with which the <see cref="Array"/> was <see cref="Open"/>ed.
-        /// </summary>
-        public QueryType QueryType()
+    /// <summary>
+    /// Gets the <see cref="CSharp.Config"/> of the <see cref="Array"/>.
+    /// </summary>
+    public Config Config()
+    {
+        var handle = new ConfigHandle();
+        tiledb_config_t* config = null;
+        var successful = false;
+        try
         {
             using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_query_type_t tiledb_query_type;
-            _ctx.handle_error(Methods.tiledb_array_get_query_type(ctxHandle, handle, &tiledb_query_type));
-            return (QueryType)tiledb_query_type;
+            using var arrayHandle = _handle.Acquire();
+            _ctx.handle_error(Methods.tiledb_array_get_config(ctxHandle, arrayHandle, &config));
+            successful = true;
         }
-
-        /// <summary>
-        /// Creates an <see cref="Array"/> at a given URI.
-        /// </summary>
-        /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
-        /// <param name="uri">The array's URI.</param>
-        /// <param name="schema">The array's schema.</param>
-        /// <seealso cref="Create(ArraySchema)"/>
-        public static void Create(Context ctx, string uri, ArraySchema schema)
+        finally
         {
-            using var ms_uri = new MarshaledString(uri);
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var schemaHandle = schema.Handle.Acquire();
-            ctx.handle_error(Methods.tiledb_array_create(ctxHandle, ms_uri, schemaHandle));
-        }
-
-        /// <summary>
-        /// Creates the <see cref="Array"/> at <see cref="Uri"/>.
-        /// </summary>
-        /// <param name="schema">The array's <see cref="ArraySchema"/>.</param>
-        /// <seealso cref="Create(CSharp.Context, string, ArraySchema)"/>
-        public void Create(ArraySchema schema)
-        {
-            Create(_ctx, _uri, schema);
-        }
-
-        /// <summary>
-        /// Applies an <see cref="ArraySchemaEvolution"/> to the schema of an array.
-        /// </summary>
-        /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
-        /// <param name="uri">The array's URI.</param>
-        /// <param name="schemaEvolution">The schema evolution to use.</param>
-        /// <seealso cref="Evolve(ArraySchemaEvolution)"/>
-        public static void Evolve(Context ctx, string uri, ArraySchemaEvolution schemaEvolution)
-        {
-            using var msUri = new MarshaledString(uri);
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var schemaEvolutionHandle = schemaEvolution.Handle.Acquire();
-            ctx.handle_error(Methods.tiledb_array_evolve(ctxHandle, msUri, schemaEvolutionHandle));
-        }
-
-        /// <summary>
-        /// Applies an <see cref="ArraySchemaEvolution"/> to the schema of this <see cref="Array"/>.
-        /// </summary>
-        /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
-        /// <param name="schemaEvolution">The schema evolution to use.</param>
-        /// <seealso cref="Evolve(ArraySchemaEvolution)"/>
-        /// <seealso cref="Evolve(CSharp.Context, string, ArraySchemaEvolution)"/>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Evolve(Context ctx, ArraySchemaEvolution schemaEvolution)
-        {
-            Evolve(ctx, _uri, schemaEvolution);
-        }
-
-        /// <summary>
-        /// Applies an <see cref="ArraySchemaEvolution"/> to the schema of this <see cref="Array"/>.
-        /// </summary>
-        /// <param name="schemaEvolution">The schema evolution to use.</param>
-        /// <seealso cref="Evolve(CSharp.Context, string, ArraySchemaEvolution)"/>
-        public void Evolve(ArraySchemaEvolution schemaEvolution)
-        {
-            Evolve(_ctx, _uri, schemaEvolution);
-        }
-
-        /// <summary>
-        /// Consolidates an array.
-        /// </summary>
-        /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
-        /// <param name="uri">The array's URI.</param>
-        /// <param name="config">Configuration parameters for the consolidation. Optional.</param>
-        public static void Consolidate(Context ctx, string uri, Config? config = null)
-        {
-            using var ms_uri = new MarshaledString(uri);
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var configHandle = config?.Handle.Acquire() ?? default;
-            ctx.handle_error(Methods.tiledb_array_consolidate(ctxHandle, ms_uri, configHandle));
-        }
-
-        /// <summary>
-        /// Consolidates the given fragments of an array into a single fragment.
-        /// </summary>
-        /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
-        /// <param name="uri">The array's URI.</param>
-        /// <param name="fragments">The names of the fragments to consolidate. They can be retrieved using <see cref="FragmentInfo.GetFragmentName"/>.</param>
-        /// <param name="config">Configuration parameters for the consolidation. Optional.</param>
-        public static void ConsolidateFragments(Context ctx, string uri, IReadOnlyList<string> fragments, Config? config = null)
-        {
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            using var msc_fragments = new MarshaledStringCollection(fragments);
-            using var configHandle = config?.Handle.Acquire() ?? default;
-            ctx.handle_error(Methods.tiledb_array_consolidate_fragments(ctxHandle, ms_uri, (sbyte**)msc_fragments.Strings, (ulong)msc_fragments.Count, configHandle));
-        }
-
-        /// <summary>
-        /// Vacuums an array.
-        /// </summary>
-        /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
-        /// <param name="uri">The array's URI.</param>
-        /// <param name="config">Configuration parameters for the consolidation. Optional.</param>
-        public static void Vacuum(Context ctx, string uri, Config? config = null)
-        {
-            using var ms_uri = new MarshaledString(uri);
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var configHandle = config?.Handle.Acquire() ?? default;
-            ctx.handle_error(Methods.tiledb_array_vacuum(ctxHandle, ms_uri, configHandle));
-        }
-
-        /// <summary>
-        /// Gets the non-empty domain of all dimensions of the <see cref="Array"/>.
-        /// </summary>
-        public (NonEmptyDomain, bool) NonEmptyDomain()
-        {
-            NonEmptyDomain nonEmptyDomain = new();
-            using ArraySchema schema = Schema();
-            using Domain domain = schema.Domain();
-
-            var ndim = domain.NDim();
-            if (ndim == 0)
+            if (successful)
             {
-                return (nonEmptyDomain, true);
+                handle.InitHandle(config);
             }
-
-            bool isEmptyDomain = true;
-            for (uint i = 0; i < ndim; ++i)
+            else
             {
-                using var dim = domain.Dimension(i);
-                var dimName = dim.Name();
-                var dimType = EnumUtil.DataTypeToType(dim.Type());
-
-                switch (Type.GetTypeCode(dimType))
-                {
-                    case TypeCode.SByte:
-                        GetDomain<sbyte>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
-                        break;
-                    case TypeCode.Int16:
-                        GetDomain<short>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
-                        break;
-                    case TypeCode.Int32:
-                        GetDomain<int>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
-                        break;
-                    case TypeCode.Int64:
-                        GetDomain<long>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
-                        break;
-                    case TypeCode.Byte:
-                        GetDomain<byte>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
-                        break;
-                    case TypeCode.UInt16:
-                        GetDomain<ushort>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
-                        break;
-                    case TypeCode.UInt32:
-                        GetDomain<uint>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
-                        break;
-                    case TypeCode.UInt64:
-                        GetDomain<ulong>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
-                        break;
-                    case TypeCode.Single:
-                        GetDomain<float>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
-                        break;
-                    case TypeCode.Double:
-                        GetDomain<double>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
-                        break;
-                    case TypeCode.String:
-                        {
-                            (string data0, string data1, bool isEmpty) = NonEmptyDomainVar(i);
-                            if (!isEmpty)
-                            {
-                                isEmptyDomain = false;
-                            }
-
-                            nonEmptyDomain.Add(dimName, new Tuple<string, string>(data0, data1));
-                        }
-                        break;
-                }
-            }
-
-            return (nonEmptyDomain, isEmptyDomain);
-
-            static void GetDomain<T>(Array array, string dimName, uint i, NonEmptyDomain nonEmptyDomain, ref bool isEmptyDomain) where T : struct
-            {
-                (T data0, T data1, bool isEmpty) = array.NonEmptyDomain<T>(i);
-                if (!isEmpty)
-                {
-                    isEmptyDomain = false;
-                }
-                nonEmptyDomain.Add(dimName, new Tuple<T, T>(data0, data1));
+                handle.SetHandleAsInvalid();
             }
         }
+        return new Config(handle);
+    }
 
-        /// <summary>
-        /// Gets the non-empty domain from a dimension of the <see cref="Array"/>, identified by its index.
-        /// </summary>
-        /// <typeparam name="T">The dimension's type.</typeparam>
-        /// <param name="index">The dimension's index.</param>
-        /// <returns>The domain's start and end values, along with whether it is empty.</returns>
-        /// <exception cref="ArgumentException"><typeparamref name="T"/> is not the dimension's type.</exception>
-        public (T Start, T End, bool IsEmpty) NonEmptyDomain<T>(uint index) where T : struct
-        {
-            using (var schema = Schema())
-            using (var domain = schema.Domain())
-            using (var dimension = domain.Dimension(index))
-            {
-                ErrorHandling.CheckDataType<T>(dimension.Type());
-            }
+    /// <summary>
+    /// Closes the <see cref="Array"/>.
+    /// </summary>
+    public void Close()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_close(ctxHandle, handle));
+    }
 
-            SequentialPair<T> data;
-            int int_empty;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_from_index(ctxHandle, handle, index,
-                &data, &int_empty));
-
-            return int_empty > 0 ? (default(T), default(T), true) : (data.First, data.Second, false);
-        }
-
-        /// <summary>
-        /// Gets the non-empty domain from a dimension of the <see cref="Array"/>, identified by its name.
-        /// </summary>
-        /// <typeparam name="T">The dimension's type.</typeparam>
-        /// <param name="name">The dimension's name.</param>
-        /// <returns>The domain's start and end values, along with whether it is empty.</returns>
-        /// <exception cref="ArgumentException"><typeparamref name="T"/> is not the dimension's type.</exception>
-        public (T Start, T End, bool IsEmpty) NonEmptyDomain<T>(string name) where T : struct
-        {
-            using (var schema = Schema())
-            using (var domain = schema.Domain())
-            using (var dimension = domain.Dimension(name))
-            {
-                ErrorHandling.CheckDataType<T>(dimension.Type());
-            }
-
-            using var ms_name = new MarshaledString(name);
-            SequentialPair<T> data;
-            int int_empty;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_from_name(ctxHandle, handle, ms_name, &data, &int_empty));
-
-            return int_empty > 0 ? (default(T), default(T), true) : (data.First, data.Second, false);
-        }
-
-        /// <summary>
-        /// Gets the non-empty domain from a variable-sized dimension of the <see cref="Array"/>, identified by its index.
-        /// </summary>
-        /// <param name="index">The dimension's index.</param>
-        /// <returns>The domain's start and end values, along with whether it is empty.</returns>
-        public (string Start, string End, bool IsEmpty) NonEmptyDomainVar(uint index)
-        {
-            ulong start_size64;
-            ulong end_size64;
-            int int_empty;
-            using (var ctxHandle = _ctx.Handle.Acquire())
-            using (var handle = _handle.Acquire())
-            {
-                _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_var_size_from_index(ctxHandle, handle, index, &start_size64, &end_size64, &int_empty));
-            }
-            if (int_empty > 0)
-            {
-                return (string.Empty, string.Empty, true);
-            }
-
-            int start_size = checked((int)start_size64);
-            int end_size = checked((int)end_size64);
-
-            using var start = new ScratchBuffer<byte>(start_size, stackalloc byte[128], exactSize: true);
-            using var end = new ScratchBuffer<byte>(end_size, stackalloc byte[128], exactSize: true);
-
-            using (var ctxHandle = _ctx.Handle.Acquire())
-            using (var handle = _handle.Acquire())
-            {
-                fixed (byte* startPtr = start, endPtr = end)
-                    _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_var_from_index(ctxHandle, handle, index,
-                        startPtr, endPtr, &int_empty));
-            }
-
-            return (MarshaledStringOut.GetString(start.Span), MarshaledStringOut.GetString(end.Span), false);
-        }
-
-        /// <summary>
-        /// Gets the non-empty domain from a variable-sized dimension of the <see cref="Array"/>, identified by its name.
-        /// </summary>
-        /// <param name="name">The dimension's name.</param>
-        /// <returns>The domain's start and end values, along with whether it is empty.</returns>
-        public (string Start, string End, bool IsEmpty) NonEmptyDomainVar(string name)
-        {
-            ulong start_size64;
-            ulong end_size64;
-            int int_empty;
-            using var ms_name = new MarshaledString(name);
-
-            using (var ctxHandle = _ctx.Handle.Acquire())
-            using (var handle = _handle.Acquire())
-            {
-                _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_var_size_from_name(ctxHandle, handle, ms_name, &start_size64, &end_size64, &int_empty));
-            }
-
-            if (int_empty > 0)
-            {
-                return (string.Empty, string.Empty, true);
-            }
-
-            int start_size = checked((int)start_size64);
-            int end_size = checked((int)end_size64);
-
-            using var start = new ScratchBuffer<byte>(start_size, stackalloc byte[128], exactSize: true);
-            using var end = new ScratchBuffer<byte>(end_size, stackalloc byte[128], exactSize: true);
-
-            using (var ctxHandle = _ctx.Handle.Acquire())
-            using (var handle = _handle.Acquire())
-            {
-                fixed (byte* startPtr = start, endPtr = end)
-                    _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_var_from_name(ctxHandle, handle, ms_name,
-                        startPtr, endPtr, &int_empty));
-            }
-
-            return new(MarshaledStringOut.GetString(start.Span), MarshaledStringOut.GetString(end.Span), false);
-        }
-
-        /// <summary>
-        /// Gets the array's URI.
-        /// </summary>
-        public string Uri()
-        {
-            sbyte* result;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_get_uri(ctxHandle, handle, &result));
-
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        /// <summary>
-        /// Gets the <see cref="CSharp.EncryptionType"/> with which an array was encrypted.
-        /// </summary>
-        /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
-        /// <param name="uri">The array's URI.</param>
-        public static EncryptionType EncryptionType(Context ctx, string uri)
-        {
-            using var ms_uri = new MarshaledString(uri);
-            tiledb_encryption_type_t tiledb_encryption_type;
-            using var ctxHandle = ctx.Handle.Acquire();
-            ctx.handle_error(Methods.tiledb_array_encryption_type(ctxHandle, ms_uri, &tiledb_encryption_type));
-            return (EncryptionType)tiledb_encryption_type;
-        }
-
-        /// <summary>
-        /// Gets an <see cref="Enumeration"/> from the <see cref="Array"/> by name.
-        /// </summary>
-        /// <param name="name">The enumeration's name.</param>
-        /// <seealso cref="LoadAllEnumerations"/>
-        public Enumeration GetEnumeration(string name)
-        {
-            var handle = new EnumerationHandle();
-            var successful = false;
-            tiledb_enumeration_t* enumeration_p = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var arrayHandle = _handle.Acquire())
-                using (var ms_name = new MarshaledString(name))
-                {
-                    _ctx.handle_error(Methods.tiledb_array_get_enumeration(ctxHandle, arrayHandle, ms_name, &enumeration_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(enumeration_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return new Enumeration(_ctx, handle);
-        }
-
-        /// <summary>
-        /// Loads all enumerations of the <see cref="Array"/>.
-        /// </summary>
-        /// <seealso cref="GetEnumeration"/>
-        public void LoadAllEnumerations()
+    /// <summary>
+    /// Gets the <see cref="Array"/>'s <see cref="ArraySchema"/>.
+    /// </summary>
+    public ArraySchema Schema()
+    {
+        var handle = new ArraySchemaHandle();
+        var successful = false;
+        tiledb_array_schema_t* array_schema_p = null;
+        try
         {
             using (var ctxHandle = _ctx.Handle.Acquire())
             using (var arrayHandle = _handle.Acquire())
             {
-                _ctx.handle_error(Methods.tiledb_array_load_all_enumerations(ctxHandle, arrayHandle));
+                _ctx.handle_error(Methods.tiledb_array_get_schema(ctxHandle, arrayHandle, &array_schema_p));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(array_schema_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+        return new ArraySchema(_ctx, handle);
+    }
+
+    /// <summary>
+    /// Gets the <see cref="CSharp.QueryType"/> with which the <see cref="Array"/> was <see cref="Open"/>ed.
+    /// </summary>
+    public QueryType QueryType()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        tiledb_query_type_t tiledb_query_type;
+        _ctx.handle_error(Methods.tiledb_array_get_query_type(ctxHandle, handle, &tiledb_query_type));
+        return (QueryType)tiledb_query_type;
+    }
+
+    /// <summary>
+    /// Creates an <see cref="Array"/> at a given URI.
+    /// </summary>
+    /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
+    /// <param name="uri">The array's URI.</param>
+    /// <param name="schema">The array's schema.</param>
+    /// <seealso cref="Create(ArraySchema)"/>
+    public static void Create(Context ctx, string uri, ArraySchema schema)
+    {
+        using var ms_uri = new MarshaledString(uri);
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var schemaHandle = schema.Handle.Acquire();
+        ctx.handle_error(Methods.tiledb_array_create(ctxHandle, ms_uri, schemaHandle));
+    }
+
+    /// <summary>
+    /// Creates the <see cref="Array"/> at <see cref="Uri"/>.
+    /// </summary>
+    /// <param name="schema">The array's <see cref="ArraySchema"/>.</param>
+    /// <seealso cref="Create(CSharp.Context, string, ArraySchema)"/>
+    public void Create(ArraySchema schema)
+    {
+        Create(_ctx, _uri, schema);
+    }
+
+    /// <summary>
+    /// Applies an <see cref="ArraySchemaEvolution"/> to the schema of an array.
+    /// </summary>
+    /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
+    /// <param name="uri">The array's URI.</param>
+    /// <param name="schemaEvolution">The schema evolution to use.</param>
+    /// <seealso cref="Evolve(ArraySchemaEvolution)"/>
+    public static void Evolve(Context ctx, string uri, ArraySchemaEvolution schemaEvolution)
+    {
+        using var msUri = new MarshaledString(uri);
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var schemaEvolutionHandle = schemaEvolution.Handle.Acquire();
+        ctx.handle_error(Methods.tiledb_array_evolve(ctxHandle, msUri, schemaEvolutionHandle));
+    }
+
+    /// <summary>
+    /// Applies an <see cref="ArraySchemaEvolution"/> to the schema of this <see cref="Array"/>.
+    /// </summary>
+    /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
+    /// <param name="schemaEvolution">The schema evolution to use.</param>
+    /// <seealso cref="Evolve(ArraySchemaEvolution)"/>
+    /// <seealso cref="Evolve(CSharp.Context, string, ArraySchemaEvolution)"/>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public void Evolve(Context ctx, ArraySchemaEvolution schemaEvolution)
+    {
+        Evolve(ctx, _uri, schemaEvolution);
+    }
+
+    /// <summary>
+    /// Applies an <see cref="ArraySchemaEvolution"/> to the schema of this <see cref="Array"/>.
+    /// </summary>
+    /// <param name="schemaEvolution">The schema evolution to use.</param>
+    /// <seealso cref="Evolve(CSharp.Context, string, ArraySchemaEvolution)"/>
+    public void Evolve(ArraySchemaEvolution schemaEvolution)
+    {
+        Evolve(_ctx, _uri, schemaEvolution);
+    }
+
+    /// <summary>
+    /// Consolidates an array.
+    /// </summary>
+    /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
+    /// <param name="uri">The array's URI.</param>
+    /// <param name="config">Configuration parameters for the consolidation. Optional.</param>
+    public static void Consolidate(Context ctx, string uri, Config? config = null)
+    {
+        using var ms_uri = new MarshaledString(uri);
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var configHandle = config?.Handle.Acquire() ?? default;
+        ctx.handle_error(Methods.tiledb_array_consolidate(ctxHandle, ms_uri, configHandle));
+    }
+
+    /// <summary>
+    /// Consolidates the given fragments of an array into a single fragment.
+    /// </summary>
+    /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
+    /// <param name="uri">The array's URI.</param>
+    /// <param name="fragments">The names of the fragments to consolidate. They can be retrieved using <see cref="FragmentInfo.GetFragmentName"/>.</param>
+    /// <param name="config">Configuration parameters for the consolidation. Optional.</param>
+    public static void ConsolidateFragments(Context ctx, string uri, IReadOnlyList<string> fragments, Config? config = null)
+    {
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        using var msc_fragments = new MarshaledStringCollection(fragments);
+        using var configHandle = config?.Handle.Acquire() ?? default;
+        ctx.handle_error(Methods.tiledb_array_consolidate_fragments(ctxHandle, ms_uri, (sbyte**)msc_fragments.Strings, (ulong)msc_fragments.Count, configHandle));
+    }
+
+    /// <summary>
+    /// Vacuums an array.
+    /// </summary>
+    /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
+    /// <param name="uri">The array's URI.</param>
+    /// <param name="config">Configuration parameters for the consolidation. Optional.</param>
+    public static void Vacuum(Context ctx, string uri, Config? config = null)
+    {
+        using var ms_uri = new MarshaledString(uri);
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var configHandle = config?.Handle.Acquire() ?? default;
+        ctx.handle_error(Methods.tiledb_array_vacuum(ctxHandle, ms_uri, configHandle));
+    }
+
+    /// <summary>
+    /// Gets the non-empty domain of all dimensions of the <see cref="Array"/>.
+    /// </summary>
+    public (NonEmptyDomain, bool) NonEmptyDomain()
+    {
+        NonEmptyDomain nonEmptyDomain = new();
+        using ArraySchema schema = Schema();
+        using Domain domain = schema.Domain();
+
+        var ndim = domain.NDim();
+        if (ndim == 0)
+        {
+            return (nonEmptyDomain, true);
+        }
+
+        bool isEmptyDomain = true;
+        for (uint i = 0; i < ndim; ++i)
+        {
+            using var dim = domain.Dimension(i);
+            var dimName = dim.Name();
+            var dimType = EnumUtil.DataTypeToType(dim.Type());
+
+            switch (Type.GetTypeCode(dimType))
+            {
+                case TypeCode.SByte:
+                    GetDomain<sbyte>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
+                    break;
+                case TypeCode.Int16:
+                    GetDomain<short>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
+                    break;
+                case TypeCode.Int32:
+                    GetDomain<int>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
+                    break;
+                case TypeCode.Int64:
+                    GetDomain<long>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
+                    break;
+                case TypeCode.Byte:
+                    GetDomain<byte>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
+                    break;
+                case TypeCode.UInt16:
+                    GetDomain<ushort>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
+                    break;
+                case TypeCode.UInt32:
+                    GetDomain<uint>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
+                    break;
+                case TypeCode.UInt64:
+                    GetDomain<ulong>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
+                    break;
+                case TypeCode.Single:
+                    GetDomain<float>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
+                    break;
+                case TypeCode.Double:
+                    GetDomain<double>(this, dimName, i, nonEmptyDomain, ref isEmptyDomain);
+                    break;
+                case TypeCode.String:
+                    {
+                        (string data0, string data1, bool isEmpty) = NonEmptyDomainVar(i);
+                        if (!isEmpty)
+                        {
+                            isEmptyDomain = false;
+                        }
+
+                        nonEmptyDomain.Add(dimName, new Tuple<string, string>(data0, data1));
+                    }
+                    break;
             }
         }
 
-        /// <summary>
-        /// Puts a multi-value metadata to the <see cref="Array"/>.
-        /// </summary>
-        /// <typeparam name="T">The metadata's type.</typeparam>
-        /// <param name="key">THe metadata's key.</param>
-        /// <param name="data">The metadata's value.</param>
-        public void PutMetadata<T>(string key, T[] data) where T : struct
-        {
-            _metadata.PutMetadata<T>(key, data);
-        }
+        return (nonEmptyDomain, isEmptyDomain);
 
-        /// <summary>
-        /// Puts a single-value metadata to the <see cref="Array"/>.
-        /// </summary>
-        /// <typeparam name="T">The metadata's type.</typeparam>
-        /// <param name="key">THe metadata's key.</param>
-        /// <param name="v">The metadata's value.</param>
-        public void PutMetadata<T>(string key, T v) where T : struct
+        static void GetDomain<T>(Array array, string dimName, uint i, NonEmptyDomain nonEmptyDomain, ref bool isEmptyDomain) where T : struct
         {
-            _metadata.PutMetadata<T>(key, v);
+            (T data0, T data1, bool isEmpty) = array.NonEmptyDomain<T>(i);
+            if (!isEmpty)
+            {
+                isEmptyDomain = false;
+            }
+            nonEmptyDomain.Add(dimName, new Tuple<T, T>(data0, data1));
         }
-
-        /// <summary>
-        /// Puts a string-typed metadata to the <see cref="Array"/>.
-        /// </summary>
-        /// <param name="key">THe metadata's key.</param>
-        /// <param name="value">The metadata's value.</param>
-        public void PutMetadata(string key, string value)
-        {
-            _metadata.PutMetadata(key, value);
-        }
-
-        /// <summary>
-        /// Deletes a metadata from the <see cref="Array"/>.
-        /// </summary>
-        /// <param name="key">The metadata's ket.</param>
-        public void DeleteMetadata(string key)
-        {
-            _metadata.DeleteMetadata(key);
-        }
-
-        /// <summary>
-        /// Deletes fragments from an array that fall within the given timestamp range.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> to use.</param>
-        /// <param name="uri">The URI to the array.</param>
-        /// <param name="timestampStart">The start of the timestamp range, inclusive.</param>
-        /// <param name="timestampEnd">The end of the timestamp range, inclusive.</param>
-        public static void DeleteFragments(Context ctx, string uri, ulong timestampStart, ulong timestampEnd)
-        {
-            using var ms_uri = new MarshaledString(uri);
-            using var ctxHandle = ctx.Handle.Acquire();
-            ctx.handle_error(Methods.tiledb_array_delete_fragments_v2(ctxHandle, ms_uri, timestampStart, timestampEnd));
-        }
-
-        /// <summary>
-        /// Deletes fragments from an array that fall within the given timestamp range.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> to use.</param>
-        /// <param name="uri">The URI to the array.</param>
-        /// <param name="fragmentUris">A list with the URIs of the fragments to delete.</param>
-        public static void DeleteFragments(Context ctx, string uri, IReadOnlyList<string> fragmentUris)
-        {
-            using var ms_uri = new MarshaledString(uri);
-            using var msc_fragmentUris = new MarshaledStringCollection(fragmentUris);
-            using var ctxHandle = ctx.Handle.Acquire();
-            ctx.handle_error(Methods.tiledb_array_delete_fragments_list(ctxHandle, ms_uri, (sbyte**)msc_fragmentUris.Strings, (nuint)msc_fragmentUris.Count));
-        }
-
-        /// <summary>
-        /// Gets metadata from the <see cref="Array"/>.
-        /// </summary>
-        /// <typeparam name="T">The metadata's type.</typeparam>
-        /// <param name="key">The metadata's key.</param>
-        /// <returns>An array with the metadata values.</returns>
-        public T[] GetMetadata<T>(string key) where T : struct
-        {
-            return _metadata.GetMetadata<T>(key);
-        }
-
-        /// <summary>
-        /// Gets string-typed metadata from the <see cref="Array"/>.
-        /// </summary>
-        /// <param name="key">The metadata's key.</param>
-        public string GetMetadata(string key)
-        {
-            return _metadata.GetMetadata(key);
-        }
-
-        /// <summary>
-        /// Gets the number of metadata of the <see cref="Array"/>.
-        /// </summary>
-        public ulong MetadataNum()
-        {
-            return _metadata.MetadataNum();
-        }
-
-        /// <summary>
-        /// Gets the <see cref="Array"/>'s metadata key and value by index.
-        /// </summary>
-        /// <typeparam name="T">The metadata's type.</typeparam>
-        /// <param name="index">The metadata's index. Must be between zero and <see cref="MetadataNum"/> minus one.</param>
-        /// <returns>A tuple with the metadata's key and value.</returns>
-        public (string key, T[] data) GetMetadataFromIndex<T>(ulong index) where T : struct
-        {
-            return _metadata.GetMetadataFromIndex<T>(index);
-        }
-
-        /// <summary>
-        /// Gets the <see cref="Array"/>'s metadata keys.
-        /// </summary>
-        public string[] MetadataKeys()
-        {
-            return _metadata.MetadataKeys();
-        }
-
-        /// <summary>
-        /// Checks whether a metadata with a given key exists in the <see cref="Array"/>.
-        /// </summary>
-        /// <param name="key">The metadata's key</param>
-        /// <returns>A tuple of whether the metadata exists, and its type.</returns>
-        public (bool has_key, DataType datatype) HasMetadata(string key)
-        {
-            return _metadata.HasMetadata(key);
-        }
-
-        /// <summary>
-        /// Loads the <see cref="ArraySchema"/> of an array at the given path.
-        /// </summary>
-        /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
-        /// <param name="path">The array's path.</param>
-        public static ArraySchema LoadArraySchema(Context ctx, string path) => ArraySchema.Load(ctx, path);
     }
+
+    /// <summary>
+    /// Gets the non-empty domain from a dimension of the <see cref="Array"/>, identified by its index.
+    /// </summary>
+    /// <typeparam name="T">The dimension's type.</typeparam>
+    /// <param name="index">The dimension's index.</param>
+    /// <returns>The domain's start and end values, along with whether it is empty.</returns>
+    /// <exception cref="ArgumentException"><typeparamref name="T"/> is not the dimension's type.</exception>
+    public (T Start, T End, bool IsEmpty) NonEmptyDomain<T>(uint index) where T : struct
+    {
+        using (var schema = Schema())
+        using (var domain = schema.Domain())
+        using (var dimension = domain.Dimension(index))
+        {
+            ErrorHandling.CheckDataType<T>(dimension.Type());
+        }
+
+        SequentialPair<T> data;
+        int int_empty;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_from_index(ctxHandle, handle, index,
+            &data, &int_empty));
+
+        return int_empty > 0 ? (default(T), default(T), true) : (data.First, data.Second, false);
+    }
+
+    /// <summary>
+    /// Gets the non-empty domain from a dimension of the <see cref="Array"/>, identified by its name.
+    /// </summary>
+    /// <typeparam name="T">The dimension's type.</typeparam>
+    /// <param name="name">The dimension's name.</param>
+    /// <returns>The domain's start and end values, along with whether it is empty.</returns>
+    /// <exception cref="ArgumentException"><typeparamref name="T"/> is not the dimension's type.</exception>
+    public (T Start, T End, bool IsEmpty) NonEmptyDomain<T>(string name) where T : struct
+    {
+        using (var schema = Schema())
+        using (var domain = schema.Domain())
+        using (var dimension = domain.Dimension(name))
+        {
+            ErrorHandling.CheckDataType<T>(dimension.Type());
+        }
+
+        using var ms_name = new MarshaledString(name);
+        SequentialPair<T> data;
+        int int_empty;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_from_name(ctxHandle, handle, ms_name, &data, &int_empty));
+
+        return int_empty > 0 ? (default(T), default(T), true) : (data.First, data.Second, false);
+    }
+
+    /// <summary>
+    /// Gets the non-empty domain from a variable-sized dimension of the <see cref="Array"/>, identified by its index.
+    /// </summary>
+    /// <param name="index">The dimension's index.</param>
+    /// <returns>The domain's start and end values, along with whether it is empty.</returns>
+    public (string Start, string End, bool IsEmpty) NonEmptyDomainVar(uint index)
+    {
+        ulong start_size64;
+        ulong end_size64;
+        int int_empty;
+        using (var ctxHandle = _ctx.Handle.Acquire())
+        using (var handle = _handle.Acquire())
+        {
+            _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_var_size_from_index(ctxHandle, handle, index, &start_size64, &end_size64, &int_empty));
+        }
+        if (int_empty > 0)
+        {
+            return (string.Empty, string.Empty, true);
+        }
+
+        int start_size = checked((int)start_size64);
+        int end_size = checked((int)end_size64);
+
+        using var start = new ScratchBuffer<byte>(start_size, stackalloc byte[128], exactSize: true);
+        using var end = new ScratchBuffer<byte>(end_size, stackalloc byte[128], exactSize: true);
+
+        using (var ctxHandle = _ctx.Handle.Acquire())
+        using (var handle = _handle.Acquire())
+        {
+            fixed (byte* startPtr = start, endPtr = end)
+                _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_var_from_index(ctxHandle, handle, index,
+                    startPtr, endPtr, &int_empty));
+        }
+
+        return (MarshaledStringOut.GetString(start.Span), MarshaledStringOut.GetString(end.Span), false);
+    }
+
+    /// <summary>
+    /// Gets the non-empty domain from a variable-sized dimension of the <see cref="Array"/>, identified by its name.
+    /// </summary>
+    /// <param name="name">The dimension's name.</param>
+    /// <returns>The domain's start and end values, along with whether it is empty.</returns>
+    public (string Start, string End, bool IsEmpty) NonEmptyDomainVar(string name)
+    {
+        ulong start_size64;
+        ulong end_size64;
+        int int_empty;
+        using var ms_name = new MarshaledString(name);
+
+        using (var ctxHandle = _ctx.Handle.Acquire())
+        using (var handle = _handle.Acquire())
+        {
+            _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_var_size_from_name(ctxHandle, handle, ms_name, &start_size64, &end_size64, &int_empty));
+        }
+
+        if (int_empty > 0)
+        {
+            return (string.Empty, string.Empty, true);
+        }
+
+        int start_size = checked((int)start_size64);
+        int end_size = checked((int)end_size64);
+
+        using var start = new ScratchBuffer<byte>(start_size, stackalloc byte[128], exactSize: true);
+        using var end = new ScratchBuffer<byte>(end_size, stackalloc byte[128], exactSize: true);
+
+        using (var ctxHandle = _ctx.Handle.Acquire())
+        using (var handle = _handle.Acquire())
+        {
+            fixed (byte* startPtr = start, endPtr = end)
+                _ctx.handle_error(Methods.tiledb_array_get_non_empty_domain_var_from_name(ctxHandle, handle, ms_name,
+                    startPtr, endPtr, &int_empty));
+        }
+
+        return new(MarshaledStringOut.GetString(start.Span), MarshaledStringOut.GetString(end.Span), false);
+    }
+
+    /// <summary>
+    /// Gets the array's URI.
+    /// </summary>
+    public string Uri()
+    {
+        sbyte* result;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_get_uri(ctxHandle, handle, &result));
+
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    /// <summary>
+    /// Gets the <see cref="CSharp.EncryptionType"/> with which an array was encrypted.
+    /// </summary>
+    /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
+    /// <param name="uri">The array's URI.</param>
+    public static EncryptionType EncryptionType(Context ctx, string uri)
+    {
+        using var ms_uri = new MarshaledString(uri);
+        tiledb_encryption_type_t tiledb_encryption_type;
+        using var ctxHandle = ctx.Handle.Acquire();
+        ctx.handle_error(Methods.tiledb_array_encryption_type(ctxHandle, ms_uri, &tiledb_encryption_type));
+        return (EncryptionType)tiledb_encryption_type;
+    }
+
+    /// <summary>
+    /// Gets an <see cref="Enumeration"/> from the <see cref="Array"/> by name.
+    /// </summary>
+    /// <param name="name">The enumeration's name.</param>
+    /// <seealso cref="LoadAllEnumerations"/>
+    public Enumeration GetEnumeration(string name)
+    {
+        var handle = new EnumerationHandle();
+        var successful = false;
+        tiledb_enumeration_t* enumeration_p = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var arrayHandle = _handle.Acquire())
+            using (var ms_name = new MarshaledString(name))
+            {
+                _ctx.handle_error(Methods.tiledb_array_get_enumeration(ctxHandle, arrayHandle, ms_name, &enumeration_p));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(enumeration_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+
+        return new Enumeration(_ctx, handle);
+    }
+
+    /// <summary>
+    /// Loads all enumerations of the <see cref="Array"/>.
+    /// </summary>
+    /// <seealso cref="GetEnumeration"/>
+    public void LoadAllEnumerations()
+    {
+        using (var ctxHandle = _ctx.Handle.Acquire())
+        using (var arrayHandle = _handle.Acquire())
+        {
+            _ctx.handle_error(Methods.tiledb_array_load_all_enumerations(ctxHandle, arrayHandle));
+        }
+    }
+
+    /// <summary>
+    /// Puts a multi-value metadata to the <see cref="Array"/>.
+    /// </summary>
+    /// <typeparam name="T">The metadata's type.</typeparam>
+    /// <param name="key">THe metadata's key.</param>
+    /// <param name="data">The metadata's value.</param>
+    public void PutMetadata<T>(string key, T[] data) where T : struct
+    {
+        _metadata.PutMetadata<T>(key, data);
+    }
+
+    /// <summary>
+    /// Puts a single-value metadata to the <see cref="Array"/>.
+    /// </summary>
+    /// <typeparam name="T">The metadata's type.</typeparam>
+    /// <param name="key">THe metadata's key.</param>
+    /// <param name="v">The metadata's value.</param>
+    public void PutMetadata<T>(string key, T v) where T : struct
+    {
+        _metadata.PutMetadata<T>(key, v);
+    }
+
+    /// <summary>
+    /// Puts a string-typed metadata to the <see cref="Array"/>.
+    /// </summary>
+    /// <param name="key">THe metadata's key.</param>
+    /// <param name="value">The metadata's value.</param>
+    public void PutMetadata(string key, string value)
+    {
+        _metadata.PutMetadata(key, value);
+    }
+
+    /// <summary>
+    /// Deletes a metadata from the <see cref="Array"/>.
+    /// </summary>
+    /// <param name="key">The metadata's ket.</param>
+    public void DeleteMetadata(string key)
+    {
+        _metadata.DeleteMetadata(key);
+    }
+
+    /// <summary>
+    /// Deletes fragments from an array that fall within the given timestamp range.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> to use.</param>
+    /// <param name="uri">The URI to the array.</param>
+    /// <param name="timestampStart">The start of the timestamp range, inclusive.</param>
+    /// <param name="timestampEnd">The end of the timestamp range, inclusive.</param>
+    public static void DeleteFragments(Context ctx, string uri, ulong timestampStart, ulong timestampEnd)
+    {
+        using var ms_uri = new MarshaledString(uri);
+        using var ctxHandle = ctx.Handle.Acquire();
+        ctx.handle_error(Methods.tiledb_array_delete_fragments_v2(ctxHandle, ms_uri, timestampStart, timestampEnd));
+    }
+
+    /// <summary>
+    /// Deletes fragments from an array that fall within the given timestamp range.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> to use.</param>
+    /// <param name="uri">The URI to the array.</param>
+    /// <param name="fragmentUris">A list with the URIs of the fragments to delete.</param>
+    public static void DeleteFragments(Context ctx, string uri, IReadOnlyList<string> fragmentUris)
+    {
+        using var ms_uri = new MarshaledString(uri);
+        using var msc_fragmentUris = new MarshaledStringCollection(fragmentUris);
+        using var ctxHandle = ctx.Handle.Acquire();
+        ctx.handle_error(Methods.tiledb_array_delete_fragments_list(ctxHandle, ms_uri, (sbyte**)msc_fragmentUris.Strings, (nuint)msc_fragmentUris.Count));
+    }
+
+    /// <summary>
+    /// Gets metadata from the <see cref="Array"/>.
+    /// </summary>
+    /// <typeparam name="T">The metadata's type.</typeparam>
+    /// <param name="key">The metadata's key.</param>
+    /// <returns>An array with the metadata values.</returns>
+    public T[] GetMetadata<T>(string key) where T : struct
+    {
+        return _metadata.GetMetadata<T>(key);
+    }
+
+    /// <summary>
+    /// Gets string-typed metadata from the <see cref="Array"/>.
+    /// </summary>
+    /// <param name="key">The metadata's key.</param>
+    public string GetMetadata(string key)
+    {
+        return _metadata.GetMetadata(key);
+    }
+
+    /// <summary>
+    /// Gets the number of metadata of the <see cref="Array"/>.
+    /// </summary>
+    public ulong MetadataNum()
+    {
+        return _metadata.MetadataNum();
+    }
+
+    /// <summary>
+    /// Gets the <see cref="Array"/>'s metadata key and value by index.
+    /// </summary>
+    /// <typeparam name="T">The metadata's type.</typeparam>
+    /// <param name="index">The metadata's index. Must be between zero and <see cref="MetadataNum"/> minus one.</param>
+    /// <returns>A tuple with the metadata's key and value.</returns>
+    public (string key, T[] data) GetMetadataFromIndex<T>(ulong index) where T : struct
+    {
+        return _metadata.GetMetadataFromIndex<T>(index);
+    }
+
+    /// <summary>
+    /// Gets the <see cref="Array"/>'s metadata keys.
+    /// </summary>
+    public string[] MetadataKeys()
+    {
+        return _metadata.MetadataKeys();
+    }
+
+    /// <summary>
+    /// Checks whether a metadata with a given key exists in the <see cref="Array"/>.
+    /// </summary>
+    /// <param name="key">The metadata's key</param>
+    /// <returns>A tuple of whether the metadata exists, and its type.</returns>
+    public (bool has_key, DataType datatype) HasMetadata(string key)
+    {
+        return _metadata.HasMetadata(key);
+    }
+
+    /// <summary>
+    /// Loads the <see cref="ArraySchema"/> of an array at the given path.
+    /// </summary>
+    /// <param name="ctx">The <see cref="CSharp.Context"/> to use.</param>
+    /// <param name="path">The array's path.</param>
+    public static ArraySchema LoadArraySchema(Context ctx, string path) => ArraySchema.Load(ctx, path);
 }

--- a/sources/TileDB.CSharp/ArrayMetadata.cs
+++ b/sources/TileDB.CSharp/ArrayMetadata.cs
@@ -37,7 +37,7 @@ namespace TileDB.CSharp
         /// <inheritdoc cref="Array.PutMetadata{T}(string, T)"/>
         public void PutMetadata<T>(string key, T v) where T : struct
         {
-            T[] data = new T[1] { v };
+            T[] data = [v];
             PutMetadata<T>(key, data);
         }
 

--- a/sources/TileDB.CSharp/ArrayMetadata.cs
+++ b/sources/TileDB.CSharp/ArrayMetadata.cs
@@ -6,319 +6,147 @@ using System.Runtime.InteropServices;
 using System.Text;
 using TileDB.Interop;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Provides a view of an <see cref="Array"/>'s metadata.
+/// </summary>
+public unsafe class ArrayMetadata : IDictionary<string, byte[]>
 {
     /// <summary>
-    /// Provides a view of an <see cref="Array"/>'s metadata.
+    /// The <see cref="Array"/> to get the metadata from.
     /// </summary>
-    public unsafe class ArrayMetadata : IDictionary<string, byte[]>
+    protected Array _array;
+
+    /// <summary>
+    /// Creates an <see cref="ArrayMetadata"/> object from an <see cref="Array"/>.
+    /// </summary>
+    /// <param name="array">The array to get the metadata from.</param>
+    public ArrayMetadata(Array array)
     {
-        /// <summary>
-        /// The <see cref="Array"/> to get the metadata from.
-        /// </summary>
-        protected Array _array;
+        _array = array;
+    }
 
-        /// <summary>
-        /// Creates an <see cref="ArrayMetadata"/> object from an <see cref="Array"/>.
-        /// </summary>
-        /// <param name="array">The array to get the metadata from.</param>
-        public ArrayMetadata(Array array)
+    /// <inheritdoc cref="Array.PutMetadata{T}(string, T[])"/>
+    public void PutMetadata<T>(string key, T[] data) where T : struct
+    {
+        var tiledb_datatype = (tiledb_datatype_t)EnumUtil.TypeToDataType(typeof(T));
+        put_metadata(key, data, tiledb_datatype);
+    }
+
+    /// <inheritdoc cref="Array.PutMetadata{T}(string, T)"/>
+    public void PutMetadata<T>(string key, T v) where T : struct
+    {
+        T[] data = [v];
+        PutMetadata<T>(key, data);
+    }
+
+    /// <inheritdoc cref="Array.PutMetadata(string, string)"/>
+    public void PutMetadata(string key, string value)
+    {
+        var data = Encoding.UTF8.GetBytes(value);
+        put_metadata(key, data, tiledb_datatype_t.TILEDB_STRING_UTF8);
+    }
+
+    /// <inheritdoc cref="Array.DeleteMetadata"/>
+    public void DeleteMetadata(string key)
+    {
+        var ctx = _array.Context();
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var arrayHandle = _array.Handle.Acquire();
+        using var ms_key = new MarshaledString(key);
+        ctx.handle_error(Methods.tiledb_array_delete_metadata(ctxHandle, arrayHandle, ms_key));
+    }
+
+    /// <inheritdoc cref="Array.GetMetadata{T}(string)"/>
+    public T[] GetMetadata<T>(string key) where T : struct
+    {
+        var (k, value, dataType, valueNum) = get_metadata(key);
+        Span<byte> valueSpan = value;
+
+        var span = MemoryMarshal.Cast<byte, T>(valueSpan);
+        return span.ToArray();
+    }
+
+    /// <inheritdoc cref="Array.GetMetadata(string)"/>
+    public string GetMetadata(string key)
+    {
+        var (_, byte_array, datatype, _) = get_metadata(key);
+        return MarshaledStringOut.GetString(byte_array, (DataType)datatype);
+    }
+
+    /// <inheritdoc cref="Array.MetadataNum"/>
+    public ulong MetadataNum()
+    {
+        var ctx = _array.Context();
+        ulong num;
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var arrayHandle = _array.Handle.Acquire();
+        ctx.handle_error(Methods.tiledb_array_get_metadata_num(ctxHandle, arrayHandle, &num));
+        return num;
+    }
+
+    /// <inheritdoc cref="Array.GetMetadataFromIndex"/>
+    public (string key, T[] data) GetMetadataFromIndex<T>(ulong index) where T : struct
+    {
+        var (key, value, dataType, valueNum) = get_metadata_from_index(index);
+        Span<byte> valueSpan = value;
+
+        var span = MemoryMarshal.Cast<byte, T>(valueSpan);
+        return (key, span.ToArray());
+
+    }
+
+    /// <inheritdoc cref="Array.MetadataKeys"/>
+    public string[] MetadataKeys()
+    {
+        var num = MetadataNum();
+        var ret = new string[(int)num];
+        for (ulong i = 0; i < num; ++i)
         {
-            _array = array;
+            var (key, _, _, _) = get_metadata_from_index(i);
+            ret[i] = key;
         }
+        return ret;
+    }
 
-        /// <inheritdoc cref="Array.PutMetadata{T}(string, T[])"/>
-        public void PutMetadata<T>(string key, T[] data) where T : struct
-        {
-            var tiledb_datatype = (tiledb_datatype_t)EnumUtil.TypeToDataType(typeof(T));
-            put_metadata(key, data, tiledb_datatype);
-        }
+    /// <inheritdoc cref="Array.HasMetadata"/>
+    public (bool has_key, DataType datatype) HasMetadata(string key)
+    {
+        var ctx = _array.Context();
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var arrayHandle = _array.Handle.Acquire();
+        using var ms_key = new MarshaledString(key);
+        tiledb_datatype_t tiledb_datatype;
+        var has_key = 0;
+        ctx.handle_error(Methods.tiledb_array_has_metadata_key(ctxHandle, arrayHandle, ms_key, &tiledb_datatype, &has_key));
 
-        /// <inheritdoc cref="Array.PutMetadata{T}(string, T)"/>
-        public void PutMetadata<T>(string key, T v) where T : struct
-        {
-            T[] data = [v];
-            PutMetadata<T>(key, data);
-        }
+        return (has_key > 0, (DataType)tiledb_datatype);
+    }
 
-        /// <inheritdoc cref="Array.PutMetadata(string, string)"/>
-        public void PutMetadata(string key, string value)
-        {
-            var data = Encoding.UTF8.GetBytes(value);
-            put_metadata(key, data, tiledb_datatype_t.TILEDB_STRING_UTF8);
-        }
-
-        /// <inheritdoc cref="Array.DeleteMetadata"/>
-        public void DeleteMetadata(string key)
-        {
-            var ctx = _array.Context();
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var arrayHandle = _array.Handle.Acquire();
-            using var ms_key = new MarshaledString(key);
-            ctx.handle_error(Methods.tiledb_array_delete_metadata(ctxHandle, arrayHandle, ms_key));
-        }
-
-        /// <inheritdoc cref="Array.GetMetadata{T}(string)"/>
-        public T[] GetMetadata<T>(string key) where T : struct
-        {
-            var (k, value, dataType, valueNum) = get_metadata(key);
-            Span<byte> valueSpan = value;
-
-            var span = MemoryMarshal.Cast<byte, T>(valueSpan);
-            return span.ToArray();
-        }
-
-        /// <inheritdoc cref="Array.GetMetadata(string)"/>
-        public string GetMetadata(string key)
-        {
-            var (_, byte_array, datatype, _) = get_metadata(key);
-            return MarshaledStringOut.GetString(byte_array, (DataType)datatype);
-        }
-
-        /// <inheritdoc cref="Array.MetadataNum"/>
-        public ulong MetadataNum()
-        {
-            var ctx = _array.Context();
-            ulong num;
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var arrayHandle = _array.Handle.Acquire();
-            ctx.handle_error(Methods.tiledb_array_get_metadata_num(ctxHandle, arrayHandle, &num));
-            return num;
-        }
-
-        /// <inheritdoc cref="Array.GetMetadataFromIndex"/>
-        public (string key, T[] data) GetMetadataFromIndex<T>(ulong index) where T : struct
-        {
-            var (key, value, dataType, valueNum) = get_metadata_from_index(index);
-            Span<byte> valueSpan = value;
-
-            var span = MemoryMarshal.Cast<byte, T>(valueSpan);
-            return (key, span.ToArray());
-
-        }
-
-        /// <inheritdoc cref="Array.MetadataKeys"/>
-        public string[] MetadataKeys()
-        {
-            var num = MetadataNum();
-            var ret = new string[(int)num];
-            for (ulong i = 0; i < num; ++i)
-            {
-                var (key, _, _, _) = get_metadata_from_index(i);
-                ret[i] = key;
-            }
-            return ret;
-        }
-
-        /// <inheritdoc cref="Array.HasMetadata"/>
-        public (bool has_key, DataType datatype) HasMetadata(string key)
-        {
-            var ctx = _array.Context();
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var arrayHandle = _array.Handle.Acquire();
-            using var ms_key = new MarshaledString(key);
-            tiledb_datatype_t tiledb_datatype;
-            var has_key = 0;
-            ctx.handle_error(Methods.tiledb_array_has_metadata_key(ctxHandle, arrayHandle, ms_key, &tiledb_datatype, &has_key));
-
-            return (has_key > 0, (DataType)tiledb_datatype);
-        }
-
-        /// <inheritdoc cref="P:System.Collections.Generic.IDictionary`2.Item(`0)"/>
-        public byte[] this[string key]
-        {
-            get
-            {
-                var ctx = _array.Context();
-                void* value_p;
-                using var ms_key = new MarshaledString(key);
-                tiledb_datatype_t datatype;
-
-                int has_key = 0;
-
-                using (var ctxHandle = ctx.Handle.Acquire())
-                using (var arrayHandle = _array.Handle.Acquire())
-                {
-                    ctx.handle_error(Methods.tiledb_array_has_metadata_key(ctxHandle, arrayHandle, ms_key, &datatype, &has_key));
-                }
-                if (has_key <= 0)
-                {
-
-                    return new byte[0];
-                }
-
-                uint value_num = 0;
-                using (var ctxHandle = ctx.Handle.Acquire())
-                using (var arrayHandle = _array.Handle.Acquire())
-                {
-                    ctx.handle_error(Methods.tiledb_array_get_metadata(ctxHandle, arrayHandle, ms_key, &datatype, &value_num, &value_p));
-                }
-                var size = (int)(value_num * Methods.tiledb_datatype_size(datatype));
-                var fill_span = new ReadOnlySpan<byte>(value_p, size);
-                return fill_span.ToArray();
-            }
-            set
-            {
-                Add(key, value);
-            }
-        }
-
-        /// <inheritdoc cref="IDictionary{TKey, TValue}.Keys"/>
-        public ICollection<string> Keys
-        {
-            get
-            {
-                List<string> ret = new List<string>();
-                var ctx = _array.Context();
-                ulong num;
-
-                using (var ctxHandle = ctx.Handle.Acquire())
-                using (var arrayHandle = _array.Handle.Acquire())
-                {
-                    ctx.handle_error(Methods.tiledb_array_get_metadata_num(ctxHandle, arrayHandle, &num));
-                }
-
-                for (ulong i = 0; i < num; ++i)
-                {
-                    var metadata = get_metadata_from_index(i);
-                    ret.Add(metadata.key);
-                }
-                return ret;
-            }
-        }
-
-        /// <inheritdoc cref="IDictionary{TKey, TValue}.Values"/>
-        public ICollection<byte[]> Values
-        {
-            get
-            {
-                List<byte[]> ret = new List<byte[]>();
-                ulong num = MetadataNum();
-                for (ulong i = 0; i < num; ++i)
-                {
-                    var metadata = get_metadata_from_index(i);
-                    ret.Add(metadata.data);
-                }
-
-                return ret;
-            }
-        }
-
-        /// <inheritdoc cref="ICollection{T}.Count"/>
-        public int Count
-        {
-            get
-            {
-                ulong num = MetadataNum();
-                return (int)num;
-            }
-        }
-
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        public bool IsReadOnly
-        {
-            get
-            {
-                QueryType querytype = _array.QueryType();
-                return querytype == QueryType.Read;
-            }
-        }
-
-        /// <inheritdoc cref="IDictionary{TKey, TValue}.Add"/>
-        public void Add(string key, byte[] value)
-        {
-            put_metadata(key, value, tiledb_datatype_t.TILEDB_UINT8);
-        }
-
-        /// <inheritdoc cref="ICollection{T}.Add"/>
-        public void Add(KeyValuePair<string, byte[]> item)
-        {
-            Add(item.Key, item.Value);
-        }
-
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        public void Clear()
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        public bool Contains(KeyValuePair<string, byte[]> item)
-        {
-            return ContainsKey(item.Key);
-        }
-
-        /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
-        public bool ContainsKey(string key)
-        {
-            var (has_key, _) = HasMetadata(key);
-            return has_key;
-        }
-
-        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
-        public void CopyTo(KeyValuePair<string, byte[]>[] array, int arrayIndex)
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
-        public IEnumerator<KeyValuePair<string, byte[]>> GetEnumerator()
-        {
-            throw new NotImplementedException();
-        }
-
-        /// <inheritdoc cref="IDictionary{TKey, TValue}.Remove"/>
-        public bool Remove(string key)
-        {
-            DeleteMetadata(key);
-            return true;
-        }
-
-        /// <inheritdoc cref="ICollection{T}.Remove"/>
-        public bool Remove(KeyValuePair<string, byte[]> item)
-        {
-            return Remove(item.Key);
-        }
-
-        /// <inheritdoc cref="IDictionary{TKey, TValue}.TryGetValue"/>
-        public bool TryGetValue(string key, [MaybeNullWhen(false)] out byte[] value)
-        {
-            if (!ContainsKey(key))
-            {
-                value = null;
-                return false;
-            }
-            var metadata = get_metadata(key);
-            value = metadata.data;
-            return true;
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            throw new NotImplementedException();
-        }
-
-        private void put_metadata<T>(string key, T[] value, tiledb_datatype_t tiledb_datatype) where T : struct
-        {
-            ErrorHandling.CheckDataType<T>((DataType)tiledb_datatype);
-            if (string.IsNullOrEmpty(key) || value.Length == 0)
-            {
-                throw new ArgumentException("ArrayMetadata.put_metadata, null or empty key-value!");
-            }
-            var ctx = _array.Context();
-            using var ms_key = new MarshaledString(key);
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var arrayHandle = _array.Handle.Acquire();
-            fixed (T* dataPtr = &value[0])
-                ctx.handle_error(Methods.tiledb_array_put_metadata(ctxHandle, arrayHandle, ms_key, tiledb_datatype, (uint)value.Length, dataPtr));
-        }
-
-        private (string key, byte[] data, tiledb_datatype_t tiledb_datatype, uint value_num) get_metadata(string key)
+    /// <inheritdoc cref="P:System.Collections.Generic.IDictionary`2.Item(`0)"/>
+    public byte[] this[string key]
+    {
+        get
         {
             var ctx = _array.Context();
             void* value_p;
             using var ms_key = new MarshaledString(key);
             tiledb_datatype_t datatype;
+
+            int has_key = 0;
+
+            using (var ctxHandle = ctx.Handle.Acquire())
+            using (var arrayHandle = _array.Handle.Acquire())
+            {
+                ctx.handle_error(Methods.tiledb_array_has_metadata_key(ctxHandle, arrayHandle, ms_key, &datatype, &has_key));
+            }
+            if (has_key <= 0)
+            {
+
+                return new byte[0];
+            }
+
             uint value_num = 0;
             using (var ctxHandle = ctx.Handle.Acquire())
             using (var arrayHandle = _array.Handle.Acquire())
@@ -327,23 +155,194 @@ namespace TileDB.CSharp
             }
             var size = (int)(value_num * Methods.tiledb_datatype_size(datatype));
             var fill_span = new ReadOnlySpan<byte>(value_p, size);
-            return (key, fill_span.ToArray(), datatype, value_num);
+            return fill_span.ToArray();
         }
-
-        private (string key, byte[] data, tiledb_datatype_t tiledb_datatype, uint value_num) get_metadata_from_index(ulong index)
+        set
         {
-            var ctx = _array.Context();
-            void* value_p;
-            sbyte* key;
-            tiledb_datatype_t dataType;
-            uint valueNum = 0;
-            uint key_len;
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var arrayHandle = _array.Handle.Acquire();
-            ctx.handle_error(Methods.tiledb_array_get_metadata_from_index(ctxHandle, arrayHandle, index, &key, &key_len, &dataType, &valueNum, &value_p));
-            var size = (int)(valueNum * Methods.tiledb_datatype_size(dataType));
-            var fill_span = new ReadOnlySpan<byte>(value_p, size);
-            return (MarshaledStringOut.GetStringFromNullTerminated(key), fill_span.ToArray(), dataType, valueNum);
+            Add(key, value);
         }
+    }
+
+    /// <inheritdoc cref="IDictionary{TKey, TValue}.Keys"/>
+    public ICollection<string> Keys
+    {
+        get
+        {
+            List<string> ret = new List<string>();
+            var ctx = _array.Context();
+            ulong num;
+
+            using (var ctxHandle = ctx.Handle.Acquire())
+            using (var arrayHandle = _array.Handle.Acquire())
+            {
+                ctx.handle_error(Methods.tiledb_array_get_metadata_num(ctxHandle, arrayHandle, &num));
+            }
+
+            for (ulong i = 0; i < num; ++i)
+            {
+                var metadata = get_metadata_from_index(i);
+                ret.Add(metadata.key);
+            }
+            return ret;
+        }
+    }
+
+    /// <inheritdoc cref="IDictionary{TKey, TValue}.Values"/>
+    public ICollection<byte[]> Values
+    {
+        get
+        {
+            List<byte[]> ret = new List<byte[]>();
+            ulong num = MetadataNum();
+            for (ulong i = 0; i < num; ++i)
+            {
+                var metadata = get_metadata_from_index(i);
+                ret.Add(metadata.data);
+            }
+
+            return ret;
+        }
+    }
+
+    /// <inheritdoc cref="ICollection{T}.Count"/>
+    public int Count
+    {
+        get
+        {
+            ulong num = MetadataNum();
+            return (int)num;
+        }
+    }
+
+    /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
+    public bool IsReadOnly
+    {
+        get
+        {
+            QueryType querytype = _array.QueryType();
+            return querytype == QueryType.Read;
+        }
+    }
+
+    /// <inheritdoc cref="IDictionary{TKey, TValue}.Add"/>
+    public void Add(string key, byte[] value)
+    {
+        put_metadata(key, value, tiledb_datatype_t.TILEDB_UINT8);
+    }
+
+    /// <inheritdoc cref="ICollection{T}.Add"/>
+    public void Add(KeyValuePair<string, byte[]> item)
+    {
+        Add(item.Key, item.Value);
+    }
+
+    /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
+    public void Clear()
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
+    public bool Contains(KeyValuePair<string, byte[]> item)
+    {
+        return ContainsKey(item.Key);
+    }
+
+    /// <inheritdoc cref="ICollection{T}.IsReadOnly"/>
+    public bool ContainsKey(string key)
+    {
+        var (has_key, _) = HasMetadata(key);
+        return has_key;
+    }
+
+    /// <inheritdoc cref="ICollection{T}.CopyTo"/>
+    public void CopyTo(KeyValuePair<string, byte[]>[] array, int arrayIndex)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
+    public IEnumerator<KeyValuePair<string, byte[]>> GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <inheritdoc cref="IDictionary{TKey, TValue}.Remove"/>
+    public bool Remove(string key)
+    {
+        DeleteMetadata(key);
+        return true;
+    }
+
+    /// <inheritdoc cref="ICollection{T}.Remove"/>
+    public bool Remove(KeyValuePair<string, byte[]> item)
+    {
+        return Remove(item.Key);
+    }
+
+    /// <inheritdoc cref="IDictionary{TKey, TValue}.TryGetValue"/>
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out byte[] value)
+    {
+        if (!ContainsKey(key))
+        {
+            value = null;
+            return false;
+        }
+        var metadata = get_metadata(key);
+        value = metadata.data;
+        return true;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+
+    private void put_metadata<T>(string key, T[] value, tiledb_datatype_t tiledb_datatype) where T : struct
+    {
+        ErrorHandling.CheckDataType<T>((DataType)tiledb_datatype);
+        if (string.IsNullOrEmpty(key) || value.Length == 0)
+        {
+            throw new ArgumentException("ArrayMetadata.put_metadata, null or empty key-value!");
+        }
+        var ctx = _array.Context();
+        using var ms_key = new MarshaledString(key);
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var arrayHandle = _array.Handle.Acquire();
+        fixed (T* dataPtr = &value[0])
+            ctx.handle_error(Methods.tiledb_array_put_metadata(ctxHandle, arrayHandle, ms_key, tiledb_datatype, (uint)value.Length, dataPtr));
+    }
+
+    private (string key, byte[] data, tiledb_datatype_t tiledb_datatype, uint value_num) get_metadata(string key)
+    {
+        var ctx = _array.Context();
+        void* value_p;
+        using var ms_key = new MarshaledString(key);
+        tiledb_datatype_t datatype;
+        uint value_num = 0;
+        using (var ctxHandle = ctx.Handle.Acquire())
+        using (var arrayHandle = _array.Handle.Acquire())
+        {
+            ctx.handle_error(Methods.tiledb_array_get_metadata(ctxHandle, arrayHandle, ms_key, &datatype, &value_num, &value_p));
+        }
+        var size = (int)(value_num * Methods.tiledb_datatype_size(datatype));
+        var fill_span = new ReadOnlySpan<byte>(value_p, size);
+        return (key, fill_span.ToArray(), datatype, value_num);
+    }
+
+    private (string key, byte[] data, tiledb_datatype_t tiledb_datatype, uint value_num) get_metadata_from_index(ulong index)
+    {
+        var ctx = _array.Context();
+        void* value_p;
+        sbyte* key;
+        tiledb_datatype_t dataType;
+        uint valueNum = 0;
+        uint key_len;
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var arrayHandle = _array.Handle.Acquire();
+        ctx.handle_error(Methods.tiledb_array_get_metadata_from_index(ctxHandle, arrayHandle, index, &key, &key_len, &dataType, &valueNum, &value_p));
+        var size = (int)(valueNum * Methods.tiledb_datatype_size(dataType));
+        var fill_span = new ReadOnlySpan<byte>(value_p, size);
+        return (MarshaledStringOut.GetStringFromNullTerminated(key), fill_span.ToArray(), dataType, valueNum);
     }
 }

--- a/sources/TileDB.CSharp/ArraySchema.cs
+++ b/sources/TileDB.CSharp/ArraySchema.cs
@@ -7,593 +7,592 @@ using FilterListHandle = TileDB.CSharp.Marshalling.SafeHandles.FilterListHandle;
 using DomainHandle = TileDB.CSharp.Marshalling.SafeHandles.DomainHandle;
 using AttributeHandle = TileDB.CSharp.Marshalling.SafeHandles.AttributeHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB array schema object.
+/// </summary>
+public sealed unsafe class ArraySchema : IDisposable
 {
+    private readonly ArraySchemaHandle _handle;
+    private readonly Context _ctx;
+
     /// <summary>
-    /// Represents a TileDB array schema object.
+    /// Creates a new <see cref="ArraySchema"/>.
     /// </summary>
-    public sealed unsafe class ArraySchema : IDisposable
+    /// <param name="ctx">The <see cref="Context"/> associated with this schema.</param>
+    /// <param name="arrayType">The array's type.</param>
+    public ArraySchema(Context ctx, ArrayType arrayType)
     {
-        private readonly ArraySchemaHandle _handle;
-        private readonly Context _ctx;
+        _ctx = ctx;
+        var tiledb_array_type = (tiledb_array_type_t)arrayType;
+        _handle = ArraySchemaHandle.Create(_ctx, tiledb_array_type);
+    }
 
-        /// <summary>
-        /// Creates a new <see cref="ArraySchema"/>.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with this schema.</param>
-        /// <param name="arrayType">The array's type.</param>
-        public ArraySchema(Context ctx, ArrayType arrayType)
+    internal ArraySchema(Context ctx, ArraySchemaHandle handle)
+    {
+        _ctx = ctx;
+        _handle = handle;
+    }
+
+    /// <summary>
+    /// Disposes this <see cref="ArraySchema"/>
+    /// </summary>
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
+
+    internal ArraySchemaHandle Handle => _handle;
+
+    /// <summary>
+    /// Adds an <see cref="CSharp.Attribute"/> in the <see cref="ArraySchema"/>.
+    /// </summary>
+    /// <param name="attr">The attribute to add.</param>
+    public void AddAttribute(Attribute attr)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var attrHandle = attr.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_add_attribute(ctxHandle, handle, attrHandle));
+    }
+
+    /// <summary>
+    /// Adds an array of <see cref="CSharp.Attribute"/>s in the <see cref="ArraySchema"/>.
+    /// </summary>
+    /// <param name="attrs">The attributes to add.</param>
+    public void AddAttributes(params Attribute[] attrs)
+    {
+        foreach (var t in attrs)
         {
-            _ctx = ctx;
-            var tiledb_array_type = (tiledb_array_type_t)arrayType;
-            _handle = ArraySchemaHandle.Create(_ctx, tiledb_array_type);
+            AddAttribute(t);
         }
+    }
 
-        internal ArraySchema(Context ctx, ArraySchemaHandle handle)
+    /// <summary>
+    /// Adds an <see cref="Enumeration"/> in the <see cref="ArraySchema"/>.
+    /// </summary>
+    /// <param name="enumeration">The enumeration to add.</param>
+    public void AddEnumeration(Enumeration enumeration)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var enumHandle = enumeration.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_add_enumeration(ctxHandle, handle, enumHandle));
+    }
+
+    /// <summary>
+    /// Sets whether cells with duplicate coordinates are allowed in the <see cref="ArraySchema"/>.
+    /// </summary>
+    /// <remarks>
+    /// Applicable to only <see cref="ArrayType.Sparse"/> arrays.
+    /// </remarks>
+    public void SetAllowsDups(bool allowsDups)
+    {
+        int int_allow_dups = allowsDups ? 1 : 0;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_set_allows_dups(ctxHandle, handle, int_allow_dups));
+    }
+
+    /// <summary>
+    /// Gets whether cells with duplicate coordinates are allowed in the <see cref="ArraySchema"/>.
+    /// </summary>
+    /// <remarks>
+    /// Applicable to only <see cref="ArrayType.Sparse"/> arrays.
+    /// </remarks>
+    public bool AllowsDups()
+    {
+        int allowDups;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_get_allows_dups(ctxHandle, handle, &allowDups));
+        return allowDups > 0;
+    }
+
+    /// <summary>
+    /// Sets the <see cref="ArraySchema"/>'s <see cref="Domain"/>.
+    /// </summary>
+    /// <param name="domain">The domain to set</param>
+    public void SetDomain(Domain domain)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var domainHandle = domain.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_set_domain(ctxHandle, handle, domainHandle));
+    }
+
+    /// <summary>
+    /// Sets the <see cref="ArraySchema"/>'s sparse fragment capacity.
+    /// </summary>
+    /// <param name="capacity">The capacity.</param>
+    public void SetCapacity(ulong capacity)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_set_capacity(ctxHandle, handle, capacity));
+    }
+
+    /// <summary>
+    /// Sets the <see cref="ArraySchema"/>'s cell order.
+    /// </summary>
+    /// <param name="layoutType">The cell order.</param>
+    public void SetCellOrder(LayoutType layoutType)
+    {
+        var tiledb_layout = (tiledb_layout_t)layoutType;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_set_cell_order(ctxHandle, handle, tiledb_layout));
+    }
+
+    /// <summary>
+    /// Sets the <see cref="ArraySchema"/>'s tile order.
+    /// </summary>
+    /// <param name="layoutType">The tile order.</param>
+    public void SetTileOrder(LayoutType layoutType)
+    {
+        var tiledb_layout = (tiledb_layout_t)layoutType;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_set_tile_order(ctxHandle, handle, tiledb_layout));
+    }
+
+    /// <summary>
+    /// Sets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s coordinates.
+    /// </summary>
+    /// <param name="filterList">The filter list.</param>
+    public void SetCoordsFilterList(FilterList filterList)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var filterListHandle = filterList.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_set_coords_filter_list(ctxHandle, handle, filterListHandle));
+    }
+
+    /// <summary>
+    /// Sets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s
+    /// offsets of variable-sized <see cref="CSharp.Attribute"/>s or <see cref="Dimension"/>s.
+    /// </summary>
+    /// <param name="filterList">The filter list.</param>
+    public void SetOffsetsFilterList(FilterList filterList)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var filterListHandle = filterList.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_set_offsets_filter_list(ctxHandle, handle, filterListHandle));
+    }
+
+    /// <summary>
+    /// Sets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s
+    /// the validity array of nullable <see cref="CSharp.Attribute"/> values.
+    /// </summary>
+    /// <param name="filterList">The filter list.</param>
+    public void SetValidityFilterList(FilterList filterList)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var filterListHandle = filterList.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_set_validity_filter_list(ctxHandle, handle, filterListHandle));
+    }
+
+    /// <summary>
+    /// Performs validity checks in the <see cref="ArraySchema"/>.
+    /// </summary>
+    public void Check()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_check(ctxHandle, handle));
+    }
+
+    /// <summary>
+    /// Gets the <see cref="ArraySchema"/>'s <see cref="CSharp.ArrayType"/>.
+    /// </summary>
+    public ArrayType ArrayType()
+    {
+        tiledb_array_type_t tiledb_array_type;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_get_array_type(ctxHandle, handle, &tiledb_array_type));
+
+        return (ArrayType)tiledb_array_type;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="ArraySchema"/>'s sparse fragment capacity.
+    /// </summary>
+    public ulong Capacity()
+    {
+        ulong capacity;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_get_capacity(ctxHandle, handle, &capacity));
+
+        return capacity;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="ArraySchema"/>'s cell order.
+    /// </summary>
+    public LayoutType CellOrder()
+    {
+        tiledb_layout_t tiledb_layout;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_get_cell_order(ctxHandle, handle, &tiledb_layout));
+        return (LayoutType)tiledb_layout;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s coordinates.
+    /// </summary>
+    public FilterList CoordsFilterList()
+    {
+        var handle = new FilterListHandle();
+        var successful = false;
+        tiledb_filter_list_t* filter_list_p = null;
+        try
         {
-            _ctx = ctx;
-            _handle = handle;
-        }
-
-        /// <summary>
-        /// Disposes this <see cref="ArraySchema"/>
-        /// </summary>
-        public void Dispose()
-        {
-            _handle.Dispose();
-        }
-
-        internal ArraySchemaHandle Handle => _handle;
-
-        /// <summary>
-        /// Adds an <see cref="CSharp.Attribute"/> in the <see cref="ArraySchema"/>.
-        /// </summary>
-        /// <param name="attr">The attribute to add.</param>
-        public void AddAttribute(Attribute attr)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var attrHandle = attr.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_add_attribute(ctxHandle, handle, attrHandle));
-        }
-
-        /// <summary>
-        /// Adds an array of <see cref="CSharp.Attribute"/>s in the <see cref="ArraySchema"/>.
-        /// </summary>
-        /// <param name="attrs">The attributes to add.</param>
-        public void AddAttributes(params Attribute[] attrs)
-        {
-            foreach (var t in attrs)
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var schemaHandle = _handle.Acquire())
             {
-                AddAttribute(t);
+                _ctx.handle_error(Methods.tiledb_array_schema_get_coords_filter_list(ctxHandle, schemaHandle, &filter_list_p));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(filter_list_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
             }
         }
 
-        /// <summary>
-        /// Adds an <see cref="Enumeration"/> in the <see cref="ArraySchema"/>.
-        /// </summary>
-        /// <param name="enumeration">The enumeration to add.</param>
-        public void AddEnumeration(Enumeration enumeration)
+        return new FilterList(_ctx, handle);
+    }
+
+    /// <summary>
+    /// Gets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s
+    /// offsets of variable-sized <see cref="CSharp.Attribute"/>s or <see cref="Dimension"/>s.
+    /// </summary>
+    public FilterList OffsetsFilterList()
+    {
+        var handle = new FilterListHandle();
+        var successful = false;
+        tiledb_filter_list_t* filter_list_p = null;
+        try
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var enumHandle = enumeration.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_add_enumeration(ctxHandle, handle, enumHandle));
-        }
-
-        /// <summary>
-        /// Sets whether cells with duplicate coordinates are allowed in the <see cref="ArraySchema"/>.
-        /// </summary>
-        /// <remarks>
-        /// Applicable to only <see cref="ArrayType.Sparse"/> arrays.
-        /// </remarks>
-        public void SetAllowsDups(bool allowsDups)
-        {
-            int int_allow_dups = allowsDups ? 1 : 0;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_set_allows_dups(ctxHandle, handle, int_allow_dups));
-        }
-
-        /// <summary>
-        /// Gets whether cells with duplicate coordinates are allowed in the <see cref="ArraySchema"/>.
-        /// </summary>
-        /// <remarks>
-        /// Applicable to only <see cref="ArrayType.Sparse"/> arrays.
-        /// </remarks>
-        public bool AllowsDups()
-        {
-            int allowDups;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_allows_dups(ctxHandle, handle, &allowDups));
-            return allowDups > 0;
-        }
-
-        /// <summary>
-        /// Sets the <see cref="ArraySchema"/>'s <see cref="Domain"/>.
-        /// </summary>
-        /// <param name="domain">The domain to set</param>
-        public void SetDomain(Domain domain)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var domainHandle = domain.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_set_domain(ctxHandle, handle, domainHandle));
-        }
-
-        /// <summary>
-        /// Sets the <see cref="ArraySchema"/>'s sparse fragment capacity.
-        /// </summary>
-        /// <param name="capacity">The capacity.</param>
-        public void SetCapacity(ulong capacity)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_set_capacity(ctxHandle, handle, capacity));
-        }
-
-        /// <summary>
-        /// Sets the <see cref="ArraySchema"/>'s cell order.
-        /// </summary>
-        /// <param name="layoutType">The cell order.</param>
-        public void SetCellOrder(LayoutType layoutType)
-        {
-            var tiledb_layout = (tiledb_layout_t)layoutType;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_set_cell_order(ctxHandle, handle, tiledb_layout));
-        }
-
-        /// <summary>
-        /// Sets the <see cref="ArraySchema"/>'s tile order.
-        /// </summary>
-        /// <param name="layoutType">The tile order.</param>
-        public void SetTileOrder(LayoutType layoutType)
-        {
-            var tiledb_layout = (tiledb_layout_t)layoutType;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_set_tile_order(ctxHandle, handle, tiledb_layout));
-        }
-
-        /// <summary>
-        /// Sets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s coordinates.
-        /// </summary>
-        /// <param name="filterList">The filter list.</param>
-        public void SetCoordsFilterList(FilterList filterList)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var filterListHandle = filterList.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_set_coords_filter_list(ctxHandle, handle, filterListHandle));
-        }
-
-        /// <summary>
-        /// Sets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s
-        /// offsets of variable-sized <see cref="CSharp.Attribute"/>s or <see cref="Dimension"/>s.
-        /// </summary>
-        /// <param name="filterList">The filter list.</param>
-        public void SetOffsetsFilterList(FilterList filterList)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var filterListHandle = filterList.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_set_offsets_filter_list(ctxHandle, handle, filterListHandle));
-        }
-
-        /// <summary>
-        /// Sets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s
-        /// the validity array of nullable <see cref="CSharp.Attribute"/> values.
-        /// </summary>
-        /// <param name="filterList">The filter list.</param>
-        public void SetValidityFilterList(FilterList filterList)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var filterListHandle = filterList.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_set_validity_filter_list(ctxHandle, handle, filterListHandle));
-        }
-
-        /// <summary>
-        /// Performs validity checks in the <see cref="ArraySchema"/>.
-        /// </summary>
-        public void Check()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_check(ctxHandle, handle));
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ArraySchema"/>'s <see cref="CSharp.ArrayType"/>.
-        /// </summary>
-        public ArrayType ArrayType()
-        {
-            tiledb_array_type_t tiledb_array_type;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_array_type(ctxHandle, handle, &tiledb_array_type));
-
-            return (ArrayType)tiledb_array_type;
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ArraySchema"/>'s sparse fragment capacity.
-        /// </summary>
-        public ulong Capacity()
-        {
-            ulong capacity;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_capacity(ctxHandle, handle, &capacity));
-
-            return capacity;
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ArraySchema"/>'s cell order.
-        /// </summary>
-        public LayoutType CellOrder()
-        {
-            tiledb_layout_t tiledb_layout;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_cell_order(ctxHandle, handle, &tiledb_layout));
-            return (LayoutType)tiledb_layout;
-        }
-
-        /// <summary>
-        /// Gets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s coordinates.
-        /// </summary>
-        public FilterList CoordsFilterList()
-        {
-            var handle = new FilterListHandle();
-            var successful = false;
-            tiledb_filter_list_t* filter_list_p = null;
-            try
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var schemaHandle = _handle.Acquire())
             {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var schemaHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_array_schema_get_coords_filter_list(ctxHandle, schemaHandle, &filter_list_p));
-                }
-                successful = true;
+                _ctx.handle_error(Methods.tiledb_array_schema_get_offsets_filter_list(ctxHandle, schemaHandle, &filter_list_p));
             }
-            finally
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                if (successful)
-                {
-                    handle.InitHandle(filter_list_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.InitHandle(filter_list_p);
             }
-
-            return new FilterList(_ctx, handle);
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
         }
 
-        /// <summary>
-        /// Gets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s
-        /// offsets of variable-sized <see cref="CSharp.Attribute"/>s or <see cref="Dimension"/>s.
-        /// </summary>
-        public FilterList OffsetsFilterList()
-        {
-            var handle = new FilterListHandle();
-            var successful = false;
-            tiledb_filter_list_t* filter_list_p = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var schemaHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_array_schema_get_offsets_filter_list(ctxHandle, schemaHandle, &filter_list_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(filter_list_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
+        return new FilterList(_ctx, handle);
+    }
 
-            return new FilterList(_ctx, handle);
+    /// <summary>
+    /// Gets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s
+    /// the validity array of nullable <see cref="CSharp.Attribute"/> values.
+    /// </summary>
+    public FilterList ValidityFilterList()
+    {
+        var handle = new FilterListHandle();
+        var successful = false;
+        tiledb_filter_list_t* filter_list_p = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var schemaHandle = _handle.Acquire())
+            {
+                _ctx.handle_error(Methods.tiledb_array_schema_get_validity_filter_list(ctxHandle, schemaHandle, &filter_list_p));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(filter_list_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
         }
 
-        /// <summary>
-        /// Gets the <see cref="FilterList"/> of filters that will be applied in the <see cref="ArraySchema"/>'s
-        /// the validity array of nullable <see cref="CSharp.Attribute"/> values.
-        /// </summary>
-        public FilterList ValidityFilterList()
-        {
-            var handle = new FilterListHandle();
-            var successful = false;
-            tiledb_filter_list_t* filter_list_p = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var schemaHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_array_schema_get_validity_filter_list(ctxHandle, schemaHandle, &filter_list_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(filter_list_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
+        return new FilterList(_ctx, handle);
+    }
 
-            return new FilterList(_ctx, handle);
+    /// <summary>
+    /// Gets the <see cref="ArraySchema"/>'s <see cref="Domain"/>.
+    /// </summary>
+    public Domain Domain()
+    {
+        var handle = new DomainHandle();
+        var successful = false;
+        tiledb_domain_t* domain_p = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var schemaHandle = _handle.Acquire())
+            {
+                _ctx.handle_error(Methods.tiledb_array_schema_get_domain(ctxHandle, schemaHandle, &domain_p));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(domain_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
         }
 
-        /// <summary>
-        /// Gets the <see cref="ArraySchema"/>'s <see cref="Domain"/>.
-        /// </summary>
-        public Domain Domain()
-        {
-            var handle = new DomainHandle();
-            var successful = false;
-            tiledb_domain_t* domain_p = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var schemaHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_array_schema_get_domain(ctxHandle, schemaHandle, &domain_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(domain_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
+        return new Domain(_ctx, handle);
+    }
 
-            return new Domain(_ctx, handle);
+    /// <summary>
+    /// Gets the <see cref="ArraySchema"/>'s tile order.
+    /// </summary>
+    public LayoutType TileOrder()
+    {
+        tiledb_layout_t tiledb_layout;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_get_tile_order(ctxHandle, handle, &tiledb_layout));
+        return (LayoutType)tiledb_layout;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="ArraySchema"/>'s format version.
+    /// </summary>
+    public uint FormatVersion()
+    {
+        uint num;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_get_version(ctxHandle, handle, &num));
+        return num;
+    }
+
+    /// <summary>
+    /// Gets the number of <see cref="CSharp.Attribute"/>s in the <see cref="ArraySchema"/>.
+    /// </summary>
+    /// <returns></returns>
+    public uint AttributeNum()
+    {
+        uint num;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_get_attribute_num(ctxHandle, handle, &num));
+        return num;
+    }
+
+    /// <summary>
+    /// Gets an <see cref="CSharp.Attribute"/> from the <see cref="ArraySchema"/> by index.
+    /// </summary>
+    /// <param name="i">The attribute's index.</param>
+    public Attribute Attribute(uint i)
+    {
+        var handle = new AttributeHandle();
+        var successful = false;
+        tiledb_attribute_t* attribute_p = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var schemaHandle = _handle.Acquire())
+            {
+                _ctx.handle_error(Methods.tiledb_array_schema_get_attribute_from_index(ctxHandle, schemaHandle, i, &attribute_p));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(attribute_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
         }
 
-        /// <summary>
-        /// Gets the <see cref="ArraySchema"/>'s tile order.
-        /// </summary>
-        public LayoutType TileOrder()
+        return new Attribute(_ctx, handle);
+    }
+
+    /// <summary>
+    /// Gets an <see cref="CSharp.Attribute"/> from the <see cref="ArraySchema"/> by name.
+    /// </summary>
+    /// <param name="name">The attribute's name.</param>
+    public Attribute Attribute(string name)
+    {
+        var handle = new AttributeHandle();
+        var successful = false;
+        tiledb_attribute_t* attribute_p = null;
+        try
         {
-            tiledb_layout_t tiledb_layout;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_tile_order(ctxHandle, handle, &tiledb_layout));
-            return (LayoutType)tiledb_layout;
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var schemaHandle = _handle.Acquire())
+            using (var ms_name = new MarshaledString(name))
+            {
+                _ctx.handle_error(Methods.tiledb_array_schema_get_attribute_from_name(ctxHandle, schemaHandle, ms_name, &attribute_p));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(attribute_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
         }
 
-        /// <summary>
-        /// Gets the <see cref="ArraySchema"/>'s format version.
-        /// </summary>
-        public uint FormatVersion()
+        return new Attribute(_ctx, handle);
+    }
+
+    /// <summary>
+    /// Checks if an <see cref="CSharp.Attribute"/> with the given name exists in the <see cref="ArraySchema"/> or not.
+    /// </summary>
+    /// <param name="name">The name to check.</param>
+    public bool HasAttribute(string name)
+    {
+        int has_attr;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(name);
+        _ctx.handle_error(Methods.tiledb_array_schema_has_attribute(ctxHandle, handle, ms_name, &has_attr));
+        return has_attr > 0;
+    }
+
+    /// <summary>
+    /// Load an <see cref="ArraySchema"/> from a URI.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> associated with this schema.</param>
+    /// <param name="uri">The array's URI.</param>
+    public static ArraySchema Load(Context ctx, string uri)
+    {
+        var handle = new ArraySchemaHandle();
+        var successful = false;
+        tiledb_array_schema_t* array_schema_p = null;
+        try
         {
-            uint num;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_version(ctxHandle, handle, &num));
-            return num;
+            using (var ms_uri = new MarshaledString(uri))
+            using (var ctxHandle = ctx.Handle.Acquire())
+            {
+                ctx.handle_error(Methods.tiledb_array_schema_load(ctxHandle, ms_uri, &array_schema_p));
+            }
+            successful = true;
         }
-
-        /// <summary>
-        /// Gets the number of <see cref="CSharp.Attribute"/>s in the <see cref="ArraySchema"/>.
-        /// </summary>
-        /// <returns></returns>
-        public uint AttributeNum()
+        finally
         {
-            uint num;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_get_attribute_num(ctxHandle, handle, &num));
-            return num;
+            if (successful)
+            {
+                handle.InitHandle(array_schema_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
         }
+        return new ArraySchema(ctx, handle);
+    }
 
-        /// <summary>
-        /// Gets an <see cref="CSharp.Attribute"/> from the <see cref="ArraySchema"/> by index.
-        /// </summary>
-        /// <param name="i">The attribute's index.</param>
-        public Attribute Attribute(uint i)
+    /// <summary>
+    /// Gets a collection with all <see cref="CSharp.Attribute"/>s of the <see cref="ArraySchema"/>.
+    /// </summary>
+    public SortedDictionary<string, Attribute> Attributes()
+    {
+        var ret = new SortedDictionary<string, Attribute>();
+        var attribute_num = AttributeNum();
+        for (uint i = 0; i < attribute_num; ++i)
         {
-            var handle = new AttributeHandle();
-            var successful = false;
-            tiledb_attribute_t* attribute_p = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var schemaHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_array_schema_get_attribute_from_index(ctxHandle, schemaHandle, i, &attribute_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(attribute_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return new Attribute(_ctx, handle);
+            var attr = Attribute(i);
+            ret.Add(attr.Name(), attr);
         }
+        return ret;
+    }
 
-        /// <summary>
-        /// Gets an <see cref="CSharp.Attribute"/> from the <see cref="ArraySchema"/> by name.
-        /// </summary>
-        /// <param name="name">The attribute's name.</param>
-        public Attribute Attribute(string name)
+    /// <summary>
+    /// Gets a collection with all <see cref="Dimension"/>s of the <see cref="ArraySchema"/>.
+    /// </summary>
+    public SortedDictionary<string, Dimension> Dimensions()
+    {
+        var ret = new SortedDictionary<string, Dimension>();
+        using var domain = Domain();
+        var ndim = domain.NDim();
+        for (uint i = 0; i < ndim; ++i)
         {
-            var handle = new AttributeHandle();
-            var successful = false;
-            tiledb_attribute_t* attribute_p = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var schemaHandle = _handle.Acquire())
-                using (var ms_name = new MarshaledString(name))
-                {
-                    _ctx.handle_error(Methods.tiledb_array_schema_get_attribute_from_name(ctxHandle, schemaHandle, ms_name, &attribute_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(attribute_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return new Attribute(_ctx, handle);
+            var dim = domain.Dimension(i);
+            ret.Add(dim.Name(), dim);
         }
+        return ret;
+    }
 
-        /// <summary>
-        /// Checks if an <see cref="CSharp.Attribute"/> with the given name exists in the <see cref="ArraySchema"/> or not.
-        /// </summary>
-        /// <param name="name">The name to check.</param>
-        public bool HasAttribute(string name)
+    /// <summary>
+    /// Checks if an <see cref="CSharp.Attribute"/> or <see cref="Dimension"/> in the <see cref="ArraySchema"/> is nullable.
+    /// </summary>
+    /// <param name="name">The attribute or dimension's name.</param>
+    public bool IsNullable(string name)
+    {
+        if (HasAttribute(name))
         {
-            int has_attr;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(name);
-            _ctx.handle_error(Methods.tiledb_array_schema_has_attribute(ctxHandle, handle, ms_name, &has_attr));
-            return has_attr > 0;
+            using var attr = Attribute(name);
+            return attr.Nullable();
         }
+        return false;
+    }
 
-        /// <summary>
-        /// Load an <see cref="ArraySchema"/> from a URI.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with this schema.</param>
-        /// <param name="uri">The array's URI.</param>
-        public static ArraySchema Load(Context ctx, string uri)
+    /// <summary>
+    /// Checks if an <see cref="CSharp.Attribute"/> or <see cref="Dimension"/> in the <see cref="ArraySchema"/> has variable size.
+    /// </summary>
+    /// <param name="name">The attribute or dimension's name.</param>
+    public bool IsVarSize(string name)
+    {
+        if (string.Equals(name, "coords"))
         {
-            var handle = new ArraySchemaHandle();
-            var successful = false;
-            tiledb_array_schema_t* array_schema_p = null;
-            try
-            {
-                using (var ms_uri = new MarshaledString(uri))
-                using (var ctxHandle = ctx.Handle.Acquire())
-                {
-                    ctx.handle_error(Methods.tiledb_array_schema_load(ctxHandle, ms_uri, &array_schema_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(array_schema_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-            return new ArraySchema(ctx, handle);
-        }
-
-        /// <summary>
-        /// Gets a collection with all <see cref="CSharp.Attribute"/>s of the <see cref="ArraySchema"/>.
-        /// </summary>
-        public SortedDictionary<string, Attribute> Attributes()
-        {
-            var ret = new SortedDictionary<string, Attribute>();
-            var attribute_num = AttributeNum();
-            for (uint i = 0; i < attribute_num; ++i)
-            {
-                var attr = Attribute(i);
-                ret.Add(attr.Name(), attr);
-            }
-            return ret;
-        }
-
-        /// <summary>
-        /// Gets a collection with all <see cref="Dimension"/>s of the <see cref="ArraySchema"/>.
-        /// </summary>
-        public SortedDictionary<string, Dimension> Dimensions()
-        {
-            var ret = new SortedDictionary<string, Dimension>();
-            using var domain = Domain();
-            var ndim = domain.NDim();
-            for (uint i = 0; i < ndim; ++i)
-            {
-                var dim = domain.Dimension(i);
-                ret.Add(dim.Name(), dim);
-            }
-            return ret;
-        }
-
-        /// <summary>
-        /// Checks if an <see cref="CSharp.Attribute"/> or <see cref="Dimension"/> in the <see cref="ArraySchema"/> is nullable.
-        /// </summary>
-        /// <param name="name">The attribute or dimension's name.</param>
-        public bool IsNullable(string name)
-        {
-            if (HasAttribute(name))
-            {
-                using var attr = Attribute(name);
-                return attr.Nullable();
-            }
             return false;
         }
 
-        /// <summary>
-        /// Checks if an <see cref="CSharp.Attribute"/> or <see cref="Dimension"/> in the <see cref="ArraySchema"/> has variable size.
-        /// </summary>
-        /// <param name="name">The attribute or dimension's name.</param>
-        public bool IsVarSize(string name)
+        if (HasAttribute(name))
         {
-            if (string.Equals(name, "coords"))
-            {
-                return false;
-            }
-
-            if (HasAttribute(name))
-            {
-                using Attribute attr = Attribute(name);
-                return attr.CellValNum() == TileDB.CSharp.Attribute.VariableSized;
-            }
-
-            using Domain domain = Domain();
-            if (domain.HasDimension(name))
-            {
-                using Dimension dim = domain.Dimension(name);
-                return dim.CellValNum() == Dimension.VariableSized;
-            }
-
-            return false;
+            using Attribute attr = Attribute(name);
+            return attr.CellValNum() == TileDB.CSharp.Attribute.VariableSized;
         }
+
+        using Domain domain = Domain();
+        if (domain.HasDimension(name))
+        {
+            using Dimension dim = domain.Dimension(name);
+            return dim.CellValNum() == Dimension.VariableSized;
+        }
+
+        return false;
     }
 }

--- a/sources/TileDB.CSharp/ArraySchemaEvolution.cs
+++ b/sources/TileDB.CSharp/ArraySchemaEvolution.cs
@@ -3,134 +3,133 @@ using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 using ArraySchemaEvolutionHandle = TileDB.CSharp.Marshalling.SafeHandles.ArraySchemaEvolutionHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB array schema evolution.
+/// </summary>
+public sealed unsafe class ArraySchemaEvolution : IDisposable
 {
+    private readonly Context _ctx;
+    private readonly ArraySchemaEvolutionHandle _handle;
+
     /// <summary>
-    /// Represents a TileDB array schema evolution.
+    /// Creates an <see cref="ArraySchemaEvolution"/>
     /// </summary>
-    public sealed unsafe class ArraySchemaEvolution : IDisposable
+    /// <param name="ctx">The <see cref="CSharp.Context"/> associated with this array schema evolution.</param>
+    public ArraySchemaEvolution(Context ctx)
     {
-        private readonly Context _ctx;
-        private readonly ArraySchemaEvolutionHandle _handle;
+        _ctx = ctx;
+        _handle = ArraySchemaEvolutionHandle.Create(_ctx);
+    }
 
-        /// <summary>
-        /// Creates an <see cref="ArraySchemaEvolution"/>
-        /// </summary>
-        /// <param name="ctx">The <see cref="CSharp.Context"/> associated with this array schema evolution.</param>
-        public ArraySchemaEvolution(Context ctx)
-        {
-            _ctx = ctx;
-            _handle = ArraySchemaEvolutionHandle.Create(_ctx);
-        }
+    /// <summary>
+    /// Disposes this <see cref="ArraySchemaEvolution"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
 
-        /// <summary>
-        /// Disposes this <see cref="ArraySchemaEvolution"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            _handle.Dispose();
-        }
+    internal ArraySchemaEvolutionHandle Handle => _handle;
 
-        internal ArraySchemaEvolutionHandle Handle => _handle;
+    /// <summary>
+    /// Get context.
+    /// </summary>
+    /// <returns></returns>
+    public Context Context() => _ctx;
 
-        /// <summary>
-        /// Get context.
-        /// </summary>
-        /// <returns></returns>
-        public Context Context() => _ctx;
+    /// <summary>
+    /// Adds an <see cref="Attribute"/> to the <see cref="ArraySchemaEvolution"/>.
+    /// </summary>
+    /// <param name="attr">A fully constructed <see cref="Attribute"/> that will be added to the schema.</param>
+    public void AddAttribute(Attribute attr)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var attrHandle = attr.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_evolution_add_attribute(ctxHandle, handle, attrHandle));
+    }
 
-        /// <summary>
-        /// Adds an <see cref="Attribute"/> to the <see cref="ArraySchemaEvolution"/>.
-        /// </summary>
-        /// <param name="attr">A fully constructed <see cref="Attribute"/> that will be added to the schema.</param>
-        public void AddAttribute(Attribute attr)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var attrHandle = attr.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_evolution_add_attribute(ctxHandle, handle, attrHandle));
-        }
+    /// <summary>
+    /// Drops an attribute with the given name from the <see cref="ArraySchemaEvolution"/>.
+    /// </summary>
+    /// <param name="attrName">The name of the attribute that will be dropped from the schema.</param>
+    public void DropAttribute(string attrName)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var msAttrName = new MarshaledString(attrName);
+        _ctx.handle_error(Methods.tiledb_array_schema_evolution_drop_attribute(ctxHandle, handle, msAttrName));
+    }
 
-        /// <summary>
-        /// Drops an attribute with the given name from the <see cref="ArraySchemaEvolution"/>.
-        /// </summary>
-        /// <param name="attrName">The name of the attribute that will be dropped from the schema.</param>
-        public void DropAttribute(string attrName)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var msAttrName = new MarshaledString(attrName);
-            _ctx.handle_error(Methods.tiledb_array_schema_evolution_drop_attribute(ctxHandle, handle, msAttrName));
-        }
+    /// <summary>
+    /// Adds an <see cref="Enumeration"/> to the <see cref="ArraySchemaEvolution"/>.
+    /// </summary>
+    /// <param name="enumeration">A fully constructed <see cref="Enumeration"/> that will be added to the schema.</param>
+    /// <seealso cref="DropEnumeration"/>
+    public void AddEnumeration(Enumeration enumeration)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var enumHandle = enumeration.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_evolution_add_enumeration(ctxHandle, handle, enumHandle));
+    }
 
-        /// <summary>
-        /// Adds an <see cref="Enumeration"/> to the <see cref="ArraySchemaEvolution"/>.
-        /// </summary>
-        /// <param name="enumeration">A fully constructed <see cref="Enumeration"/> that will be added to the schema.</param>
-        /// <seealso cref="DropEnumeration"/>
-        public void AddEnumeration(Enumeration enumeration)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var enumHandle = enumeration.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_evolution_add_enumeration(ctxHandle, handle, enumHandle));
-        }
+    /// <summary>
+    /// Adds an <see cref="Enumeration"/> to the <see cref="ArraySchemaEvolution"/>.
+    /// </summary>
+    /// <param name="enumeration">A fully constructed <see cref="Enumeration"/> that will be added to the schema.</param>
+    /// <seealso cref="DropEnumeration"/>
+    public void ExtendEnumeration(Enumeration enumeration)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var enumHandle = enumeration.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_schema_evolution_extend_enumeration(ctxHandle, handle, enumHandle));
+    }
 
-        /// <summary>
-        /// Adds an <see cref="Enumeration"/> to the <see cref="ArraySchemaEvolution"/>.
-        /// </summary>
-        /// <param name="enumeration">A fully constructed <see cref="Enumeration"/> that will be added to the schema.</param>
-        /// <seealso cref="DropEnumeration"/>
-        public void ExtendEnumeration(Enumeration enumeration)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var enumHandle = enumeration.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_schema_evolution_extend_enumeration(ctxHandle, handle, enumHandle));
-        }
+    /// <summary>
+    /// Drops an enumeration with the given name from the <see cref="ArraySchemaEvolution"/>.
+    /// </summary>
+    /// <param name="enumerationName">The name of the attribute that will be dropped from the schema.</param>
+    /// <seealso cref="AddEnumeration"/>
+    public void DropEnumeration(string enumerationName)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var msEnumerationName = new MarshaledString(enumerationName);
+        _ctx.handle_error(Methods.tiledb_array_schema_evolution_drop_enumeration(ctxHandle, handle, msEnumerationName));
+    }
 
-        /// <summary>
-        /// Drops an enumeration with the given name from the <see cref="ArraySchemaEvolution"/>.
-        /// </summary>
-        /// <param name="enumerationName">The name of the attribute that will be dropped from the schema.</param>
-        /// <seealso cref="AddEnumeration"/>
-        public void DropEnumeration(string enumerationName)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var msEnumerationName = new MarshaledString(enumerationName);
-            _ctx.handle_error(Methods.tiledb_array_schema_evolution_drop_enumeration(ctxHandle, handle, msEnumerationName));
-        }
+    /// <summary>
+    /// Drops an <see cref="Attribute"/> from the <see cref="ArraySchemaEvolution"/>.
+    /// </summary>
+    /// <param name="attr">The <see cref="Attribute"/> whose name will be dropped from the schema.</param>
+    public void DropAttribute(Attribute attr) => DropAttribute(attr.Name());
 
-        /// <summary>
-        /// Drops an <see cref="Attribute"/> from the <see cref="ArraySchemaEvolution"/>.
-        /// </summary>
-        /// <param name="attr">The <see cref="Attribute"/> whose name will be dropped from the schema.</param>
-        public void DropAttribute(Attribute attr) => DropAttribute(attr.Name());
+    /// <summary>
+    /// Sets the timestamp range of this <see cref="ArraySchemaEvolution"/>.
+    /// </summary>
+    /// <param name="high">High value of timestamp range.</param>
+    /// <param name="low">Low value of timestamp range.</param>
+    public void SetTimeStampRange(ulong high, ulong low)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(
+            Methods.tiledb_array_schema_evolution_set_timestamp_range(ctxHandle, handle, low, high));
+    }
 
-        /// <summary>
-        /// Sets the timestamp range of this <see cref="ArraySchemaEvolution"/>.
-        /// </summary>
-        /// <param name="high">High value of timestamp range.</param>
-        /// <param name="low">Low value of timestamp range.</param>
-        public void SetTimeStampRange(ulong high, ulong low)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(
-                Methods.tiledb_array_schema_evolution_set_timestamp_range(ctxHandle, handle, low, high));
-        }
-
-        /// <summary>
-        /// Applies the <see cref="ArraySchemaEvolution"/> to an existing array.
-        /// </summary>
-        /// <param name="uri">The array's URI.</param>
-        public void EvolveArray(string uri)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var msUri = new MarshaledString(uri);
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_array_evolve(ctxHandle, msUri, handle));
-        }
+    /// <summary>
+    /// Applies the <see cref="ArraySchemaEvolution"/> to an existing array.
+    /// </summary>
+    /// <param name="uri">The array's URI.</param>
+    public void EvolveArray(string uri)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var msUri = new MarshaledString(uri);
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_array_evolve(ctxHandle, msUri, handle));
     }
 }

--- a/sources/TileDB.CSharp/Attribute.cs
+++ b/sources/TileDB.CSharp/Attribute.cs
@@ -8,437 +8,436 @@ using TileDB.CSharp.Marshalling.SafeHandles;
 using AttributeHandle = TileDB.CSharp.Marshalling.SafeHandles.AttributeHandle;
 using FilterListHandle = TileDB.CSharp.Marshalling.SafeHandles.FilterListHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB attribute object.
+/// </summary>
+public sealed unsafe class Attribute : IDisposable
 {
+    private readonly AttributeHandle _handle;
+    private readonly Context _ctx;
+
     /// <summary>
-    /// Represents a TileDB attribute object.
+    /// This value indicates a variable-sized attribute.
+    /// It may be returned from <see cref="CellValNum"/>
+    /// and can be passed to <see cref="SetCellValNum"/>.
     /// </summary>
-    public sealed unsafe class Attribute : IDisposable
+    public const uint VariableSized = Constants.VariableSizedImpl;
+
+    /// <summary>
+    /// Creates an <see cref="Attribute"/>.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> associated with the attribute.</param>
+    /// <param name="name">The attribute's name.</param>
+    /// <param name="dataType">The attribute's data type.</param>
+    public Attribute(Context ctx, string name, DataType dataType)
     {
-        private readonly AttributeHandle _handle;
-        private readonly Context _ctx;
-
-        /// <summary>
-        /// This value indicates a variable-sized attribute.
-        /// It may be returned from <see cref="CellValNum"/>
-        /// and can be passed to <see cref="SetCellValNum"/>.
-        /// </summary>
-        public const uint VariableSized = Constants.VariableSizedImpl;
-
-        /// <summary>
-        /// Creates an <see cref="Attribute"/>.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with the attribute.</param>
-        /// <param name="name">The attribute's name.</param>
-        /// <param name="dataType">The attribute's data type.</param>
-        public Attribute(Context ctx, string name, DataType dataType)
+        _ctx = ctx;
+        var tiledb_datatype = (tiledb_datatype_t)dataType;
+        _handle = AttributeHandle.Create(_ctx, name, tiledb_datatype);
+        if (EnumUtil.IsStringType(dataType))
         {
-            _ctx = ctx;
-            var tiledb_datatype = (tiledb_datatype_t)dataType;
-            _handle = AttributeHandle.Create(_ctx, name, tiledb_datatype);
-            if (EnumUtil.IsStringType(dataType))
+            SetCellValNum(VariableSized);
+        }
+    }
+
+    internal Attribute(Context ctx, AttributeHandle handle)
+    {
+        _ctx = ctx;
+        _handle = handle;
+    }
+
+    /// <summary>
+    /// Disposes this <see cref="Attribute"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
+
+    internal AttributeHandle Handle => _handle;
+
+    /// <summary>
+    /// Sets whether this <see cref="Attribute"/> can take null values.
+    /// </summary>
+    public void SetNullable(bool nullable)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        var int8_nullable = nullable ? (byte)1 : (byte)0;
+        _ctx.handle_error(Methods.tiledb_attribute_set_nullable(ctxHandle, handle, int8_nullable));
+    }
+
+    /// <summary>
+    /// Sets the <see cref="CSharp.FilterList"/> of <see cref="Filter"/>s that will be applied to this <see cref="Attribute"/>.
+    /// </summary>
+    public void SetFilterList(FilterList filterList)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var filterListHandle = filterList.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_attribute_set_filter_list(ctxHandle, handle, filterListHandle));
+    }
+
+    /// <summary>
+    /// Sets the number of values per cell for this attribute.
+    /// For variable-sized attributes the value should be <see cref="VariableSized"/>.
+    /// </summary>
+    public void SetCellValNum(uint cellValNum)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_attribute_set_cell_val_num(ctxHandle, handle, cellValNum));
+    }
+    
+    /// <summary>
+    /// Sets the name of the <see cref="Attribute"/>'s enumeration.
+    /// </summary>
+    public void SetEnumerationName(string enumerationName)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_enumerationName = new MarshaledString(enumerationName);
+        _ctx.handle_error(Methods.tiledb_attribute_set_enumeration_name(ctxHandle, handle, ms_enumerationName));
+    }
+
+    /// <summary>
+    /// Get name of the attribute.
+    /// </summary>
+    /// <returns></returns>
+    public string Name()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        sbyte* result;
+        _ctx.handle_error(Methods.tiledb_attribute_get_name(ctxHandle, handle, &result));
+
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    /// <summary>
+    /// Gets the data type of this <see cref="Attribute"/>.
+    /// </summary>
+    public DataType Type()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        tiledb_datatype_t tiledb_datatype;
+        _ctx.handle_error(Methods.tiledb_attribute_get_type(ctxHandle, handle, &tiledb_datatype));
+        return (DataType)tiledb_datatype;
+    }
+
+    /// <summary>
+    /// Gets whether this <see cref="Attribute"/> can take null values.
+    /// </summary>
+    public bool Nullable()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        byte nullable;
+        _ctx.handle_error(Methods.tiledb_attribute_get_nullable(ctxHandle, handle, &nullable));
+        return nullable > 0;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="CSharp.FilterList"/> of <see cref="Filter"/>s that will be applied to this <see cref="Attribute"/>.
+    /// </summary>
+    public FilterList FilterList()
+    {
+        var handle = new FilterListHandle();
+        var successful = false;
+        tiledb_filter_list_t* filter_list_p = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var attributeHandle = _handle.Acquire())
             {
-                SetCellValNum(VariableSized);
+                _ctx.handle_error(Methods.tiledb_attribute_get_filter_list(ctxHandle, attributeHandle, &filter_list_p));
             }
+            successful = true;
         }
-
-        internal Attribute(Context ctx, AttributeHandle handle)
+        finally
         {
-            _ctx = ctx;
-            _handle = handle;
-        }
-
-        /// <summary>
-        /// Disposes this <see cref="Attribute"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            _handle.Dispose();
-        }
-
-        internal AttributeHandle Handle => _handle;
-
-        /// <summary>
-        /// Sets whether this <see cref="Attribute"/> can take null values.
-        /// </summary>
-        public void SetNullable(bool nullable)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            var int8_nullable = nullable ? (byte)1 : (byte)0;
-            _ctx.handle_error(Methods.tiledb_attribute_set_nullable(ctxHandle, handle, int8_nullable));
-        }
-
-        /// <summary>
-        /// Sets the <see cref="CSharp.FilterList"/> of <see cref="Filter"/>s that will be applied to this <see cref="Attribute"/>.
-        /// </summary>
-        public void SetFilterList(FilterList filterList)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var filterListHandle = filterList.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_attribute_set_filter_list(ctxHandle, handle, filterListHandle));
-        }
-
-        /// <summary>
-        /// Sets the number of values per cell for this attribute.
-        /// For variable-sized attributes the value should be <see cref="VariableSized"/>.
-        /// </summary>
-        public void SetCellValNum(uint cellValNum)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_attribute_set_cell_val_num(ctxHandle, handle, cellValNum));
-        }
-        
-        /// <summary>
-        /// Sets the name of the <see cref="Attribute"/>'s enumeration.
-        /// </summary>
-        public void SetEnumerationName(string enumerationName)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_enumerationName = new MarshaledString(enumerationName);
-            _ctx.handle_error(Methods.tiledb_attribute_set_enumeration_name(ctxHandle, handle, ms_enumerationName));
-        }
-
-        /// <summary>
-        /// Get name of the attribute.
-        /// </summary>
-        /// <returns></returns>
-        public string Name()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            sbyte* result;
-            _ctx.handle_error(Methods.tiledb_attribute_get_name(ctxHandle, handle, &result));
-
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        /// <summary>
-        /// Gets the data type of this <see cref="Attribute"/>.
-        /// </summary>
-        public DataType Type()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_datatype_t tiledb_datatype;
-            _ctx.handle_error(Methods.tiledb_attribute_get_type(ctxHandle, handle, &tiledb_datatype));
-            return (DataType)tiledb_datatype;
-        }
-
-        /// <summary>
-        /// Gets whether this <see cref="Attribute"/> can take null values.
-        /// </summary>
-        public bool Nullable()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            byte nullable;
-            _ctx.handle_error(Methods.tiledb_attribute_get_nullable(ctxHandle, handle, &nullable));
-            return nullable > 0;
-        }
-
-        /// <summary>
-        /// Gets the <see cref="CSharp.FilterList"/> of <see cref="Filter"/>s that will be applied to this <see cref="Attribute"/>.
-        /// </summary>
-        public FilterList FilterList()
-        {
-            var handle = new FilterListHandle();
-            var successful = false;
-            tiledb_filter_list_t* filter_list_p = null;
-            try
+            if (successful)
             {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var attributeHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_attribute_get_filter_list(ctxHandle, attributeHandle, &filter_list_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(filter_list_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return new FilterList(_ctx, handle);
-        }
-
-        /// <summary>
-        /// Gets the number of values per cell for this attribute.
-        /// </summary>
-        /// <remarks>
-        /// For variable-sized attributes the result is <see cref="VariableSized"/>.
-        /// </remarks>
-        public uint CellValNum()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            uint cell_val_num;
-            _ctx.handle_error(Methods.tiledb_attribute_get_cell_val_num(ctxHandle, handle, &cell_val_num));
-            return cell_val_num;
-        }
-
-        /// <summary>
-        /// Gets the cell size of this <see cref="Attribute"/>.
-        /// </summary>
-        public ulong CellSize()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong cell_size;
-            _ctx.handle_error(Methods.tiledb_attribute_get_cell_size(ctxHandle, handle, &cell_size));
-            return cell_size;
-        }
-
-        /// <summary>
-        /// Gets the name of the <see cref="Attribute"/>'s enumeration.
-        /// </summary>
-        /// <returns>
-        /// A string with the name of the attribute's enumeration, or an
-        /// empty string if the attribute does not have an enumeration.
-        /// </returns>
-        public string EnumerationName()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var nameHolder = new StringHandleHolder();
-            _ctx.handle_error(Methods.tiledb_attribute_get_enumeration_name(ctxHandle, handle, &nameHolder._handle));
-
-            return nameHolder.ToString();
-        }
-
-        /// <summary>
-        /// Sets the fill value of a nullable multi-valued <see cref="Attribute"/>.
-        /// Used when the fill value is multi-valued.
-        /// </summary>
-        /// <typeparam name="T">The attribute's data type.</typeparam>
-        /// <param name="data">An array of values that will be used as the fill value.</param>
-        private void SetFillValue<T>(T[] data) where T : struct
-        {
-            ErrorHandling.CheckDataType<T>(Type());
-            if (data.Length == 0)
-            {
-                throw new ArgumentException("Attribute.SetFillValue, data is empty!");
-            }
-
-            var cell_val_num = this.CellValNum();
-
-            if (cell_val_num != VariableSized && cell_val_num != data.Length)
-            {
-                throw new ArgumentException("Attribute.SetFillValue_nullable, data length is not equal to cell_val_num!");
-            }
-
-            ulong size;
-            if (cell_val_num == VariableSized)
-            {
-                size = (ulong)(data.Length* Marshal.SizeOf(data[0]));
+                handle.InitHandle(filter_list_p);
             }
             else
             {
-                size = cell_val_num * (ulong)(Marshal.SizeOf(data[0]));
+                handle.SetHandleAsInvalid();
             }
-
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            fixed (T* dataPtr = &data[0])
-                _ctx.handle_error(Methods.tiledb_attribute_set_fill_value(ctxHandle, handle, dataPtr, size));
         }
 
-        /// <summary>
-        /// Sets the fill value of a nullable <see cref="Attribute"/>.
-        /// </summary>
-        /// <typeparam name="T">The attribute's data type.</typeparam>
-        /// <param name="value">The attribute's fill value.</param>
-        public void SetFillValue<T>(T value) where T : struct
+        return new FilterList(_ctx, handle);
+    }
+
+    /// <summary>
+    /// Gets the number of values per cell for this attribute.
+    /// </summary>
+    /// <remarks>
+    /// For variable-sized attributes the result is <see cref="VariableSized"/>.
+    /// </remarks>
+    public uint CellValNum()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        uint cell_val_num;
+        _ctx.handle_error(Methods.tiledb_attribute_get_cell_val_num(ctxHandle, handle, &cell_val_num));
+        return cell_val_num;
+    }
+
+    /// <summary>
+    /// Gets the cell size of this <see cref="Attribute"/>.
+    /// </summary>
+    public ulong CellSize()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong cell_size;
+        _ctx.handle_error(Methods.tiledb_attribute_get_cell_size(ctxHandle, handle, &cell_size));
+        return cell_size;
+    }
+
+    /// <summary>
+    /// Gets the name of the <see cref="Attribute"/>'s enumeration.
+    /// </summary>
+    /// <returns>
+    /// A string with the name of the attribute's enumeration, or an
+    /// empty string if the attribute does not have an enumeration.
+    /// </returns>
+    public string EnumerationName()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var nameHolder = new StringHandleHolder();
+        _ctx.handle_error(Methods.tiledb_attribute_get_enumeration_name(ctxHandle, handle, &nameHolder._handle));
+
+        return nameHolder.ToString();
+    }
+
+    /// <summary>
+    /// Sets the fill value of a nullable multi-valued <see cref="Attribute"/>.
+    /// Used when the fill value is multi-valued.
+    /// </summary>
+    /// <typeparam name="T">The attribute's data type.</typeparam>
+    /// <param name="data">An array of values that will be used as the fill value.</param>
+    private void SetFillValue<T>(T[] data) where T : struct
+    {
+        ErrorHandling.CheckDataType<T>(Type());
+        if (data.Length == 0)
         {
-            if (typeof(T) == typeof(bool))
-            {
-                SetFillValue<byte>(Convert.ToByte(value));
-                return;
-            }
-
-            var cell_val_num = this.CellValNum();
-            var data = cell_val_num == VariableSized
-                ? [value]
-                : Enumerable.Repeat(value, (int)cell_val_num).ToArray();
-            SetFillValue(data);
+            throw new ArgumentException("Attribute.SetFillValue, data is empty!");
         }
 
-        /// <summary>
-        /// Sets the fill value of a variable-sized <see cref="Attribute"/> to a string.
-        /// </summary>
-        /// <param name="value">The attribute's fill value.</param>
-        public void SetFillValue(string value)
+        var cell_val_num = this.CellValNum();
+
+        if (cell_val_num != VariableSized && cell_val_num != data.Length)
         {
-            var str_bytes = Encoding.ASCII.GetBytes(value);
-            SetFillValue(str_bytes);
+            throw new ArgumentException("Attribute.SetFillValue_nullable, data length is not equal to cell_val_num!");
         }
 
-        private ReadOnlySpan<byte> get_fill_value()
+        ulong size;
+        if (cell_val_num == VariableSized)
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            void* value_p;
-            ulong size;
-            _ctx.handle_error(Methods.tiledb_attribute_get_fill_value(ctxHandle, handle, &value_p, &size));
-
-            return new ReadOnlySpan<byte>(value_p, (int)size);
+            size = (ulong)(data.Length* Marshal.SizeOf(data[0]));
         }
-
-        /// <summary>
-        /// Gets the fill value of the <see cref="Attribute"/>.
-        /// </summary>
-        /// <typeparam name="T">The attribute's data type.</typeparam>
-        public T[] FillValue<T>() where T : struct
+        else
         {
-            if (typeof(T) == typeof(char))
-            {
-                throw new NotSupportedException("Attribute.FillValue, please use FillValue<byte> for TILEDB_CHAR attributes!");
-            }
-            var fill_bytes = get_fill_value();
-            var span = MemoryMarshal.Cast<byte, T>(fill_bytes);
-            return span.ToArray();
+            size = cell_val_num * (ulong)(Marshal.SizeOf(data[0]));
         }
 
-        /// <summary>
-        /// Gets the fill value of the attribute rendered as a string.
-        /// </summary>
-        /// <exception cref="NotSupportedException">The attribute is not string-typed.</exception>
-        public string FillValue()
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        fixed (T* dataPtr = &data[0])
+            _ctx.handle_error(Methods.tiledb_attribute_set_fill_value(ctxHandle, handle, dataPtr, size));
+    }
+
+    /// <summary>
+    /// Sets the fill value of a nullable <see cref="Attribute"/>.
+    /// </summary>
+    /// <typeparam name="T">The attribute's data type.</typeparam>
+    /// <param name="value">The attribute's fill value.</param>
+    public void SetFillValue<T>(T value) where T : struct
+    {
+        if (typeof(T) == typeof(bool))
         {
-            var datatype = Type();
-            if (!EnumUtil.IsStringType(datatype))
-            {
-                throw new NotSupportedException("Attribute.FillValue, please use FillValue<T> for non-string attribute!");
-            }
-            var fill_bytes = get_fill_value();
-            return MarshaledStringOut.GetString(fill_bytes, datatype);
+            SetFillValue<byte>(Convert.ToByte(value));
+            return;
         }
 
-        /// <summary>
-        /// Sets the fill value and validity of a nullable <see cref="Attribute"/>.
-        /// Used when the fill value is multi-valued.
-        /// </summary>
-        /// <typeparam name="T">The attribute's data type.</typeparam>
-        /// <param name="data">The attribute's fill value.</param>
-        /// <param name="valid">Whether the fill value will be non-null.</param>
-        private void SetFillValueNullable<T>(T[] data, bool valid) where T : struct
+        var cell_val_num = this.CellValNum();
+        var data = cell_val_num == VariableSized
+            ? [value]
+            : Enumerable.Repeat(value, (int)cell_val_num).ToArray();
+        SetFillValue(data);
+    }
+
+    /// <summary>
+    /// Sets the fill value of a variable-sized <see cref="Attribute"/> to a string.
+    /// </summary>
+    /// <param name="value">The attribute's fill value.</param>
+    public void SetFillValue(string value)
+    {
+        var str_bytes = Encoding.ASCII.GetBytes(value);
+        SetFillValue(str_bytes);
+    }
+
+    private ReadOnlySpan<byte> get_fill_value()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        void* value_p;
+        ulong size;
+        _ctx.handle_error(Methods.tiledb_attribute_get_fill_value(ctxHandle, handle, &value_p, &size));
+
+        return new ReadOnlySpan<byte>(value_p, (int)size);
+    }
+
+    /// <summary>
+    /// Gets the fill value of the <see cref="Attribute"/>.
+    /// </summary>
+    /// <typeparam name="T">The attribute's data type.</typeparam>
+    public T[] FillValue<T>() where T : struct
+    {
+        if (typeof(T) == typeof(char))
         {
-            if (data.Length == 0)
-            {
-                throw new ArgumentException("Attribute.SetFillValueNullable, data is empty!");
-            }
-
-            var cell_val_num = this.CellValNum();
-            if (cell_val_num != VariableSized && cell_val_num != data.Length)
-            {
-                throw new ArgumentException("Attribute.SetFillValueNullable, data length is not equal to cell_val_num!");
-            }
-
-            ulong size;
-            if (cell_val_num == VariableSized)
-            {
-                size = (ulong)(data.Length * Marshal.SizeOf(data[0]));
-            }
-            else
-            {
-                size = cell_val_num * (ulong)Marshal.SizeOf(data[0]);
-            }
-
-            var validity = valid ? (byte)1 : (byte)0;
-
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            fixed (T* dataPtr = &data[0])
-                _ctx.handle_error(Methods.tiledb_attribute_set_fill_value_nullable(ctxHandle, handle, dataPtr, size, validity));
+            throw new NotSupportedException("Attribute.FillValue, please use FillValue<byte> for TILEDB_CHAR attributes!");
         }
+        var fill_bytes = get_fill_value();
+        var span = MemoryMarshal.Cast<byte, T>(fill_bytes);
+        return span.ToArray();
+    }
 
-        /// <summary>
-        /// Sets the fill value and validity of a nullable <see cref="Attribute"/>.
-        /// Used when the attribute is single-valued or all its values are the same.
-        /// </summary>
-        /// <typeparam name="T">The attribute's data type.</typeparam>
-        /// <param name="value">The attribute's fill value.</param>
-        /// <param name="valid">Whether the fill value will be non-null.</param>
-        public void SetFillValueNullable<T>(T value, bool valid) where T : struct
+    /// <summary>
+    /// Gets the fill value of the attribute rendered as a string.
+    /// </summary>
+    /// <exception cref="NotSupportedException">The attribute is not string-typed.</exception>
+    public string FillValue()
+    {
+        var datatype = Type();
+        if (!EnumUtil.IsStringType(datatype))
         {
-            var cell_val_num = this.CellValNum();
-            var data = cell_val_num == VariableSized ? [value] : Enumerable.Repeat(value, (int)cell_val_num).ToArray();
-            SetFillValueNullable(data, valid);
+            throw new NotSupportedException("Attribute.FillValue, please use FillValue<T> for non-string attribute!");
         }
+        var fill_bytes = get_fill_value();
+        return MarshaledStringOut.GetString(fill_bytes, datatype);
+    }
 
-        /// <summary>
-        /// Sets the fill value and validity of a string-typed <see cref="Attribute"/>.
-        /// </summary>
-        /// <param name="value">The attribute's fill value.</param>
-        /// <param name="valid">Whether the fill value will be non-null.</param>
-        public void SetFillValueNullable(string value, bool valid)
+    /// <summary>
+    /// Sets the fill value and validity of a nullable <see cref="Attribute"/>.
+    /// Used when the fill value is multi-valued.
+    /// </summary>
+    /// <typeparam name="T">The attribute's data type.</typeparam>
+    /// <param name="data">The attribute's fill value.</param>
+    /// <param name="valid">Whether the fill value will be non-null.</param>
+    private void SetFillValueNullable<T>(T[] data, bool valid) where T : struct
+    {
+        if (data.Length == 0)
         {
-            var str_bytes = Encoding.ASCII.GetBytes(value);
-            SetFillValueNullable(str_bytes, valid);
+            throw new ArgumentException("Attribute.SetFillValueNullable, data is empty!");
         }
 
-        /// <summary>
-        /// Gets the <see cref="Attribute"/>'s fill value as an array of bytes, and its validity.
-        /// </summary>
-        private (byte[] bytearray, bool valid) get_fill_value_nullable()
+        var cell_val_num = this.CellValNum();
+        if (cell_val_num != VariableSized && cell_val_num != data.Length)
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            void* value_p;
-            ulong size;
-            var byte_valid = default(byte);
-            _ctx.handle_error(Methods.tiledb_attribute_get_fill_value_nullable(ctxHandle, handle, &value_p, &size, &byte_valid));
-
-            var fill_span = new ReadOnlySpan<byte>(value_p, (int)size);
-            return (fill_span.ToArray(), byte_valid>0);
+            throw new ArgumentException("Attribute.SetFillValueNullable, data length is not equal to cell_val_num!");
         }
 
-        /// <summary>
-        /// Gets the <see cref="Attribute"/>'s fill value and validity.
-        /// </summary>
-        /// <typeparam name="T">The attribute's data type.</typeparam>
-        public Tuple<T[], bool> FillValueNullable<T>() where T : struct
+        ulong size;
+        if (cell_val_num == VariableSized)
         {
-            var fill_value = get_fill_value_nullable();
-            Span<byte> byteSpan = fill_value.bytearray;
-            var span = MemoryMarshal.Cast<byte, T>(byteSpan);
-            return new Tuple<T[], bool>(span.ToArray(), fill_value.valid);
+            size = (ulong)(data.Length * Marshal.SizeOf(data[0]));
+        }
+        else
+        {
+            size = cell_val_num * (ulong)Marshal.SizeOf(data[0]);
         }
 
-        /// <summary>
-        /// Gets the <see cref="Attribute"/>'s fill value as a string.
-        /// </summary>
-        public string FillValueNullable()
-        {
-            var datatype = Type();
-            if (!EnumUtil.IsStringType(datatype))
-            {
-                throw new NotSupportedException("Attribute.FillValueNullable, please use fill_value<T> for non-string attribute!");
-            }
-            var (fill_bytes, _) = get_fill_value_nullable();
-            return MarshaledStringOut.GetString(fill_bytes, datatype);
-        }
+        var validity = valid ? (byte)1 : (byte)0;
 
-        /// <summary>
-        /// Creates an <see cref="Attribute"/>.
-        /// </summary>
-        /// <typeparam name="T">The attribute's data type.</typeparam>
-        /// <param name="ctx">The <see cref="Context"/> associated with the attribute.</param>
-        /// <param name="name">The attribute's name.</param>
-        public static Attribute Create<T>(Context ctx, string name)
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        fixed (T* dataPtr = &data[0])
+            _ctx.handle_error(Methods.tiledb_attribute_set_fill_value_nullable(ctxHandle, handle, dataPtr, size, validity));
+    }
+
+    /// <summary>
+    /// Sets the fill value and validity of a nullable <see cref="Attribute"/>.
+    /// Used when the attribute is single-valued or all its values are the same.
+    /// </summary>
+    /// <typeparam name="T">The attribute's data type.</typeparam>
+    /// <param name="value">The attribute's fill value.</param>
+    /// <param name="valid">Whether the fill value will be non-null.</param>
+    public void SetFillValueNullable<T>(T value, bool valid) where T : struct
+    {
+        var cell_val_num = this.CellValNum();
+        var data = cell_val_num == VariableSized ? [value] : Enumerable.Repeat(value, (int)cell_val_num).ToArray();
+        SetFillValueNullable(data, valid);
+    }
+
+    /// <summary>
+    /// Sets the fill value and validity of a string-typed <see cref="Attribute"/>.
+    /// </summary>
+    /// <param name="value">The attribute's fill value.</param>
+    /// <param name="valid">Whether the fill value will be non-null.</param>
+    public void SetFillValueNullable(string value, bool valid)
+    {
+        var str_bytes = Encoding.ASCII.GetBytes(value);
+        SetFillValueNullable(str_bytes, valid);
+    }
+
+    /// <summary>
+    /// Gets the <see cref="Attribute"/>'s fill value as an array of bytes, and its validity.
+    /// </summary>
+    private (byte[] bytearray, bool valid) get_fill_value_nullable()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        void* value_p;
+        ulong size;
+        var byte_valid = default(byte);
+        _ctx.handle_error(Methods.tiledb_attribute_get_fill_value_nullable(ctxHandle, handle, &value_p, &size, &byte_valid));
+
+        var fill_span = new ReadOnlySpan<byte>(value_p, (int)size);
+        return (fill_span.ToArray(), byte_valid>0);
+    }
+
+    /// <summary>
+    /// Gets the <see cref="Attribute"/>'s fill value and validity.
+    /// </summary>
+    /// <typeparam name="T">The attribute's data type.</typeparam>
+    public Tuple<T[], bool> FillValueNullable<T>() where T : struct
+    {
+        var fill_value = get_fill_value_nullable();
+        Span<byte> byteSpan = fill_value.bytearray;
+        var span = MemoryMarshal.Cast<byte, T>(byteSpan);
+        return new Tuple<T[], bool>(span.ToArray(), fill_value.valid);
+    }
+
+    /// <summary>
+    /// Gets the <see cref="Attribute"/>'s fill value as a string.
+    /// </summary>
+    public string FillValueNullable()
+    {
+        var datatype = Type();
+        if (!EnumUtil.IsStringType(datatype))
         {
-            var datatype = EnumUtil.TypeToDataType(typeof(T));
-            return new Attribute(ctx, name, datatype);
+            throw new NotSupportedException("Attribute.FillValueNullable, please use fill_value<T> for non-string attribute!");
         }
+        var (fill_bytes, _) = get_fill_value_nullable();
+        return MarshaledStringOut.GetString(fill_bytes, datatype);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="Attribute"/>.
+    /// </summary>
+    /// <typeparam name="T">The attribute's data type.</typeparam>
+    /// <param name="ctx">The <see cref="Context"/> associated with the attribute.</param>
+    /// <param name="name">The attribute's name.</param>
+    public static Attribute Create<T>(Context ctx, string name)
+    {
+        var datatype = EnumUtil.TypeToDataType(typeof(T));
+        return new Attribute(ctx, name, datatype);
     }
 }

--- a/sources/TileDB.CSharp/Attribute.cs
+++ b/sources/TileDB.CSharp/Attribute.cs
@@ -268,7 +268,7 @@ namespace TileDB.CSharp
 
             var cell_val_num = this.CellValNum();
             var data = cell_val_num == VariableSized
-                ? new[] { value }
+                ? [value]
                 : Enumerable.Repeat(value, (int)cell_val_num).ToArray();
             SetFillValue(data);
         }
@@ -372,7 +372,7 @@ namespace TileDB.CSharp
         public void SetFillValueNullable<T>(T value, bool valid) where T : struct
         {
             var cell_val_num = this.CellValNum();
-            var data = cell_val_num == VariableSized ? new[] { value } : Enumerable.Repeat(value, (int)cell_val_num).ToArray();
+            var data = cell_val_num == VariableSized ? [value] : Enumerable.Repeat(value, (int)cell_val_num).ToArray();
             SetFillValueNullable(data, valid);
         }
 

--- a/sources/TileDB.CSharp/Config.cs
+++ b/sources/TileDB.CSharp/Config.cs
@@ -4,178 +4,177 @@ using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 using ConfigHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB config object.
+/// </summary>
+public sealed unsafe class Config : IDisposable
 {
+    private readonly ConfigHandle _handle;
+
     /// <summary>
-    /// Represents a TileDB config object.
+    /// Creates a <see cref="Config"/>.
     /// </summary>
-    public sealed unsafe class Config : IDisposable
+    public Config()
     {
-        private readonly ConfigHandle _handle;
+        _handle = ConfigHandle.Create();
+    }
 
-        /// <summary>
-        /// Creates a <see cref="Config"/>.
-        /// </summary>
-        public Config()
+    internal Config(ConfigHandle handle)
+    {
+        _handle = handle;
+    }
+
+    /// <summary>
+    /// Disposes this <see cref="Config"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
+
+    internal ConfigHandle Handle => _handle;
+
+    /// <summary>
+    /// Sets a parameter.
+    /// </summary>
+    /// <param name="param">The parameter's name.</param>
+    /// <param name="value">The parameter's value.</param>
+    /// <exception cref="ArgumentException"><paramref name="param"/> is <see langword="null"/> or empty.</exception>
+    public void Set(string param, string value)
+    {
+        if (string.IsNullOrEmpty(param) || string.IsNullOrEmpty(value))
         {
-            _handle = ConfigHandle.Create();
+            throw new ArgumentException("Config.set, param or value is null or empty!");
         }
 
-        internal Config(ConfigHandle handle)
+        using var ms_param = new MarshaledString(param);
+        using var ms_value = new MarshaledString(value);
+
+        tiledb_error_t* p_tiledb_error;
+        int status;
+        using (var handle = _handle.Acquire())
         {
-            _handle = handle;
+            status = Methods.tiledb_config_set(handle, ms_param, ms_value, &p_tiledb_error);
+        }
+        ErrorHandling.CheckLastError(&p_tiledb_error, status);
+    }
+
+    /// <summary>
+    /// Gets the value of a parameter.
+    /// </summary>
+    /// <param name="param">The parameter's name</param>
+    /// <exception cref="ArgumentException"><paramref name="param"/> is <see langword="null"/> or empty.</exception>
+    public string Get(string param)
+    {
+        if (string.IsNullOrEmpty(param))
+        {
+            throw new ArgumentException("Config.get, param or value is null or empty!");
         }
 
-        /// <summary>
-        /// Disposes this <see cref="Config"/>.
-        /// </summary>
-        public void Dispose()
+        using var ms_param = new MarshaledString(param);
+        sbyte* result;
+
+        tiledb_error_t* p_tiledb_error;
+        int status;
+        using (var handle = _handle.Acquire())
         {
-            _handle.Dispose();
+            status = Methods.tiledb_config_get(handle, ms_param, &result, &p_tiledb_error);
+        }
+        ErrorHandling.CheckLastError(&p_tiledb_error, status);
+
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    /// <summary>
+    /// Unsets a parameter.
+    /// </summary>
+    /// <param name="param">The parameter's name.</param>
+    /// <exception cref="ArgumentException"><paramref name="param"/> is <see langword="null"/> or empty.</exception>
+    public void Unset(string param)
+    {
+        if (string.IsNullOrEmpty(param))
+        {
+            throw new ArgumentException("Config.set, param is null or empty!");
         }
 
-        internal ConfigHandle Handle => _handle;
+        using var ms_param = new MarshaledString(param);
 
-        /// <summary>
-        /// Sets a parameter.
-        /// </summary>
-        /// <param name="param">The parameter's name.</param>
-        /// <param name="value">The parameter's value.</param>
-        /// <exception cref="ArgumentException"><paramref name="param"/> is <see langword="null"/> or empty.</exception>
-        public void Set(string param, string value)
+        tiledb_error_t* p_tiledb_error;
+        int status;
+        using (var handle = _handle.Acquire())
         {
-            if (string.IsNullOrEmpty(param) || string.IsNullOrEmpty(value))
-            {
-                throw new ArgumentException("Config.set, param or value is null or empty!");
-            }
+            status = Methods.tiledb_config_unset(handle, ms_param, &p_tiledb_error);
+        }
+        ErrorHandling.CheckLastError(&p_tiledb_error, status);
+    }
 
-            using var ms_param = new MarshaledString(param);
-            using var ms_value = new MarshaledString(value);
-
-            tiledb_error_t* p_tiledb_error;
-            int status;
-            using (var handle = _handle.Acquire())
-            {
-                status = Methods.tiledb_config_set(handle, ms_param, ms_value, &p_tiledb_error);
-            }
-            ErrorHandling.CheckLastError(&p_tiledb_error, status);
+    /// <summary>
+    /// Loads the options from a file.
+    /// </summary>
+    /// <param name="filename">The file's name.</param>
+    /// <exception cref="ArgumentException"><paramref name="filename"/> is <see langword="null"/> or empty.</exception>
+    public void LoadFromFile(string filename)
+    {
+        if (string.IsNullOrEmpty(filename))
+        {
+            throw new ArgumentException("Config.load_from_file, filename is null or empty!");
         }
 
-        /// <summary>
-        /// Gets the value of a parameter.
-        /// </summary>
-        /// <param name="param">The parameter's name</param>
-        /// <exception cref="ArgumentException"><paramref name="param"/> is <see langword="null"/> or empty.</exception>
-        public string Get(string param)
+        using var ms_filename = new MarshaledString(filename);
+
+        tiledb_error_t* p_tiledb_error;
+        int status;
+        using (var handle = _handle.Acquire())
         {
-            if (string.IsNullOrEmpty(param))
-            {
-                throw new ArgumentException("Config.get, param or value is null or empty!");
-            }
+            status = Methods.tiledb_config_load_from_file(handle, ms_filename, &p_tiledb_error);
+        }
+        ErrorHandling.CheckLastError(&p_tiledb_error, status);
+    }
 
-            using var ms_param = new MarshaledString(param);
-            sbyte* result;
-
-            tiledb_error_t* p_tiledb_error;
-            int status;
-            using (var handle = _handle.Acquire())
-            {
-                status = Methods.tiledb_config_get(handle, ms_param, &result, &p_tiledb_error);
-            }
-            ErrorHandling.CheckLastError(&p_tiledb_error, status);
-
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
+    /// <summary>
+    /// Saves the options from a file.
+    /// </summary>
+    /// <param name="filename">The file's name.</param>
+    /// <exception cref="ArgumentException"><paramref name="filename"/> is <see langword="null"/> or empty.</exception>
+    public void SaveToFile(string filename)
+    {
+        if (string.IsNullOrEmpty(filename))
+        {
+            throw new ArgumentException("Config.save_to_file, filename is null or empty!");
         }
 
-        /// <summary>
-        /// Unsets a parameter.
-        /// </summary>
-        /// <param name="param">The parameter's name.</param>
-        /// <exception cref="ArgumentException"><paramref name="param"/> is <see langword="null"/> or empty.</exception>
-        public void Unset(string param)
+        using var ms_filename = new MarshaledString(filename);
+
+        tiledb_error_t* p_tiledb_error;
+        int status;
+        using (var handle = _handle.Acquire())
         {
-            if (string.IsNullOrEmpty(param))
-            {
-                throw new ArgumentException("Config.set, param is null or empty!");
-            }
-
-            using var ms_param = new MarshaledString(param);
-
-            tiledb_error_t* p_tiledb_error;
-            int status;
-            using (var handle = _handle.Acquire())
-            {
-                status = Methods.tiledb_config_unset(handle, ms_param, &p_tiledb_error);
-            }
-            ErrorHandling.CheckLastError(&p_tiledb_error, status);
+            status = Methods.tiledb_config_save_to_file(handle, ms_filename, &p_tiledb_error);
         }
+        ErrorHandling.CheckLastError(&p_tiledb_error, status);
+    }
 
-        /// <summary>
-        /// Loads the options from a file.
-        /// </summary>
-        /// <param name="filename">The file's name.</param>
-        /// <exception cref="ArgumentException"><paramref name="filename"/> is <see langword="null"/> or empty.</exception>
-        public void LoadFromFile(string filename)
-        {
-            if (string.IsNullOrEmpty(filename))
-            {
-                throw new ArgumentException("Config.load_from_file, filename is null or empty!");
-            }
+    /// <summary>
+    /// Gets a <see cref="ConfigIterator"/> that enumerates over all options whose parameter namess start with a given prefix.
+    /// </summary>
+    /// <param name="prefix">The parameters' name's prefix.</param>
+    public ConfigIterator Iterate(string prefix)
+    {
+        return new ConfigIterator(_handle, prefix);
+    }
 
-            using var ms_filename = new MarshaledString(filename);
-
-            tiledb_error_t* p_tiledb_error;
-            int status;
-            using (var handle = _handle.Acquire())
-            {
-                status = Methods.tiledb_config_load_from_file(handle, ms_filename, &p_tiledb_error);
-            }
-            ErrorHandling.CheckLastError(&p_tiledb_error, status);
-        }
-
-        /// <summary>
-        /// Saves the options from a file.
-        /// </summary>
-        /// <param name="filename">The file's name.</param>
-        /// <exception cref="ArgumentException"><paramref name="filename"/> is <see langword="null"/> or empty.</exception>
-        public void SaveToFile(string filename)
-        {
-            if (string.IsNullOrEmpty(filename))
-            {
-                throw new ArgumentException("Config.save_to_file, filename is null or empty!");
-            }
-
-            using var ms_filename = new MarshaledString(filename);
-
-            tiledb_error_t* p_tiledb_error;
-            int status;
-            using (var handle = _handle.Acquire())
-            {
-                status = Methods.tiledb_config_save_to_file(handle, ms_filename, &p_tiledb_error);
-            }
-            ErrorHandling.CheckLastError(&p_tiledb_error, status);
-        }
-
-        /// <summary>
-        /// Gets a <see cref="ConfigIterator"/> that enumerates over all options whose parameter namess start with a given prefix.
-        /// </summary>
-        /// <param name="prefix">The parameters' name's prefix.</param>
-        public ConfigIterator Iterate(string prefix)
-        {
-            return new ConfigIterator(_handle, prefix);
-        }
-
-        /// <summary>
-        /// Checks if two <see cref="Config"/>s have the same content.
-        /// </summary>
-        /// <param name="other">The config to compare this one with.</param>
-        public bool Cmp(ref Config other)
-        {
-            using var handle = Handle.Acquire();
-            using var otherHandle = other.Handle.Acquire();
-            byte equal;
-            Methods.tiledb_config_compare(handle, otherHandle, &equal);
-            return equal == 1;
-        }
+    /// <summary>
+    /// Checks if two <see cref="Config"/>s have the same content.
+    /// </summary>
+    /// <param name="other">The config to compare this one with.</param>
+    public bool Cmp(ref Config other)
+    {
+        using var handle = Handle.Acquire();
+        using var otherHandle = other.Handle.Acquire();
+        byte equal;
+        Methods.tiledb_config_compare(handle, otherHandle, &equal);
+        return equal == 1;
     }
 }

--- a/sources/TileDB.CSharp/ConfigIterator.cs
+++ b/sources/TileDB.CSharp/ConfigIterator.cs
@@ -4,91 +4,90 @@ using TileDB.Interop;
 using ConfigHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigHandle;
 using ConfigIteratorHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigIteratorHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+public sealed unsafe class ConfigIterator : IDisposable
 {
-    public sealed unsafe class ConfigIterator : IDisposable
+    private readonly ConfigIteratorHandle _handle;
+    private readonly ConfigHandle _hConfig;
+    private bool _disposed;
+
+    internal ConfigIterator(ConfigHandle hConfig, string prefix)
     {
-        private readonly ConfigIteratorHandle _handle;
-        private readonly ConfigHandle _hConfig;
-        private bool _disposed;
+        _hConfig = hConfig;
+        _handle = ConfigIteratorHandle.Create(hConfig, prefix);
+    }
 
-        internal ConfigIterator(ConfigHandle hConfig, string prefix)
+    public void Dispose()
+    {
+        Dispose(true);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing && (!_handle.IsInvalid))
         {
-            _hConfig = hConfig;
-            _handle = ConfigIteratorHandle.Create(hConfig, prefix);
+            _handle.Dispose();
         }
 
-        public void Dispose()
+        _disposed = true;
+    }
+
+    internal ConfigIteratorHandle Handle => _handle;
+
+    public Tuple<string, string> Here()
+    {
+        tiledb_error_t* p_tiledb_error;
+        sbyte* paramPtr;
+        sbyte* valuePtr;
+        int status;
+        using (var handle = _handle.Acquire())
         {
-            Dispose(true);
+            status = Methods.tiledb_config_iter_here(handle, &paramPtr, &valuePtr, &p_tiledb_error);
         }
 
-        private void Dispose(bool disposing)
+        ErrorHandling.CheckLastError(&p_tiledb_error, status);
+
+        string param = MarshaledStringOut.GetStringFromNullTerminated(paramPtr);
+        string value = MarshaledStringOut.GetStringFromNullTerminated(valuePtr);
+        return new Tuple<string, string>(param, value);
+    }
+
+    public void Next()
+    {
+        tiledb_error_t* p_tiledb_error;
+        int status;
+        using (var handle = _handle.Acquire())
         {
-            if (_disposed) return;
-            if (disposing && (!_handle.IsInvalid))
-            {
-                _handle.Dispose();
-            }
-
-            _disposed = true;
+            status = Methods.tiledb_config_iter_next(handle, &p_tiledb_error);
         }
+        ErrorHandling.CheckLastError(&p_tiledb_error, status);
+    }
 
-        internal ConfigIteratorHandle Handle => _handle;
-
-        public Tuple<string, string> Here()
+    public bool Done()
+    {
+        tiledb_error_t* p_tiledb_error;
+        int c_done;
+        int status;
+        using (var handle = _handle.Acquire())
         {
-            tiledb_error_t* p_tiledb_error;
-            sbyte* paramPtr;
-            sbyte* valuePtr;
-            int status;
-            using (var handle = _handle.Acquire())
-            {
-                status = Methods.tiledb_config_iter_here(handle, &paramPtr, &valuePtr, &p_tiledb_error);
-            }
-
-            ErrorHandling.CheckLastError(&p_tiledb_error, status);
-
-            string param = MarshaledStringOut.GetStringFromNullTerminated(paramPtr);
-            string value = MarshaledStringOut.GetStringFromNullTerminated(valuePtr);
-            return new Tuple<string, string>(param, value);
+            status = Methods.tiledb_config_iter_done(handle, &c_done, &p_tiledb_error);
         }
+        ErrorHandling.CheckLastError(&p_tiledb_error, status);
+        return c_done == 1;
+    }
 
-        public void Next()
+    public void Reset(string prefix)
+    {
+        tiledb_error_t* p_tiledb_error;
+        using var ms_prefix = new MarshaledString(prefix);
+        int status;
+        using (var configHandle = _hConfig.Acquire())
+        using (var handle = _handle.Acquire())
         {
-            tiledb_error_t* p_tiledb_error;
-            int status;
-            using (var handle = _handle.Acquire())
-            {
-                status = Methods.tiledb_config_iter_next(handle, &p_tiledb_error);
-            }
-            ErrorHandling.CheckLastError(&p_tiledb_error, status);
+            status = Methods.tiledb_config_iter_reset(configHandle, handle, ms_prefix, &p_tiledb_error);
         }
-
-        public bool Done()
-        {
-            tiledb_error_t* p_tiledb_error;
-            int c_done;
-            int status;
-            using (var handle = _handle.Acquire())
-            {
-                status = Methods.tiledb_config_iter_done(handle, &c_done, &p_tiledb_error);
-            }
-            ErrorHandling.CheckLastError(&p_tiledb_error, status);
-            return c_done == 1;
-        }
-
-        public void Reset(string prefix)
-        {
-            tiledb_error_t* p_tiledb_error;
-            using var ms_prefix = new MarshaledString(prefix);
-            int status;
-            using (var configHandle = _hConfig.Acquire())
-            using (var handle = _handle.Acquire())
-            {
-                status = Methods.tiledb_config_iter_reset(configHandle, handle, ms_prefix, &p_tiledb_error);
-            }
-            ErrorHandling.CheckLastError(&p_tiledb_error, status);
-        }
+        ErrorHandling.CheckLastError(&p_tiledb_error, status);
     }
 }

--- a/sources/TileDB.CSharp/Context.cs
+++ b/sources/TileDB.CSharp/Context.cs
@@ -241,7 +241,7 @@ namespace TileDB.CSharp
             handle_error(Methods.tiledb_object_move(handle, ms_oldUri, ms_newUri));
         }
 
-        [UnmanagedCallersOnly(CallConvs = new Type[] { typeof(CallConvCdecl) })]
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
         private static int VisitCallback(sbyte* uriPtr, tiledb_object_t objectType, void* arg)
         {
             VisitCallbackData* data = (VisitCallbackData*)arg;

--- a/sources/TileDB.CSharp/Context.cs
+++ b/sources/TileDB.CSharp/Context.cs
@@ -10,371 +10,370 @@ using TileDB.Interop;
 using ContextHandle = TileDB.CSharp.Marshalling.SafeHandles.ContextHandle;
 using ConfigHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB context.
+/// </summary>
+public sealed unsafe class Context : IDisposable
 {
+    private readonly ContextHandle _handle;
+
+    private bool IsDefault { get; init; }
+
     /// <summary>
-    /// Represents a TileDB context.
+    /// Creates a <see cref="Context"/>.
     /// </summary>
-    public sealed unsafe class Context : IDisposable
+    public Context()
     {
-        private readonly ContextHandle _handle;
+        _handle = ContextHandle.Create();
+        SetDefaultTags();
+    }
 
-        private bool IsDefault { get; init; }
+    /// <summary>
+    /// Creates a <see cref="Context"/> with an associated <see cref="CSharp.Config"/>.
+    /// </summary>
+    /// <param name="config">The context's config.</param>
+    public Context(Config config)
+    {
+        _handle = ContextHandle.Create(config.Handle);
+        SetDefaultTags();
+    }
 
-        /// <summary>
-        /// Creates a <see cref="Context"/>.
-        /// </summary>
-        public Context()
+    private void SetDefaultTags()
+    {
+        SetTag("x-tiledb-api-language", "csharp");
+    }
+
+    /// <summary>
+    /// Disposes the <see cref="Context"/>.
+    /// </summary>
+    /// <remarks>
+    /// Calling this method on the context returned by <see cref="GetDefault"/> will have no effect.
+    /// </remarks>
+    public void Dispose()
+    {
+        if (IsDefault)
         {
-            _handle = ContextHandle.Create();
-            SetDefaultTags();
+            return;
         }
 
-        /// <summary>
-        /// Creates a <see cref="Context"/> with an associated <see cref="CSharp.Config"/>.
-        /// </summary>
-        /// <param name="config">The context's config.</param>
-        public Context(Config config)
+        _handle.Dispose();
+    }
+
+    internal ContextHandle Handle => _handle;
+
+    private static readonly Context _default = new() { IsDefault = true };
+
+    /// <summary>
+    /// Gets the default <see cref="Context"/>.
+    /// </summary>
+    public static Context GetDefault() => _default;
+
+    /// <summary>
+    /// Gets a JSON string with statistics about the context.
+    /// </summary>
+    public string Stats()
+    {
+        sbyte* result = null;
+        try
         {
-            _handle = ContextHandle.Create(config.Handle);
-            SetDefaultTags();
+            using var handle = _handle.Acquire();
+            ErrorHandling.ThrowOnError(Methods.tiledb_ctx_get_stats(handle, &result));
+
+            return MarshaledStringOut.GetStringFromNullTerminated(result);
         }
-
-        private void SetDefaultTags()
+        finally
         {
-            SetTag("x-tiledb-api-language", "csharp");
-        }
-
-        /// <summary>
-        /// Disposes the <see cref="Context"/>.
-        /// </summary>
-        /// <remarks>
-        /// Calling this method on the context returned by <see cref="GetDefault"/> will have no effect.
-        /// </remarks>
-        public void Dispose()
-        {
-            if (IsDefault)
+            if (result is not null)
             {
-                return;
-            }
-
-            _handle.Dispose();
-        }
-
-        internal ContextHandle Handle => _handle;
-
-        private static readonly Context _default = new() { IsDefault = true };
-
-        /// <summary>
-        /// Gets the default <see cref="Context"/>.
-        /// </summary>
-        public static Context GetDefault() => _default;
-
-        /// <summary>
-        /// Gets a JSON string with statistics about the context.
-        /// </summary>
-        public string Stats()
-        {
-            sbyte* result = null;
-            try
-            {
-                using var handle = _handle.Acquire();
-                ErrorHandling.ThrowOnError(Methods.tiledb_ctx_get_stats(handle, &result));
-
-                return MarshaledStringOut.GetStringFromNullTerminated(result);
-            }
-            finally
-            {
-                if (result is not null)
-                {
-                    ErrorHandling.ThrowOnError(Methods.tiledb_stats_free_str(&result));
-                }
+                ErrorHandling.ThrowOnError(Methods.tiledb_stats_free_str(&result));
             }
         }
+    }
 
-        /// <summary>
-        /// Gets the <see cref="Context"/>'s <see cref="Config"/>.
-        /// </summary>
-        public Config Config()
+    /// <summary>
+    /// Gets the <see cref="Context"/>'s <see cref="Config"/>.
+    /// </summary>
+    public Config Config()
+    {
+        var handle = new ConfigHandle();
+        tiledb_config_t* config = null;
+        var successful = false;
+        try
         {
-            var handle = new ConfigHandle();
-            tiledb_config_t* config = null;
-            var successful = false;
-            try
-            {
-                using var ctxHandle = _handle.Acquire();
-                handle_error(Methods.tiledb_ctx_get_config(ctxHandle, &config));
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(config);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-            return new Config(handle);
+            using var ctxHandle = _handle.Acquire();
+            handle_error(Methods.tiledb_ctx_get_config(ctxHandle, &config));
+            successful = true;
         }
-
-        /// <summary>
-        /// Gets the last error message associated with this <see cref="Context"/>.
-        /// </summary>
-        public string LastError()
+        finally
         {
-            var sb_result = new StringBuilder();
-
-            tiledb_error_t* p_tiledb_error;
-            int status;
-            using (var handle = _handle.Acquire())
+            if (successful)
             {
-                status = Methods.tiledb_ctx_get_last_error(handle, &p_tiledb_error);
+                handle.InitHandle(config);
             }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+        return new Config(handle);
+    }
+
+    /// <summary>
+    /// Gets the last error message associated with this <see cref="Context"/>.
+    /// </summary>
+    public string LastError()
+    {
+        var sb_result = new StringBuilder();
+
+        tiledb_error_t* p_tiledb_error;
+        int status;
+        using (var handle = _handle.Acquire())
+        {
+            status = Methods.tiledb_ctx_get_last_error(handle, &p_tiledb_error);
+        }
+        if (status == (int)Status.TILEDB_OK)
+        {
+            sbyte* messagePtr;
+
+            status = Methods.tiledb_error_message(p_tiledb_error, &messagePtr);
+
             if (status == (int)Status.TILEDB_OK)
             {
-                sbyte* messagePtr;
-
-                status = Methods.tiledb_error_message(p_tiledb_error, &messagePtr);
-
-                if (status == (int)Status.TILEDB_OK)
-                {
-                    string message = MarshaledStringOut.GetStringFromNullTerminated(messagePtr);
-                    sb_result.Append(message);
-                }
-                else
-                {
-                    var message = Enum.IsDefined(typeof(Status), status) ? ((Status)status).ToString() : ("Unknown error with code:" + status);
-                    sb_result.Append(" Context.last_error,caught exception:" + message);
-                }
+                string message = MarshaledStringOut.GetStringFromNullTerminated(messagePtr);
+                sb_result.Append(message);
             }
             else
             {
                 var message = Enum.IsDefined(typeof(Status), status) ? ((Status)status).ToString() : ("Unknown error with code:" + status);
                 sb_result.Append(" Context.last_error,caught exception:" + message);
             }
-            Methods.tiledb_error_free(&p_tiledb_error);
+        }
+        else
+        {
+            var message = Enum.IsDefined(typeof(Status), status) ? ((Status)status).ToString() : ("Unknown error with code:" + status);
+            sb_result.Append(" Context.last_error,caught exception:" + message);
+        }
+        Methods.tiledb_error_free(&p_tiledb_error);
 
-            return sb_result.ToString();
+        return sb_result.ToString();
+    }
+
+    /// <summary>
+    /// Cancels the asynchronous tasks associated with this <see cref="Context"/>.
+    /// </summary>
+    public void CancelTasks()
+    {
+        using var handle = _handle.Acquire();
+        handle_error(Methods.tiledb_ctx_cancel_tasks(handle));
+    }
+
+    /// <summary>
+    /// Checks whether the given <see cref="FileSystemType"/> is supported.
+    /// </summary>
+    /// <param name="fileSystem">The file system type to check.</param>
+    public bool IsFileSystemSupported(FileSystemType fileSystem)
+    {
+        using var handle = _handle.Acquire();
+        int result;
+        handle_error(Methods.tiledb_ctx_is_supported_fs(handle, (tiledb_filesystem_t)fileSystem, &result));
+        return result != 0;
+    }
+
+    /// <summary>
+    /// Sets a string key-value “tag” on the given context.
+    /// </summary>
+    /// <param name="key">The tag's key.</param>
+    /// <param name="value">The tag's value.</param>
+    /// <exception cref="ArgumentException"><paramref name="key"/> or
+    /// <paramref name="value"/> are <see langword="null"/> or empty.</exception>
+    public void SetTag(string key, string value)
+    {
+        if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(value))
+        {
+            throw new ArgumentException("Context.set_tag, key or value is null or empty!");
         }
 
-        /// <summary>
-        /// Cancels the asynchronous tasks associated with this <see cref="Context"/>.
-        /// </summary>
-        public void CancelTasks()
-        {
-            using var handle = _handle.Acquire();
-            handle_error(Methods.tiledb_ctx_cancel_tasks(handle));
-        }
+        using var handle = _handle.Acquire();
+        using var ms_key = new MarshaledString(key);
+        using var ms_value = new MarshaledString(value);
+        handle_error(Methods.tiledb_ctx_set_tag(handle, ms_key, ms_value));
+    }
 
-        /// <summary>
-        /// Checks whether the given <see cref="FileSystemType"/> is supported.
-        /// </summary>
-        /// <param name="fileSystem">The file system type to check.</param>
-        public bool IsFileSystemSupported(FileSystemType fileSystem)
-        {
-            using var handle = _handle.Acquire();
-            int result;
-            handle_error(Methods.tiledb_ctx_is_supported_fs(handle, (tiledb_filesystem_t)fileSystem, &result));
-            return result != 0;
-        }
+    /// <summary>
+    /// Returns the TileDB object type for a given resource path.
+    /// </summary>
+    /// <param name="uri">The path to check.</param>
+    /// <returns>
+    /// The type of the object in <paramref name="uri"/> or
+    /// <see cref="ObjectType.Invalid"/> if it is not a TileDB object.</returns>
+    public ObjectType GetObjectType(string uri)
+    {
+        using var handle = _handle.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        tiledb_object_t type;
+        handle_error(Methods.tiledb_object_type(handle, ms_uri, &type));
+        return (ObjectType)type;
+    }
 
-        /// <summary>
-        /// Sets a string key-value “tag” on the given context.
-        /// </summary>
-        /// <param name="key">The tag's key.</param>
-        /// <param name="value">The tag's value.</param>
-        /// <exception cref="ArgumentException"><paramref name="key"/> or
-        /// <paramref name="value"/> are <see langword="null"/> or empty.</exception>
-        public void SetTag(string key, string value)
+    /// <summary>
+    /// Deletes a TileDB resource (group or array).
+    /// </summary>
+    /// <param name="uri">The resource's path.</param>
+    public void RemoveObject(string uri)
+    {
+        using var handle = _handle.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        handle_error(Methods.tiledb_object_remove(handle, ms_uri));
+    }
+
+    /// <summary>
+    /// Moves a TileDB resource (group or array).
+    /// </summary>
+    /// <param name="oldUri">The resource's old directory.</param>
+    /// <param name="newUri">The resource's new directory.</param>
+    public void MoveObject(string oldUri, string newUri)
+    {
+        using var handle = _handle.Acquire();
+        using var ms_oldUri = new MarshaledString(oldUri);
+        using var ms_newUri = new MarshaledString(newUri);
+        handle_error(Methods.tiledb_object_move(handle, ms_oldUri, ms_newUri));
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static int VisitCallback(sbyte* uriPtr, tiledb_object_t objectType, void* arg)
+    {
+        VisitCallbackData* data = (VisitCallbackData*)arg;
+        Debug.Assert(data->Exception is null);
+        bool shouldContinue;
+        try
         {
-            if (string.IsNullOrEmpty(key) || string.IsNullOrEmpty(value))
+            string uri = MarshaledStringOut.GetStringFromNullTerminated(uriPtr);
+            shouldContinue = data->Invoke(uri, (ObjectType)objectType);
+        }
+        catch (Exception e)
+        {
+            data->Exception = ExceptionDispatchInfo.Capture(e);
+            shouldContinue = false;
+        }
+        return shouldContinue ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Visits the TileDB objects contained in <paramref name="uri"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of <paramref name="callbackArg"/>.</typeparam>
+    /// <param name="uri">The URI to check.</param>
+    /// <param name="walkOrder">The order to recursively visit the objects.
+    /// Setting this parameter to <see langword="null"/> will visit only
+    /// the top-level objects of <paramref name="uri"/>.</param>
+    /// <param name="callback">A callback that gets called for each TileDB object that got found.
+    /// It accepts its URI, its <see cref="ObjectType"/> and <paramref name="callbackArg"/>.</param>
+    /// <param name="callbackArg">An argument that will be passed to <paramref name="callback"/>.</param>
+    /// <remarks>
+    /// This method ignores any file system object that is not TileDB-related.
+    /// </remarks>
+    /// <seealso cref="GetChildObjects"/>
+    public void VisitChildObjects<T>(string uri, WalkOrderType? walkOrder, Func<string, ObjectType, T, bool> callback, T callbackArg)
+    {
+        // See VFS.VisitChildren for comments on how it works.
+        ValueTuple<Func<string, ObjectType, T, bool>, T> genericCallbackData = (callback, callbackArg);
+        var callbackData = new VisitCallbackData()
+        {
+            Callback = static (uri, objectType, arg) =>
             {
-                throw new ArgumentException("Context.set_tag, key or value is null or empty!");
-            }
+                var dataPtr = (ValueTuple<Func<string, ObjectType, T, bool>, T>*)arg;
+                return dataPtr->Item1(uri, objectType, dataPtr->Item2);
+            },
+            CallbackArgument = (IntPtr)(&genericCallbackData)
+        };
 
-            using var handle = _handle.Acquire();
-            using var ms_key = new MarshaledString(key);
-            using var ms_value = new MarshaledString(value);
-            handle_error(Methods.tiledb_ctx_set_tag(handle, ms_key, ms_value));
+        using var handle = _handle.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        switch (walkOrder)
+        {
+            case WalkOrderType order:
+                handle_error(Methods.tiledb_object_walk(handle, ms_uri, (tiledb_walk_order_t)order, &VisitCallback, &callbackData));
+                break;
+            case null:
+                handle_error(Methods.tiledb_object_ls(handle, ms_uri, &VisitCallback, &callbackData));
+                break;
+        }
+        callbackData.Exception?.Throw();
+    }
+
+    /// <summary>
+    /// Returns the TileDB objects contained in <paramref name="uri"/>.
+    /// </summary>
+    /// <param name="uri">The URI to check.</param>
+    /// <param name="walkOrder">The order to recursively visit the objects.
+    /// Setting this parameter to <see langword="null"/> will visit only
+    /// the top-level objects of <paramref name="uri"/>.</param>
+    /// <remarks>
+    /// This method ignores any file system object that is not TileDB-related.
+    /// </remarks>
+    /// <returns>
+    /// A <see cref="List{T}"/> with the URIs of each TileDB object in <paramref name="uri"/>,
+    /// along with its <see cref="ObjectType"/>.
+    /// </returns>
+    public List<(string Uri, ObjectType ObjectType)> GetChildObjects(string uri, WalkOrderType? walkOrder)
+    {
+        var list = new List<(string Uri, ObjectType ObjectType)>();
+        VisitChildObjects(uri, walkOrder, static (uri, objectType, list) =>
+        {
+            list.Add((uri, objectType));
+            return true;
+        }, list);
+        return list;
+    }
+
+    internal void handle_error(int rc)
+    {
+        var status = (Status)Methods.tiledb_status(rc);
+
+        if (status == Status.TILEDB_OK)
+        {
+            return;
         }
 
-        /// <summary>
-        /// Returns the TileDB object type for a given resource path.
-        /// </summary>
-        /// <param name="uri">The path to check.</param>
-        /// <returns>
-        /// The type of the object in <paramref name="uri"/> or
-        /// <see cref="ObjectType.Invalid"/> if it is not a TileDB object.</returns>
-        public ObjectType GetObjectType(string uri)
+        string message;
+        tiledb_error_t* p_tiledb_error;
+        using (var handle = _handle.Acquire())
         {
-            using var handle = _handle.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            tiledb_object_t type;
-            handle_error(Methods.tiledb_object_type(handle, ms_uri, &type));
-            return (ObjectType)type;
+            status = (Status)Methods.tiledb_status(Methods.tiledb_ctx_get_last_error(handle, &p_tiledb_error));
         }
-
-        /// <summary>
-        /// Deletes a TileDB resource (group or array).
-        /// </summary>
-        /// <param name="uri">The resource's path.</param>
-        public void RemoveObject(string uri)
+        if (status == Status.TILEDB_OK)
         {
-            using var handle = _handle.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            handle_error(Methods.tiledb_object_remove(handle, ms_uri));
-        }
-
-        /// <summary>
-        /// Moves a TileDB resource (group or array).
-        /// </summary>
-        /// <param name="oldUri">The resource's old directory.</param>
-        /// <param name="newUri">The resource's new directory.</param>
-        public void MoveObject(string oldUri, string newUri)
-        {
-            using var handle = _handle.Acquire();
-            using var ms_oldUri = new MarshaledString(oldUri);
-            using var ms_newUri = new MarshaledString(newUri);
-            handle_error(Methods.tiledb_object_move(handle, ms_oldUri, ms_newUri));
-        }
-
-        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
-        private static int VisitCallback(sbyte* uriPtr, tiledb_object_t objectType, void* arg)
-        {
-            VisitCallbackData* data = (VisitCallbackData*)arg;
-            Debug.Assert(data->Exception is null);
-            bool shouldContinue;
-            try
-            {
-                string uri = MarshaledStringOut.GetStringFromNullTerminated(uriPtr);
-                shouldContinue = data->Invoke(uri, (ObjectType)objectType);
-            }
-            catch (Exception e)
-            {
-                data->Exception = ExceptionDispatchInfo.Capture(e);
-                shouldContinue = false;
-            }
-            return shouldContinue ? 1 : 0;
-        }
-
-        /// <summary>
-        /// Visits the TileDB objects contained in <paramref name="uri"/>.
-        /// </summary>
-        /// <typeparam name="T">The type of <paramref name="callbackArg"/>.</typeparam>
-        /// <param name="uri">The URI to check.</param>
-        /// <param name="walkOrder">The order to recursively visit the objects.
-        /// Setting this parameter to <see langword="null"/> will visit only
-        /// the top-level objects of <paramref name="uri"/>.</param>
-        /// <param name="callback">A callback that gets called for each TileDB object that got found.
-        /// It accepts its URI, its <see cref="ObjectType"/> and <paramref name="callbackArg"/>.</param>
-        /// <param name="callbackArg">An argument that will be passed to <paramref name="callback"/>.</param>
-        /// <remarks>
-        /// This method ignores any file system object that is not TileDB-related.
-        /// </remarks>
-        /// <seealso cref="GetChildObjects"/>
-        public void VisitChildObjects<T>(string uri, WalkOrderType? walkOrder, Func<string, ObjectType, T, bool> callback, T callbackArg)
-        {
-            // See VFS.VisitChildren for comments on how it works.
-            ValueTuple<Func<string, ObjectType, T, bool>, T> genericCallbackData = (callback, callbackArg);
-            var callbackData = new VisitCallbackData()
-            {
-                Callback = static (uri, objectType, arg) =>
-                {
-                    var dataPtr = (ValueTuple<Func<string, ObjectType, T, bool>, T>*)arg;
-                    return dataPtr->Item1(uri, objectType, dataPtr->Item2);
-                },
-                CallbackArgument = (IntPtr)(&genericCallbackData)
-            };
-
-            using var handle = _handle.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            switch (walkOrder)
-            {
-                case WalkOrderType order:
-                    handle_error(Methods.tiledb_object_walk(handle, ms_uri, (tiledb_walk_order_t)order, &VisitCallback, &callbackData));
-                    break;
-                case null:
-                    handle_error(Methods.tiledb_object_ls(handle, ms_uri, &VisitCallback, &callbackData));
-                    break;
-            }
-            callbackData.Exception?.Throw();
-        }
-
-        /// <summary>
-        /// Returns the TileDB objects contained in <paramref name="uri"/>.
-        /// </summary>
-        /// <param name="uri">The URI to check.</param>
-        /// <param name="walkOrder">The order to recursively visit the objects.
-        /// Setting this parameter to <see langword="null"/> will visit only
-        /// the top-level objects of <paramref name="uri"/>.</param>
-        /// <remarks>
-        /// This method ignores any file system object that is not TileDB-related.
-        /// </remarks>
-        /// <returns>
-        /// A <see cref="List{T}"/> with the URIs of each TileDB object in <paramref name="uri"/>,
-        /// along with its <see cref="ObjectType"/>.
-        /// </returns>
-        public List<(string Uri, ObjectType ObjectType)> GetChildObjects(string uri, WalkOrderType? walkOrder)
-        {
-            var list = new List<(string Uri, ObjectType ObjectType)>();
-            VisitChildObjects(uri, walkOrder, static (uri, objectType, list) =>
-            {
-                list.Add((uri, objectType));
-                return true;
-            }, list);
-            return list;
-        }
-
-        internal void handle_error(int rc)
-        {
-            var status = (Status)Methods.tiledb_status(rc);
+            sbyte* messagePtr;
+            status = (Status)Methods.tiledb_status(Methods.tiledb_error_message(p_tiledb_error, &messagePtr));
 
             if (status == Status.TILEDB_OK)
             {
-                return;
-            }
-
-            string message;
-            tiledb_error_t* p_tiledb_error;
-            using (var handle = _handle.Acquire())
-            {
-                status = (Status)Methods.tiledb_status(Methods.tiledb_ctx_get_last_error(handle, &p_tiledb_error));
-            }
-            if (status == Status.TILEDB_OK)
-            {
-                sbyte* messagePtr;
-                status = (Status)Methods.tiledb_status(Methods.tiledb_error_message(p_tiledb_error, &messagePtr));
-
-                if (status == Status.TILEDB_OK)
-                {
-                    message = MarshaledStringOut.GetStringFromNullTerminated(messagePtr);
-                }
-                else
-                {
-                    message = $"Error during tiledb_error_message: {status}";
-                }
+                message = MarshaledStringOut.GetStringFromNullTerminated(messagePtr);
             }
             else
             {
-                message = $"Error during tiledb_ctx_get_last_error: {status}";
+                message = $"Error during tiledb_error_message: {status}";
             }
-            Methods.tiledb_error_free(&p_tiledb_error);
-
-            throw new TileDBException(message) { StatusCode = (int)status };
         }
-
-        private struct VisitCallbackData
+        else
         {
-            public Func<string, ObjectType, IntPtr, bool> Callback;
-
-            public IntPtr CallbackArgument;
-
-            public ExceptionDispatchInfo? Exception;
-
-            public bool Invoke(string uri, ObjectType objectType) => Callback(uri, objectType, CallbackArgument);
+            message = $"Error during tiledb_ctx_get_last_error: {status}";
         }
+        Methods.tiledb_error_free(&p_tiledb_error);
+
+        throw new TileDBException(message) { StatusCode = (int)status };
+    }
+
+    private struct VisitCallbackData
+    {
+        public Func<string, ObjectType, IntPtr, bool> Callback;
+
+        public IntPtr CallbackArgument;
+
+        public ExceptionDispatchInfo? Exception;
+
+        public bool Invoke(string uri, ObjectType objectType) => Callback(uri, objectType, CallbackArgument);
     }
 }

--- a/sources/TileDB.CSharp/CoreUtil.cs
+++ b/sources/TileDB.CSharp/CoreUtil.cs
@@ -4,227 +4,226 @@ using System.Collections.Generic;
 using TileDB.Interop;
 using TileDB.CSharp.Marshalling;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Contains general utility functions.
+/// </summary>
+public static class CoreUtil
 {
+    private static Version? _coreLibVersion;
+
+    private static string? _buildConfiguration;
+
     /// <summary>
-    /// Contains general utility functions.
+    /// Returns the version of the TileDB Embedded binary being used.
     /// </summary>
-    public static class CoreUtil
+    public static Version GetCoreLibVersion()
     {
-        private static Version? _coreLibVersion;
+        return _coreLibVersion ??= GetVersion();
 
-        private static string? _buildConfiguration;
-
-        /// <summary>
-        /// Returns the version of the TileDB Embedded binary being used.
-        /// </summary>
-        public static Version GetCoreLibVersion()
+        static unsafe Version GetVersion()
         {
-            return _coreLibVersion ??= GetVersion();
-
-            static unsafe Version GetVersion()
-            {
-                int major, minor, rev;
-                Methods.tiledb_version(&major, &minor, &rev);
-                return new Version(major, minor, rev);
-            }
+            int major, minor, rev;
+            Methods.tiledb_version(&major, &minor, &rev);
+            return new Version(major, minor, rev);
         }
-
-        /// <summary>
-        /// Returns a string describing the build configuration of the TileDB Embedded binary being used.
-        /// </summary>
-        /// <remarks>
-        /// This method exposes the <c>tiledb_as_built_dump</c> function of the TileDB Embedded C API.
-        /// </remarks>
-        public static string GetBuildConfiguration()
-        {
-            return _buildConfiguration ??= Create();
-
-            static unsafe string Create()
-            {
-                using var resultHolder = new StringHandleHolder();
-                ErrorHandling.ThrowOnError(Methods.tiledb_as_built_dump(&resultHolder._handle));
-                return resultHolder.ToString();
-            }
-        }
-
-        #region  Buffer
-
-        /// <summary>
-        /// Convert element offsets to byte offsets.
-        /// </summary>
-        /// <param name="element_offsets"></param>
-        /// <returns></returns>
-        public static ulong[] ElementOffsetsToByteOffsets(ulong[] element_offsets, DataType dataType)
-        {
-            ulong[] ret = new ulong[element_offsets.Length];
-            for (var i = 0; i < element_offsets.Length; ++i)
-            {
-                ret[i] = element_offsets[i] * EnumUtil.DataTypeSize(dataType);
-            }
-            return ret;
-        }
-
-        /// <summary>
-        /// Convert byte offsets to element offsets
-        /// </summary>
-        /// <param name="offsets"></param>
-        /// <returns></returns>
-        public static ulong[] ByteOffsetsToElementOffsets(ulong[] offsets, DataType dataType)
-        {
-            ulong[] ret = new ulong[offsets.Length];
-            for (var i = 0; i < offsets.Length; ++i)
-            {
-                ret[i] = offsets[i] / EnumUtil.DataTypeSize(dataType);
-            }
-            return ret;
-        }
-
-
-        /// <summary>
-        /// Pack string array.
-        /// </summary>
-        /// <param name="strarray"></param>
-        /// <param name="encodingmethod"></param>
-        /// <returns></returns>
-        public static (byte[] data, ulong[] offsets) PackStringArray(string[] strarray, string encodingmethod = "ASCII")
-        {
-            if (strarray.Length == 0)
-            {
-                return (new byte[0], new ulong[0]);
-            }
-
-            int totsize = 0;
-            for (int i = 0; i < strarray.Length; ++i)
-            {
-                int bytes_size = 0;
-                if (encodingmethod == "ASCII")
-                {
-                    bytes_size = Encoding.ASCII.GetByteCount(strarray[i]);
-                }
-                else if (encodingmethod == "UTF16")
-                {
-                    bytes_size = Encoding.Unicode.GetByteCount(strarray[i]);
-                }
-                else if (encodingmethod == "UTF32")
-                {
-                    bytes_size = Encoding.UTF32.GetByteCount(strarray[i]);
-                }
-                else
-                {
-                    bytes_size = Encoding.UTF8.GetByteCount(strarray[i]);
-                }
-                totsize += bytes_size;
-            }
-
-            byte[] data = new byte[totsize];
-            ulong[] offsets = new ulong[strarray.Length];
-            offsets[0] = 0;
-
-            int idx = 0;
-            for (int i = 0; i < strarray.Length; ++i)
-            {
-                byte[] bytes;
-                if (encodingmethod == "ASCII")
-                {
-                    bytes = Encoding.ASCII.GetBytes(strarray[i]);
-
-                }
-                else if (encodingmethod == "UTF16")
-                {
-                    bytes = Encoding.Unicode.GetBytes(strarray[i]);
-                }
-                else if (encodingmethod == "UTF32")
-                {
-                    bytes = Encoding.UTF32.GetBytes(strarray[i]);
-                }
-                else
-                {
-                    bytes = Encoding.UTF8.GetBytes(strarray[i]);
-                }
-                bytes.CopyTo(data, idx);
-                idx += bytes.Length;
-
-
-                if (i < (strarray.Length - 1))
-                {
-                    offsets[i + 1] = offsets[i] + (ulong)bytes.Length;
-                }
-
-            }
-            return (data, offsets);
-        }
-
-
-        /// <summary>
-        /// Unpack string array.
-        /// </summary>
-        /// <param name="data"></param>
-        /// <param name="offsets"></param>
-        /// <param name="validities"></param>
-        /// <param name="encodingmethod"></param>
-        /// <returns></returns>
-        /// <exception cref="System.ArgumentException"></exception>
-        public static List<string> UnPackStringArray(byte[] data, ulong[] offsets, byte[]? validities = null, string encodingmethod = "ASCII")
-        {
-            List<string> result = new List<string>();
-            int tot_bytes_size = data.Length;
-            int length = offsets.Length;
-
-            bool is_nullable = (validities != null);
-            if (is_nullable && (validities?.Length != offsets.Length))
-            {
-                throw new System.ArgumentException("CoreUtil.UnpackStringArray, the lengths of offsets and validities are not equal!");
-            }
-
-            int totsize = 0;
-            int indexFrom = 0;
-            for (int i = 0; i < length; ++i)
-            {
-                if (is_nullable && validities?[i] == 0)
-                {
-                    continue;
-                }
-                int bytesize = 0;
-                if (i < (length - 1))
-                {
-                    bytesize = (int)(offsets[i + 1] - offsets[i]);
-
-                }
-                else
-                {
-                    bytesize = tot_bytes_size - (int)offsets[length - 1];
-                }
-
-                totsize += bytesize;
-                if (totsize <= tot_bytes_size && bytesize > 0)
-                {
-                    byte[] bytes = new byte[bytesize];
-                    System.Array.Copy(data, indexFrom, bytes, 0, bytesize);
-                    if (encodingmethod == "ASCII")
-                    {
-                        result.Add(Encoding.ASCII.GetString(bytes));
-                    }
-                    else if (encodingmethod == "UTF16")
-                    {
-                        result.Add(Encoding.Unicode.GetString(bytes));
-                    }
-                    else if (encodingmethod == "UTF32")
-                    {
-                        result.Add(Encoding.UTF32.GetString(bytes));
-                    }
-                    else
-                    {
-                        result.Add(Encoding.UTF8.GetString(bytes));
-                    }
-
-                    indexFrom = totsize;
-                }
-
-            } //for
-
-            return result;
-        }
-        #endregion Buffer
     }
+
+    /// <summary>
+    /// Returns a string describing the build configuration of the TileDB Embedded binary being used.
+    /// </summary>
+    /// <remarks>
+    /// This method exposes the <c>tiledb_as_built_dump</c> function of the TileDB Embedded C API.
+    /// </remarks>
+    public static string GetBuildConfiguration()
+    {
+        return _buildConfiguration ??= Create();
+
+        static unsafe string Create()
+        {
+            using var resultHolder = new StringHandleHolder();
+            ErrorHandling.ThrowOnError(Methods.tiledb_as_built_dump(&resultHolder._handle));
+            return resultHolder.ToString();
+        }
+    }
+
+    #region  Buffer
+
+    /// <summary>
+    /// Convert element offsets to byte offsets.
+    /// </summary>
+    /// <param name="element_offsets"></param>
+    /// <returns></returns>
+    public static ulong[] ElementOffsetsToByteOffsets(ulong[] element_offsets, DataType dataType)
+    {
+        ulong[] ret = new ulong[element_offsets.Length];
+        for (var i = 0; i < element_offsets.Length; ++i)
+        {
+            ret[i] = element_offsets[i] * EnumUtil.DataTypeSize(dataType);
+        }
+        return ret;
+    }
+
+    /// <summary>
+    /// Convert byte offsets to element offsets
+    /// </summary>
+    /// <param name="offsets"></param>
+    /// <returns></returns>
+    public static ulong[] ByteOffsetsToElementOffsets(ulong[] offsets, DataType dataType)
+    {
+        ulong[] ret = new ulong[offsets.Length];
+        for (var i = 0; i < offsets.Length; ++i)
+        {
+            ret[i] = offsets[i] / EnumUtil.DataTypeSize(dataType);
+        }
+        return ret;
+    }
+
+
+    /// <summary>
+    /// Pack string array.
+    /// </summary>
+    /// <param name="strarray"></param>
+    /// <param name="encodingmethod"></param>
+    /// <returns></returns>
+    public static (byte[] data, ulong[] offsets) PackStringArray(string[] strarray, string encodingmethod = "ASCII")
+    {
+        if (strarray.Length == 0)
+        {
+            return (new byte[0], new ulong[0]);
+        }
+
+        int totsize = 0;
+        for (int i = 0; i < strarray.Length; ++i)
+        {
+            int bytes_size = 0;
+            if (encodingmethod == "ASCII")
+            {
+                bytes_size = Encoding.ASCII.GetByteCount(strarray[i]);
+            }
+            else if (encodingmethod == "UTF16")
+            {
+                bytes_size = Encoding.Unicode.GetByteCount(strarray[i]);
+            }
+            else if (encodingmethod == "UTF32")
+            {
+                bytes_size = Encoding.UTF32.GetByteCount(strarray[i]);
+            }
+            else
+            {
+                bytes_size = Encoding.UTF8.GetByteCount(strarray[i]);
+            }
+            totsize += bytes_size;
+        }
+
+        byte[] data = new byte[totsize];
+        ulong[] offsets = new ulong[strarray.Length];
+        offsets[0] = 0;
+
+        int idx = 0;
+        for (int i = 0; i < strarray.Length; ++i)
+        {
+            byte[] bytes;
+            if (encodingmethod == "ASCII")
+            {
+                bytes = Encoding.ASCII.GetBytes(strarray[i]);
+
+            }
+            else if (encodingmethod == "UTF16")
+            {
+                bytes = Encoding.Unicode.GetBytes(strarray[i]);
+            }
+            else if (encodingmethod == "UTF32")
+            {
+                bytes = Encoding.UTF32.GetBytes(strarray[i]);
+            }
+            else
+            {
+                bytes = Encoding.UTF8.GetBytes(strarray[i]);
+            }
+            bytes.CopyTo(data, idx);
+            idx += bytes.Length;
+
+
+            if (i < (strarray.Length - 1))
+            {
+                offsets[i + 1] = offsets[i] + (ulong)bytes.Length;
+            }
+
+        }
+        return (data, offsets);
+    }
+
+
+    /// <summary>
+    /// Unpack string array.
+    /// </summary>
+    /// <param name="data"></param>
+    /// <param name="offsets"></param>
+    /// <param name="validities"></param>
+    /// <param name="encodingmethod"></param>
+    /// <returns></returns>
+    /// <exception cref="System.ArgumentException"></exception>
+    public static List<string> UnPackStringArray(byte[] data, ulong[] offsets, byte[]? validities = null, string encodingmethod = "ASCII")
+    {
+        List<string> result = new List<string>();
+        int tot_bytes_size = data.Length;
+        int length = offsets.Length;
+
+        bool is_nullable = (validities != null);
+        if (is_nullable && (validities?.Length != offsets.Length))
+        {
+            throw new System.ArgumentException("CoreUtil.UnpackStringArray, the lengths of offsets and validities are not equal!");
+        }
+
+        int totsize = 0;
+        int indexFrom = 0;
+        for (int i = 0; i < length; ++i)
+        {
+            if (is_nullable && validities?[i] == 0)
+            {
+                continue;
+            }
+            int bytesize = 0;
+            if (i < (length - 1))
+            {
+                bytesize = (int)(offsets[i + 1] - offsets[i]);
+
+            }
+            else
+            {
+                bytesize = tot_bytes_size - (int)offsets[length - 1];
+            }
+
+            totsize += bytesize;
+            if (totsize <= tot_bytes_size && bytesize > 0)
+            {
+                byte[] bytes = new byte[bytesize];
+                System.Array.Copy(data, indexFrom, bytes, 0, bytesize);
+                if (encodingmethod == "ASCII")
+                {
+                    result.Add(Encoding.ASCII.GetString(bytes));
+                }
+                else if (encodingmethod == "UTF16")
+                {
+                    result.Add(Encoding.Unicode.GetString(bytes));
+                }
+                else if (encodingmethod == "UTF32")
+                {
+                    result.Add(Encoding.UTF32.GetString(bytes));
+                }
+                else
+                {
+                    result.Add(Encoding.UTF8.GetString(bytes));
+                }
+
+                indexFrom = totsize;
+            }
+
+        } //for
+
+        return result;
+    }
+    #endregion Buffer
 }

--- a/sources/TileDB.CSharp/Dimension.cs
+++ b/sources/TileDB.CSharp/Dimension.cs
@@ -7,256 +7,255 @@ using TileDB.Interop;
 using DimensionHandle = TileDB.CSharp.Marshalling.SafeHandles.DimensionHandle;
 using FilterListHandle = TileDB.CSharp.Marshalling.SafeHandles.FilterListHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB dimension object.
+/// </summary>
+public sealed unsafe class Dimension : IDisposable
 {
+    private readonly DimensionHandle _handle;
+    private readonly Context _ctx;
+
     /// <summary>
-    /// Represents a TileDB dimension object.
+    /// This value indicates a variable-sized attribute.
+    /// It may be returned from <see cref="CellValNum"/>
+    /// and can be passed to <see cref="SetCellValNum"/>.
     /// </summary>
-    public sealed unsafe class Dimension : IDisposable
+    public const uint VariableSized = Constants.VariableSizedImpl;
+
+    internal Dimension(Context ctx, DimensionHandle handle)
     {
-        private readonly DimensionHandle _handle;
-        private readonly Context _ctx;
+        _ctx = ctx;
+        _handle = handle;
+    }
 
-        /// <summary>
-        /// This value indicates a variable-sized attribute.
-        /// It may be returned from <see cref="CellValNum"/>
-        /// and can be passed to <see cref="SetCellValNum"/>.
-        /// </summary>
-        public const uint VariableSized = Constants.VariableSizedImpl;
+    /// <summary>
+    /// Disposes the <see cref="Dimension"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
 
-        internal Dimension(Context ctx, DimensionHandle handle)
+    internal DimensionHandle Handle => _handle;
+
+    /// <summary>
+    /// Set filter list.
+    /// </summary>
+    /// <param name="filterList"></param>
+    public void SetFilterList(FilterList filterList)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var filterListHandle = filterList.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_dimension_set_filter_list(ctxHandle, handle, filterListHandle));
+    }
+
+    /// <summary>
+    /// Sets the number of values per cell for this dimension.
+    /// For variable-sized attributes the value should be <see cref="VariableSized"/>.
+    /// </summary>
+    public void SetCellValNum(uint cellValNum)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_dimension_set_cell_val_num(ctxHandle, handle, cellValNum));
+    }
+
+    /// <summary>
+    /// Gets the filter list of this dimension.
+    /// </summary>
+    public FilterList FilterList()
+    {
+        var handle = new FilterListHandle();
+        var successful = false;
+        tiledb_filter_list_t* filter_list_p = null;
+        try
         {
-            _ctx = ctx;
-            _handle = handle;
-        }
-
-        /// <summary>
-        /// Disposes the <see cref="Dimension"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            _handle.Dispose();
-        }
-
-        internal DimensionHandle Handle => _handle;
-
-        /// <summary>
-        /// Set filter list.
-        /// </summary>
-        /// <param name="filterList"></param>
-        public void SetFilterList(FilterList filterList)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var filterListHandle = filterList.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_dimension_set_filter_list(ctxHandle, handle, filterListHandle));
-        }
-
-        /// <summary>
-        /// Sets the number of values per cell for this dimension.
-        /// For variable-sized attributes the value should be <see cref="VariableSized"/>.
-        /// </summary>
-        public void SetCellValNum(uint cellValNum)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_dimension_set_cell_val_num(ctxHandle, handle, cellValNum));
-        }
-
-        /// <summary>
-        /// Gets the filter list of this dimension.
-        /// </summary>
-        public FilterList FilterList()
-        {
-            var handle = new FilterListHandle();
-            var successful = false;
-            tiledb_filter_list_t* filter_list_p = null;
-            try
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var dimensionHandle = _handle.Acquire())
             {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var dimensionHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_dimension_get_filter_list(ctxHandle, dimensionHandle, &filter_list_p));
-                }
-                successful = true;
+                _ctx.handle_error(Methods.tiledb_dimension_get_filter_list(ctxHandle, dimensionHandle, &filter_list_p));
             }
-            finally
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                if (successful)
-                {
-                    handle.InitHandle(filter_list_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.InitHandle(filter_list_p);
             }
-
-            return new FilterList(_ctx, handle);
-        }
-
-        /// <summary>
-        /// Gets the number of values per cell for the dimension.
-        /// </summary>
-        /// <returns>
-        /// The number of values per cell for the dimension,
-        /// or <see cref="VariableSized"/> for variable-sized dimensions.
-        /// </returns>
-        public uint CellValNum()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            uint cell_value_num;
-            _ctx.handle_error(Methods.tiledb_dimension_get_cell_val_num(ctxHandle, handle, &cell_value_num));
-            return cell_value_num;
-        }
-
-        /// <summary>
-        /// Get name of the dimension.
-        /// </summary>
-        /// <returns></returns>
-        public string Name()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            sbyte* name;
-            _ctx.handle_error(Methods.tiledb_dimension_get_name(ctxHandle, handle, &name));
-
-            return MarshaledStringOut.GetStringFromNullTerminated(name);
-        }
-
-        /// <summary>
-        /// Get <see cref="DataType"/> of the dimension.
-        /// </summary>
-        public DataType Type()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_datatype_t tiledb_datatype;
-
-            _ctx.handle_error(Methods.tiledb_dimension_get_type(ctxHandle, handle, &tiledb_datatype));
-
-            return (DataType)tiledb_datatype;
-        }
-
-        /// <summary>
-        /// Gets the allowed starting and ending values of the dimension, inclusive.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public (T Start, T End) GetDomain<T>() where T : struct
-        {
-            ErrorHandling.CheckDataType<T>(Type());
-            void* value_p;
-
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_dimension_get_domain(ctxHandle, handle, &value_p));
-
-            return Unsafe.ReadUnaligned<SequentialPair<T>>(value_p);
-        }
-
-        /// <summary>
-        /// Gets the dimension's tile extent.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public T TileExtent<T>() where T : struct
-        {
-            ErrorHandling.CheckDataType<T>(Type());
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            void* value_p;
-            _ctx.handle_error(Methods.tiledb_dimension_get_tile_extent(ctxHandle, handle, &value_p));
-
-            return Unsafe.ReadUnaligned<T>(value_p);
-        }
-
-        /// <summary>
-        /// Gets the dimension's tile extent as string.
-        /// </summary>
-        public string TileExtentToStr()
-        {
-            var datatype = Type();
-            var t = EnumUtil.DataTypeToType(datatype);
-            return System.Type.GetTypeCode(t) switch
+            else
             {
-                TypeCode.Int16 => Format<short>(),
-                TypeCode.Int32 => Format<int>(),
-                TypeCode.Int64 => Format<long>(),
-                TypeCode.UInt16 => Format<ushort>(),
-                TypeCode.UInt32 => Format<uint>(),
-                TypeCode.UInt64 => Format<ulong>(),
-                TypeCode.Single => Format<float>(),
-                TypeCode.Double => Format<double>(),
-                _ => ","
-            };
-
-            string Format<T>() where T : struct, IFormattable => TileExtent<T>().ToString(null, CultureInfo.InvariantCulture);
-        }
-
-        /// <summary>
-        /// Gets the dimension's domain as string.
-        /// </summary>
-        public string DomainToStr()
-        {
-            var datatype = Type();
-            var t = EnumUtil.DataTypeToType(datatype);
-            return System.Type.GetTypeCode(t) switch
-            {
-                TypeCode.Int16 => Format<short>(),
-                TypeCode.Int32 => Format<int>(),
-                TypeCode.Int64 => Format<long>(),
-                TypeCode.UInt16 => Format<ushort>(),
-                TypeCode.UInt32 => Format<uint>(),
-                TypeCode.UInt64 => Format<ulong>(),
-                TypeCode.Single => Format<float>(),
-                TypeCode.Double => Format<double>(),
-                _ => ","
-            };
-
-            string Format<T>() where T : struct
-            {
-                (T Start, T End) = GetDomain<T>();
-                return FormattableString.Invariant($"{Start},{End}");
+                handle.SetHandleAsInvalid();
             }
         }
 
-        /// <summary>
-        /// Creates a <see cref="Dimension"/>.
-        /// </summary>
-        /// <typeparam name="T">The dimension's type.</typeparam>
-        /// <param name="ctx">The <see cref="Context"/> associated with the dimension.</param>
-        /// <param name="name">The dimension's name.</param>
-        /// <param name="boundLower">The dimension's lower bound, inclusive.</param>
-        /// <param name="boundUpper">The dimension's upper bound, inclusive.</param>
-        /// <param name="extent">The dimension's tile extent.</param>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
-        public static Dimension Create<T>(Context ctx, string name, T boundLower, T boundUpper, T extent)
+        return new FilterList(_ctx, handle);
+    }
+
+    /// <summary>
+    /// Gets the number of values per cell for the dimension.
+    /// </summary>
+    /// <returns>
+    /// The number of values per cell for the dimension,
+    /// or <see cref="VariableSized"/> for variable-sized dimensions.
+    /// </returns>
+    public uint CellValNum()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        uint cell_value_num;
+        _ctx.handle_error(Methods.tiledb_dimension_get_cell_val_num(ctxHandle, handle, &cell_value_num));
+        return cell_value_num;
+    }
+
+    /// <summary>
+    /// Get name of the dimension.
+    /// </summary>
+    /// <returns></returns>
+    public string Name()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        sbyte* name;
+        _ctx.handle_error(Methods.tiledb_dimension_get_name(ctxHandle, handle, &name));
+
+        return MarshaledStringOut.GetStringFromNullTerminated(name);
+    }
+
+    /// <summary>
+    /// Get <see cref="DataType"/> of the dimension.
+    /// </summary>
+    public DataType Type()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        tiledb_datatype_t tiledb_datatype;
+
+        _ctx.handle_error(Methods.tiledb_dimension_get_type(ctxHandle, handle, &tiledb_datatype));
+
+        return (DataType)tiledb_datatype;
+    }
+
+    /// <summary>
+    /// Gets the allowed starting and ending values of the dimension, inclusive.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public (T Start, T End) GetDomain<T>() where T : struct
+    {
+        ErrorHandling.CheckDataType<T>(Type());
+        void* value_p;
+
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_dimension_get_domain(ctxHandle, handle, &value_p));
+
+        return Unsafe.ReadUnaligned<SequentialPair<T>>(value_p);
+    }
+
+    /// <summary>
+    /// Gets the dimension's tile extent.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <returns></returns>
+    public T TileExtent<T>() where T : struct
+    {
+        ErrorHandling.CheckDataType<T>(Type());
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        void* value_p;
+        _ctx.handle_error(Methods.tiledb_dimension_get_tile_extent(ctxHandle, handle, &value_p));
+
+        return Unsafe.ReadUnaligned<T>(value_p);
+    }
+
+    /// <summary>
+    /// Gets the dimension's tile extent as string.
+    /// </summary>
+    public string TileExtentToStr()
+    {
+        var datatype = Type();
+        var t = EnumUtil.DataTypeToType(datatype);
+        return System.Type.GetTypeCode(t) switch
         {
-            var tiledb_datatype = (tiledb_datatype_t)EnumUtil.TypeToDataType(typeof(T));
+            TypeCode.Int16 => Format<short>(),
+            TypeCode.Int32 => Format<int>(),
+            TypeCode.Int64 => Format<long>(),
+            TypeCode.UInt16 => Format<ushort>(),
+            TypeCode.UInt32 => Format<uint>(),
+            TypeCode.UInt64 => Format<ulong>(),
+            TypeCode.Single => Format<float>(),
+            TypeCode.Double => Format<double>(),
+            _ => ","
+        };
 
-            if (tiledb_datatype == tiledb_datatype_t.TILEDB_STRING_ASCII)
-            {
-                var str_dim_handle = DimensionHandle.Create(ctx, name, tiledb_datatype, null, null);
-                return new Dimension(ctx, str_dim_handle);
-            }
+        string Format<T>() where T : struct, IFormattable => TileExtent<T>().ToString(null, CultureInfo.InvariantCulture);
+    }
 
-            SequentialPair<T> data = (boundLower, boundUpper);
-            var handle = DimensionHandle.Create(ctx, name, tiledb_datatype, &data, &extent);
-            return new Dimension(ctx, handle);
+    /// <summary>
+    /// Gets the dimension's domain as string.
+    /// </summary>
+    public string DomainToStr()
+    {
+        var datatype = Type();
+        var t = EnumUtil.DataTypeToType(datatype);
+        return System.Type.GetTypeCode(t) switch
+        {
+            TypeCode.Int16 => Format<short>(),
+            TypeCode.Int32 => Format<int>(),
+            TypeCode.Int64 => Format<long>(),
+            TypeCode.UInt16 => Format<ushort>(),
+            TypeCode.UInt32 => Format<uint>(),
+            TypeCode.UInt64 => Format<ulong>(),
+            TypeCode.Single => Format<float>(),
+            TypeCode.Double => Format<double>(),
+            _ => ","
+        };
+
+        string Format<T>() where T : struct
+        {
+            (T Start, T End) = GetDomain<T>();
+            return FormattableString.Invariant($"{Start},{End}");
         }
+    }
 
-        /// <summary>
-        /// Create a string <see cref="Dimension"/>.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with the dimension.</param>
-        /// <param name="name">The dimension's name.</param>
-        /// <returns></returns>
-        public static Dimension CreateString(Context ctx, string name)
+    /// <summary>
+    /// Creates a <see cref="Dimension"/>.
+    /// </summary>
+    /// <typeparam name="T">The dimension's type.</typeparam>
+    /// <param name="ctx">The <see cref="Context"/> associated with the dimension.</param>
+    /// <param name="name">The dimension's name.</param>
+    /// <param name="boundLower">The dimension's lower bound, inclusive.</param>
+    /// <param name="boundUpper">The dimension's upper bound, inclusive.</param>
+    /// <param name="extent">The dimension's tile extent.</param>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
+    public static Dimension Create<T>(Context ctx, string name, T boundLower, T boundUpper, T extent)
+    {
+        var tiledb_datatype = (tiledb_datatype_t)EnumUtil.TypeToDataType(typeof(T));
+
+        if (tiledb_datatype == tiledb_datatype_t.TILEDB_STRING_ASCII)
         {
-            var str_dim_handle = DimensionHandle.Create(ctx, name, tiledb_datatype_t.TILEDB_STRING_ASCII, null, null);
+            var str_dim_handle = DimensionHandle.Create(ctx, name, tiledb_datatype, null, null);
             return new Dimension(ctx, str_dim_handle);
         }
+
+        SequentialPair<T> data = (boundLower, boundUpper);
+        var handle = DimensionHandle.Create(ctx, name, tiledb_datatype, &data, &extent);
+        return new Dimension(ctx, handle);
+    }
+
+    /// <summary>
+    /// Create a string <see cref="Dimension"/>.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> associated with the dimension.</param>
+    /// <param name="name">The dimension's name.</param>
+    /// <returns></returns>
+    public static Dimension CreateString(Context ctx, string name)
+    {
+        var str_dim_handle = DimensionHandle.Create(ctx, name, tiledb_datatype_t.TILEDB_STRING_ASCII, null, null);
+        return new Dimension(ctx, str_dim_handle);
     }
 }

--- a/sources/TileDB.CSharp/Domain.cs
+++ b/sources/TileDB.CSharp/Domain.cs
@@ -4,178 +4,177 @@ using TileDB.Interop;
 using DomainHandle = TileDB.CSharp.Marshalling.SafeHandles.DomainHandle;
 using DimensionHandle = TileDB.CSharp.Marshalling.SafeHandles.DimensionHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+public sealed unsafe class Domain : IDisposable 
 {
-    public sealed unsafe class Domain : IDisposable 
+    private readonly DomainHandle _handle;
+    private readonly Context _ctx;
+    private bool _disposed;
+
+    public Domain(Context ctx) 
     {
-        private readonly DomainHandle _handle;
-        private readonly Context _ctx;
-        private bool _disposed;
-
-        public Domain(Context ctx) 
-        {
-            _ctx = ctx;
-            _handle = DomainHandle.Create(_ctx);
-        }
-
-        internal Domain(Context ctx, DomainHandle handle) 
-        {
-            _ctx = ctx;
-            _handle = handle;
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (_disposed) return;
-            if (disposing && (!_handle.IsInvalid))
-            {
-                _handle.Dispose();
-            }
-
-            _disposed = true;
-        }
-
-        internal DomainHandle Handle => _handle;
-
-        #region capi functions
-        /// <summary>
-        /// Get type of homogenous dimensions. Will throw exception for heterogeneous dimensions.
-        /// </summary>
-        /// <returns></returns>
-        public DataType Type()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_datatype_t tiledb_datatype;
-            _ctx.handle_error(Methods.tiledb_domain_get_type(ctxHandle, handle, &tiledb_datatype));
-            return (DataType)tiledb_datatype;
-        }
-
-        /// <summary>
-        /// Get number of dimensions.
-        /// </summary>
-        /// <returns></returns>
-        public uint NDim()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            uint ndim;
-            _ctx.handle_error(Methods.tiledb_domain_get_ndim(ctxHandle, handle, &ndim));
-            return ndim;
-        }
-
-        /// <summary>
-        /// Add a dimension.
-        /// </summary>
-        /// <param name="d"></param>
-        public void AddDimension(Dimension d)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var dHandle = d.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_domain_add_dimension(ctxHandle, handle, dHandle));
-        }
-
-        /// <summary>
-        /// Add dimensions.
-        /// </summary>
-        /// <param name="d"></param>
-        public void AddDimensions(params Dimension[] d)
-        {
-            foreach (var t in d)
-            {
-                AddDimension(t);
-            }
-        }
-
-        /// <summary>
-        /// Get a dimension from index.
-        /// </summary>
-        /// <param name="index"></param>
-        /// <returns></returns>
-        public Dimension Dimension(uint index)
-        {
-            var handle = new DimensionHandle();
-            var successful = false;
-            tiledb_dimension_t* dimension_p = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var domainHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_domain_get_dimension_from_index(ctxHandle, domainHandle, index, &dimension_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(dimension_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return new Dimension(_ctx, handle);
-        }
-
-        /// <summary>
-        /// Get a dimension from name.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public Dimension Dimension(string name)
-        {
-            var handle = new DimensionHandle();
-            var successful = false;
-            tiledb_dimension_t* dimension_p = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var domainHandle = _handle.Acquire())
-                using (var ms_name = new MarshaledString(name))
-                {
-                    _ctx.handle_error(Methods.tiledb_domain_get_dimension_from_name(ctxHandle, domainHandle, ms_name, &dimension_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(dimension_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return new Dimension(_ctx, handle);
-        }
-
-        /// <summary>
-        /// Test if a dimension with name exists or not.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public bool HasDimension(string name)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            int has_dim;
-            using var ms_name = new MarshaledString(name);
-            _ctx.handle_error(Methods.tiledb_domain_has_dimension(ctxHandle, handle, ms_name, &has_dim));
-            return has_dim > 0;
-        }
-        #endregion
+        _ctx = ctx;
+        _handle = DomainHandle.Create(_ctx);
     }
+
+    internal Domain(Context ctx, DomainHandle handle) 
+    {
+        _ctx = ctx;
+        _handle = handle;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing && (!_handle.IsInvalid))
+        {
+            _handle.Dispose();
+        }
+
+        _disposed = true;
+    }
+
+    internal DomainHandle Handle => _handle;
+
+    #region capi functions
+    /// <summary>
+    /// Get type of homogenous dimensions. Will throw exception for heterogeneous dimensions.
+    /// </summary>
+    /// <returns></returns>
+    public DataType Type()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        tiledb_datatype_t tiledb_datatype;
+        _ctx.handle_error(Methods.tiledb_domain_get_type(ctxHandle, handle, &tiledb_datatype));
+        return (DataType)tiledb_datatype;
+    }
+
+    /// <summary>
+    /// Get number of dimensions.
+    /// </summary>
+    /// <returns></returns>
+    public uint NDim()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        uint ndim;
+        _ctx.handle_error(Methods.tiledb_domain_get_ndim(ctxHandle, handle, &ndim));
+        return ndim;
+    }
+
+    /// <summary>
+    /// Add a dimension.
+    /// </summary>
+    /// <param name="d"></param>
+    public void AddDimension(Dimension d)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var dHandle = d.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_domain_add_dimension(ctxHandle, handle, dHandle));
+    }
+
+    /// <summary>
+    /// Add dimensions.
+    /// </summary>
+    /// <param name="d"></param>
+    public void AddDimensions(params Dimension[] d)
+    {
+        foreach (var t in d)
+        {
+            AddDimension(t);
+        }
+    }
+
+    /// <summary>
+    /// Get a dimension from index.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    public Dimension Dimension(uint index)
+    {
+        var handle = new DimensionHandle();
+        var successful = false;
+        tiledb_dimension_t* dimension_p = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var domainHandle = _handle.Acquire())
+            {
+                _ctx.handle_error(Methods.tiledb_domain_get_dimension_from_index(ctxHandle, domainHandle, index, &dimension_p));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(dimension_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+
+        return new Dimension(_ctx, handle);
+    }
+
+    /// <summary>
+    /// Get a dimension from name.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public Dimension Dimension(string name)
+    {
+        var handle = new DimensionHandle();
+        var successful = false;
+        tiledb_dimension_t* dimension_p = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var domainHandle = _handle.Acquire())
+            using (var ms_name = new MarshaledString(name))
+            {
+                _ctx.handle_error(Methods.tiledb_domain_get_dimension_from_name(ctxHandle, domainHandle, ms_name, &dimension_p));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(dimension_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+
+        return new Dimension(_ctx, handle);
+    }
+
+    /// <summary>
+    /// Test if a dimension with name exists or not.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <returns></returns>
+    public bool HasDimension(string name)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        int has_dim;
+        using var ms_name = new MarshaledString(name);
+        _ctx.handle_error(Methods.tiledb_domain_has_dimension(ctxHandle, handle, ms_name, &has_dim));
+        return has_dim > 0;
+    }
+    #endregion
 }

--- a/sources/TileDB.CSharp/Enumeration.cs
+++ b/sources/TileDB.CSharp/Enumeration.cs
@@ -5,384 +5,383 @@ using TileDB.CSharp.Marshalling;
 using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB enumeration object.
+/// </summary>
+public sealed unsafe class Enumeration : IDisposable
 {
     /// <summary>
-    /// Represents a TileDB enumeration object.
+    /// This value indicates an enumeration with variable-sized members.
+    /// It may be returned from <see cref="ValuesPerMember"/>.
     /// </summary>
-    public sealed unsafe class Enumeration : IDisposable
+    /// <seealso cref="Create{T}(Context, string, bool, ReadOnlySpan{T}, ReadOnlySpan{ulong}, DataType?)"/>
+    public const uint VariableSized = Constants.VariableSizedImpl;
+
+    private readonly Context _ctx;
+
+    private readonly EnumerationHandle _handle;
+
+    internal Enumeration(Context ctx, EnumerationHandle handle)
     {
-        /// <summary>
-        /// This value indicates an enumeration with variable-sized members.
-        /// It may be returned from <see cref="ValuesPerMember"/>.
-        /// </summary>
-        /// <seealso cref="Create{T}(Context, string, bool, ReadOnlySpan{T}, ReadOnlySpan{ulong}, DataType?)"/>
-        public const uint VariableSized = Constants.VariableSizedImpl;
+        _ctx = ctx;
+        _handle = handle;
+    }
 
-        private readonly Context _ctx;
+    internal EnumerationHandle Handle => _handle;
 
-        private readonly EnumerationHandle _handle;
+    /// <summary>
+    /// Creates an <see cref="Enumeration"/> with fixed-sized members.
+    /// </summary>
+    /// <typeparam name="T">The type of the enumeration's members.</typeparam>
+    /// <param name="ctx">The <see cref="Context"/> to use.</param>
+    /// <param name="name">The name of the enumeration.</param>
+    /// <param name="ordered">The value of <see cref="IsOrdered"/>.</param>
+    /// <param name="values">A <see cref="ReadOnlySpan{T}"/> of the enumeration's values.</param>
+    /// <param name="cellValNum">The number of values per member in the enumeration. Optional,
+    /// defaults to 1. If specified, its value must divide the length of <paramref name="values"/>.</param>
+    /// <param name="dataType">The data type of the enumeration. Defaults to the
+    /// default data type of <typeparamref name="T"/>.</param>
+    /// <exception cref="InvalidOperationException"><paramref name="dataType"/> does not
+    /// match <typeparamref name="T"/>.</exception>
+    public static Enumeration Create<T>(Context ctx, string name, bool ordered, ReadOnlySpan<T> values, uint cellValNum = 1, DataType? dataType = null) where T : struct
+    {
+        DataType dataTypeActual = dataType ??= EnumUtil.TypeToDataType(typeof(T));
+        ErrorHandling.CheckDataType<T>(dataTypeActual);
 
-        internal Enumeration(Context ctx, EnumerationHandle handle)
+        fixed (T* valuesPtr = &MemoryMarshal.GetReference(values))
         {
-            _ctx = ctx;
-            _handle = handle;
-        }
-
-        internal EnumerationHandle Handle => _handle;
-
-        /// <summary>
-        /// Creates an <see cref="Enumeration"/> with fixed-sized members.
-        /// </summary>
-        /// <typeparam name="T">The type of the enumeration's members.</typeparam>
-        /// <param name="ctx">The <see cref="Context"/> to use.</param>
-        /// <param name="name">The name of the enumeration.</param>
-        /// <param name="ordered">The value of <see cref="IsOrdered"/>.</param>
-        /// <param name="values">A <see cref="ReadOnlySpan{T}"/> of the enumeration's values.</param>
-        /// <param name="cellValNum">The number of values per member in the enumeration. Optional,
-        /// defaults to 1. If specified, its value must divide the length of <paramref name="values"/>.</param>
-        /// <param name="dataType">The data type of the enumeration. Defaults to the
-        /// default data type of <typeparamref name="T"/>.</param>
-        /// <exception cref="InvalidOperationException"><paramref name="dataType"/> does not
-        /// match <typeparamref name="T"/>.</exception>
-        public static Enumeration Create<T>(Context ctx, string name, bool ordered, ReadOnlySpan<T> values, uint cellValNum = 1, DataType? dataType = null) where T : struct
-        {
-            DataType dataTypeActual = dataType ??= EnumUtil.TypeToDataType(typeof(T));
-            ErrorHandling.CheckDataType<T>(dataTypeActual);
-
-            fixed (T* valuesPtr = &MemoryMarshal.GetReference(values))
-            {
-                EnumerationHandle handle = EnumerationHandle.Create(ctx, name, (tiledb_datatype_t)dataTypeActual, cellValNum, ordered, (byte*)valuesPtr, (ulong)values.Length * (ulong)sizeof(T), null, 0);
-                return new Enumeration(ctx, handle);
-            }
-        }
-
-        /// <summary>
-        /// Creates an <see cref="Enumeration"/> with variable-sized members.
-        /// </summary>
-        /// <typeparam name="T">The type of the enumeration's members.</typeparam>
-        /// <param name="ctx">The <see cref="Context"/> to use.</param>
-        /// <param name="name">The name of the enumeration.</param>
-        /// <param name="ordered">The value of <see cref="IsOrdered"/>.</param>
-        /// <param name="values">A <see cref="ReadOnlySpan{T}"/> of all values of each member of the enumeration, concatenated.</param>
-        /// <param name="offsets">A <see cref="ReadOnlySpan{T}"/> of the offsets to the first byte of each member of the enumeration.</param>
-        /// <param name="dataType">The data type of the enumeration. Defaults to the
-        /// default data type of <typeparamref name="T"/>.</param>
-        /// <exception cref="InvalidOperationException"><paramref name="dataType"/> does not
-        /// match <typeparamref name="T"/>.</exception>
-        public static Enumeration Create<T>(Context ctx, string name, bool ordered, ReadOnlySpan<T> values, ReadOnlySpan<ulong> offsets, DataType? dataType = null) where T : struct
-        {
-            DataType dataTypeActual = dataType ??= EnumUtil.TypeToDataType(typeof(T));
-            ErrorHandling.CheckDataType<T>(dataTypeActual);
-
-            EnumerationHandle handle;
-            fixed (T* valuesPtr = &MemoryMarshal.GetReference(values))
-            fixed (ulong* offsetsPtr = &MemoryMarshal.GetReference(offsets))
-            {
-                handle = EnumerationHandle.Create(ctx, name, (tiledb_datatype_t)dataTypeActual, VariableSized, ordered, (byte*)valuesPtr, (ulong)values.Length * (ulong)sizeof(T), offsetsPtr, (ulong)offsets.Length * sizeof(ulong));
-            }
+            EnumerationHandle handle = EnumerationHandle.Create(ctx, name, (tiledb_datatype_t)dataTypeActual, cellValNum, ordered, (byte*)valuesPtr, (ulong)values.Length * (ulong)sizeof(T), null, 0);
             return new Enumeration(ctx, handle);
         }
+    }
 
-        /// <summary>
-        /// Creates an <see cref="Enumeration"/> from a collection of strings.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> to use.</param>
-        /// <param name="name">The name of the enumeration.</param>
-        /// <param name="ordered">Whether the enumeration should be considered as ordered.
-        /// If false, prevents inequality operators in <see cref="QueryCondition"/>s from
-        /// being used with this enumeration.</param>
-        /// <param name="values">The collection of values for the enumeration.</param>
-        /// <param name="dataType">The data type of the enumeration. Must be a string type.
-        /// Optional, defaults to <see cref="DataType.StringUtf8"/>.</param>
-        public static Enumeration Create(Context ctx, string name, bool ordered, IReadOnlyCollection<string> values, DataType dataType = DataType.StringUtf8)
+    /// <summary>
+    /// Creates an <see cref="Enumeration"/> with variable-sized members.
+    /// </summary>
+    /// <typeparam name="T">The type of the enumeration's members.</typeparam>
+    /// <param name="ctx">The <see cref="Context"/> to use.</param>
+    /// <param name="name">The name of the enumeration.</param>
+    /// <param name="ordered">The value of <see cref="IsOrdered"/>.</param>
+    /// <param name="values">A <see cref="ReadOnlySpan{T}"/> of all values of each member of the enumeration, concatenated.</param>
+    /// <param name="offsets">A <see cref="ReadOnlySpan{T}"/> of the offsets to the first byte of each member of the enumeration.</param>
+    /// <param name="dataType">The data type of the enumeration. Defaults to the
+    /// default data type of <typeparamref name="T"/>.</param>
+    /// <exception cref="InvalidOperationException"><paramref name="dataType"/> does not
+    /// match <typeparamref name="T"/>.</exception>
+    public static Enumeration Create<T>(Context ctx, string name, bool ordered, ReadOnlySpan<T> values, ReadOnlySpan<ulong> offsets, DataType? dataType = null) where T : struct
+    {
+        DataType dataTypeActual = dataType ??= EnumUtil.TypeToDataType(typeof(T));
+        ErrorHandling.CheckDataType<T>(dataTypeActual);
+
+        EnumerationHandle handle;
+        fixed (T* valuesPtr = &MemoryMarshal.GetReference(values))
+        fixed (ulong* offsetsPtr = &MemoryMarshal.GetReference(offsets))
         {
-            using MarshaledContiguousStringCollection marshaledStrings = new(values, dataType);
-            var handle = EnumerationHandle.Create(ctx, name, (tiledb_datatype_t)dataType, VariableSized,
-                ordered, marshaledStrings.Data, marshaledStrings.DataCount, marshaledStrings.Offsets, marshaledStrings.OffsetsCount);
-            return new Enumeration(ctx, handle);
+            handle = EnumerationHandle.Create(ctx, name, (tiledb_datatype_t)dataTypeActual, VariableSized, ordered, (byte*)valuesPtr, (ulong)values.Length * (ulong)sizeof(T), offsetsPtr, (ulong)offsets.Length * sizeof(ulong));
         }
+        return new Enumeration(ctx, handle);
+    }
 
-        /// <summary>
-        /// Adds additional values to an <see cref="Enumeration"/> with fixed-sized members.
-        /// </summary>
-        /// <typeparam name="T">The type of the enumeration's members.</typeparam>
-        /// <param name="values">A <see cref="ReadOnlySpan{T}"/> of the enumeration's values.</param>
-        /// <exception cref="InvalidOperationException">The enumeration's
-        /// <see cref="DataType"/> does not match <typeparamref name="T"/>.</exception>
-        public Enumeration Extend<T>(ReadOnlySpan<T> values) where T : struct
+    /// <summary>
+    /// Creates an <see cref="Enumeration"/> from a collection of strings.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> to use.</param>
+    /// <param name="name">The name of the enumeration.</param>
+    /// <param name="ordered">Whether the enumeration should be considered as ordered.
+    /// If false, prevents inequality operators in <see cref="QueryCondition"/>s from
+    /// being used with this enumeration.</param>
+    /// <param name="values">The collection of values for the enumeration.</param>
+    /// <param name="dataType">The data type of the enumeration. Must be a string type.
+    /// Optional, defaults to <see cref="DataType.StringUtf8"/>.</param>
+    public static Enumeration Create(Context ctx, string name, bool ordered, IReadOnlyCollection<string> values, DataType dataType = DataType.StringUtf8)
+    {
+        using MarshaledContiguousStringCollection marshaledStrings = new(values, dataType);
+        var handle = EnumerationHandle.Create(ctx, name, (tiledb_datatype_t)dataType, VariableSized,
+            ordered, marshaledStrings.Data, marshaledStrings.DataCount, marshaledStrings.Offsets, marshaledStrings.OffsetsCount);
+        return new Enumeration(ctx, handle);
+    }
+
+    /// <summary>
+    /// Adds additional values to an <see cref="Enumeration"/> with fixed-sized members.
+    /// </summary>
+    /// <typeparam name="T">The type of the enumeration's members.</typeparam>
+    /// <param name="values">A <see cref="ReadOnlySpan{T}"/> of the enumeration's values.</param>
+    /// <exception cref="InvalidOperationException">The enumeration's
+    /// <see cref="DataType"/> does not match <typeparamref name="T"/>.</exception>
+    public Enumeration Extend<T>(ReadOnlySpan<T> values) where T : struct
+    {
+        ErrorHandling.CheckDataType<T>(DataType);
+
+        fixed (T* valuesPtr = &MemoryMarshal.GetReference(values))
         {
-            ErrorHandling.CheckDataType<T>(DataType);
-
-            fixed (T* valuesPtr = &MemoryMarshal.GetReference(values))
-            {
-                EnumerationHandle handle = _handle.Extend(_ctx, (byte*)valuesPtr, (ulong)values.Length * (ulong)sizeof(T), null, 0);
-                return new Enumeration(_ctx, handle);
-            }
-        }
-
-        /// <summary>
-        /// Extends an <see cref="Enumeration"/> with variable-sized members.
-        /// </summary>
-        /// <typeparam name="T">The type of the enumeration's members.</typeparam>
-        /// <param name="values">A <see cref="ReadOnlySpan{T}"/> of all values of each additional member of the enumeration, concatenated.</param>
-        /// <param name="offsets">A <see cref="ReadOnlySpan{T}"/> of the offsets to the first byte of each member of the enumeration.</param>
-        /// <exception cref="InvalidOperationException">The enumeration's
-        /// <see cref="DataType"/> does not match <typeparamref name="T"/>.</exception>
-        public Enumeration Extend<T>(ReadOnlySpan<T> values, ReadOnlySpan<ulong> offsets) where T : struct
-        {
-            ErrorHandling.CheckDataType<T>(DataType);
-
-            EnumerationHandle handle;
-            fixed (T* valuesPtr = &MemoryMarshal.GetReference(values))
-            fixed (ulong* offsetsPtr = &MemoryMarshal.GetReference(offsets))
-            {
-                handle = _handle.Extend(_ctx, (byte*)valuesPtr, (ulong)values.Length * (ulong)sizeof(T), offsetsPtr, (ulong)offsets.Length * sizeof(ulong));
-            }
+            EnumerationHandle handle = _handle.Extend(_ctx, (byte*)valuesPtr, (ulong)values.Length * (ulong)sizeof(T), null, 0);
             return new Enumeration(_ctx, handle);
         }
+    }
 
-        /// <summary>
-        /// Extends an <see cref="Enumeration"/> of strings.
-        /// </summary>
-        /// <param name="values">The strings to add to the enumeration.</param>
-        /// <exception cref="InvalidOperationException">The enumeration has a non-string data
-        /// type, or its members are fixed-size.</exception>
-        public Enumeration Extend(IReadOnlyCollection<string> values)
+    /// <summary>
+    /// Extends an <see cref="Enumeration"/> with variable-sized members.
+    /// </summary>
+    /// <typeparam name="T">The type of the enumeration's members.</typeparam>
+    /// <param name="values">A <see cref="ReadOnlySpan{T}"/> of all values of each additional member of the enumeration, concatenated.</param>
+    /// <param name="offsets">A <see cref="ReadOnlySpan{T}"/> of the offsets to the first byte of each member of the enumeration.</param>
+    /// <exception cref="InvalidOperationException">The enumeration's
+    /// <see cref="DataType"/> does not match <typeparamref name="T"/>.</exception>
+    public Enumeration Extend<T>(ReadOnlySpan<T> values, ReadOnlySpan<ulong> offsets) where T : struct
+    {
+        ErrorHandling.CheckDataType<T>(DataType);
+
+        EnumerationHandle handle;
+        fixed (T* valuesPtr = &MemoryMarshal.GetReference(values))
+        fixed (ulong* offsetsPtr = &MemoryMarshal.GetReference(offsets))
         {
-            if (ValuesPerMember != VariableSized)
-            {
-                throw new InvalidOperationException("Enumeration must have variable-sized members.");
-            }
-            DataType dataType = DataType;
-            if (!EnumUtil.IsStringType(dataType))
-            {
-                throw new InvalidOperationException($"Cannot extend enumeration with non-string data type, got {dataType}.");
-            }
+            handle = _handle.Extend(_ctx, (byte*)valuesPtr, (ulong)values.Length * (ulong)sizeof(T), offsetsPtr, (ulong)offsets.Length * sizeof(ulong));
+        }
+        return new Enumeration(_ctx, handle);
+    }
 
-            using MarshaledContiguousStringCollection marshaledStrings = new(values, dataType);
-            var handle = _handle.Extend(_ctx, marshaledStrings.Data, marshaledStrings.DataCount, marshaledStrings.Offsets, marshaledStrings.OffsetsCount);
-            return new Enumeration(_ctx, handle);
+    /// <summary>
+    /// Extends an <see cref="Enumeration"/> of strings.
+    /// </summary>
+    /// <param name="values">The strings to add to the enumeration.</param>
+    /// <exception cref="InvalidOperationException">The enumeration has a non-string data
+    /// type, or its members are fixed-size.</exception>
+    public Enumeration Extend(IReadOnlyCollection<string> values)
+    {
+        if (ValuesPerMember != VariableSized)
+        {
+            throw new InvalidOperationException("Enumeration must have variable-sized members.");
+        }
+        DataType dataType = DataType;
+        if (!EnumUtil.IsStringType(dataType))
+        {
+            throw new InvalidOperationException($"Cannot extend enumeration with non-string data type, got {dataType}.");
         }
 
-        /// <summary>
-        /// Disposes the <see cref="Enumeration"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            _handle.Dispose();
-        }
+        using MarshaledContiguousStringCollection marshaledStrings = new(values, dataType);
+        var handle = _handle.Extend(_ctx, marshaledStrings.Data, marshaledStrings.DataCount, marshaledStrings.Offsets, marshaledStrings.OffsetsCount);
+        return new Enumeration(_ctx, handle);
+    }
 
-        /// <summary>
-        /// Returns the number of values for each member of the <see cref="Enumeration"/>.
-        /// </summary>
-        /// <remarks>
-        /// <para>If this property has a value of <see cref="VariableSized"/>,
-        /// each value has a different size.</para>
-        /// <para>This method exposes the <c>tiledb_enumeration_get_cell_val_num</c> function of the TileDB Embedded C API.</para>
-        /// </remarks>
-        public uint ValuesPerMember
-        {
-            get
-            {
-                uint result;
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var handle = _handle.Acquire();
-                _ctx.handle_error(Methods.tiledb_enumeration_get_cell_val_num(ctxHandle, handle, &result));
-                return result;
-            }
-        }
+    /// <summary>
+    /// Disposes the <see cref="Enumeration"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
 
-        /// <summary>
-        /// The <see cref="DataType"/> of the <see cref="Enumeration"/>.
-        /// </summary>
-        public DataType DataType
+    /// <summary>
+    /// Returns the number of values for each member of the <see cref="Enumeration"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>If this property has a value of <see cref="VariableSized"/>,
+    /// each value has a different size.</para>
+    /// <para>This method exposes the <c>tiledb_enumeration_get_cell_val_num</c> function of the TileDB Embedded C API.</para>
+    /// </remarks>
+    public uint ValuesPerMember
+    {
+        get
         {
-            get
-            {
-                tiledb_datatype_t result;
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var handle = _handle.Acquire();
-                _ctx.handle_error(Methods.tiledb_enumeration_get_type(ctxHandle, handle, &result));
-                return (DataType)result;
-            }
-        }
-
-        /// <summary>
-        /// Whether the <see cref="Enumeration"/> should be considered as ordered.
-        /// </summary>
-        /// <remarks>
-        /// If <see langword="false"/>, prevents inequality operators in
-        /// <see cref="QueryCondition"/>s from being used with this enumeration.
-        /// </remarks>
-        public bool IsOrdered
-        {
-            get
-            {
-                int result;
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var handle = _handle.Acquire();
-                _ctx.handle_error(Methods.tiledb_enumeration_get_ordered(ctxHandle, handle, &result));
-                return result != 0;
-            }
-        }
-
-        /// <summary>
-        /// Returns the name of the <see cref="Enumeration"/>.
-        /// </summary>
-        public string GetName()
-        {
-            using StringHandleHolder nameHolder = new();
+            uint result;
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_enumeration_get_name(ctxHandle, handle, &nameHolder._handle));
-            return nameHolder.ToString();
+            _ctx.handle_error(Methods.tiledb_enumeration_get_cell_val_num(ctxHandle, handle, &result));
+            return result;
         }
+    }
 
-        /// <summary>
-        /// Returns the values of the <see cref="Enumeration"/>.
-        /// </summary>
-        /// <returns>
-        /// An array whose type depends on the enumeration's <see cref="DataType"/>
-        /// and <see cref="ValuesPerMember"/>:
-        /// <list type="bullet">
-        /// <item>If <see cref="DataType"/> is a string datatype, the
-        /// method will return an array of <see cref="string"/>.</item>
-        /// <item>If the enumeration's values have a fixed size (i.e. <see cref="ValuesPerMember"/>
-        /// is not equal to <see cref="VariableSized"/>), the method will return an array of
-        /// values of the underlying data type.</item>
-        /// <item>If the enumeration's values have a variable size (i.e. <see cref="ValuesPerMember"/>
-        /// is equal to <see cref="VariableSized"/>), the method will return an array of arrays of
-        /// values of the underlying data type.</item>
-        /// </list>
-        /// </returns>
-        public System.Array GetValues()
+    /// <summary>
+    /// The <see cref="DataType"/> of the <see cref="Enumeration"/>.
+    /// </summary>
+    public DataType DataType
+    {
+        get
         {
-            // Keep the handles acquired for the entire method.
-            // This prevents another thread freeing the data and offsets buffers.
+            tiledb_datatype_t result;
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-
-            void* dataPtr;
-            ulong* offsetsPtr;
-            ulong dataSize, offsetsSize;
-            _ctx.handle_error(Methods.tiledb_enumeration_get_data(ctxHandle, handle, &dataPtr, &dataSize));
-            _ctx.handle_error(Methods.tiledb_enumeration_get_offsets(ctxHandle, handle, (void**)&offsetsPtr, &offsetsSize));
-
-            DataType datatype;
-            _ctx.handle_error(Methods.tiledb_enumeration_get_type(ctxHandle, handle, (tiledb_datatype_t*)&datatype));
-
-            if (EnumUtil.IsStringType(datatype))
-            {
-                ReadOnlySpan<ulong> offsets = new(offsetsPtr, checked((int)(offsetsSize / sizeof(ulong))));
-                string[] result = new string[offsets.Length];
-
-                for (int i = 0; i < offsets.Length; i++)
-                {
-                    ulong nextOffset = i == offsets.Length - 1 ? dataSize : offsets[i + 1];
-                    ReadOnlySpan<byte> bytes = new((byte*)dataPtr + offsets[i], checked((int)(nextOffset - offsets[i])));
-                    result[i] = MarshaledStringOut.GetString(bytes, datatype);
-                }
-
-                return result;
-            }
-
-            Type type = EnumUtil.DataTypeToType(datatype);
-            if (type == typeof(sbyte))
-            {
-                return GetValues<sbyte>(dataPtr, dataSize, offsetsPtr, offsetsSize);
-            }
-            if (type == typeof(byte))
-            {
-                return GetValues<byte>(dataPtr, dataSize, offsetsPtr, offsetsSize);
-            }
-            if (type == typeof(short))
-            {
-                return GetValues<short>(dataPtr, dataSize, offsetsPtr, offsetsSize);
-            }
-            if (type == typeof(ushort))
-            {
-                return GetValues<ushort>(dataPtr, dataSize, offsetsPtr, offsetsSize);
-            }
-            if (type == typeof(int))
-            {
-                return GetValues<int>(dataPtr, dataSize, offsetsPtr, offsetsSize);
-            }
-            if (type == typeof(uint))
-            {
-                return GetValues<uint>(dataPtr, dataSize, offsetsPtr, offsetsSize);
-            }
-            if (type == typeof(long))
-            {
-                return GetValues<long>(dataPtr, dataSize, offsetsPtr, offsetsSize);
-            }
-            if (type == typeof(ulong))
-            {
-                return GetValues<ulong>(dataPtr, dataSize, offsetsPtr, offsetsSize);
-            }
-            if (type == typeof(float))
-            {
-                return GetValues<float>(dataPtr, dataSize, offsetsPtr, offsetsSize);
-            }
-            if (type == typeof(double))
-            {
-                return GetValues<double>(dataPtr, dataSize, offsetsPtr, offsetsSize);
-            }
-            throw new NotSupportedException($"Unsupported enumeration type: {type}. Please open a bug report.");
-
-            System.Array GetValues<T>(void* dataPtr, ulong dataSize, ulong* offsetsPtr, ulong offsetsSize)
-            {
-                uint cellValNum;
-                _ctx.handle_error(Methods.tiledb_enumeration_get_cell_val_num(ctxHandle, handle, &cellValNum));
-                if (cellValNum != VariableSized)
-                {
-                    return new ReadOnlySpan<T>(dataPtr, checked((int)(dataSize / (ulong)sizeof(T)))).ToArray();
-                }
-
-                ReadOnlySpan<ulong> offsets = new(offsetsPtr, checked((int)(offsetsSize / sizeof(ulong))));
-                T[][] result = new T[offsets.Length][];
-                for (int i = 0; i < offsets.Length; i++)
-                {
-                    ulong nextOffset = i == offsets.Length - 1 ? dataSize : offsets[i + 1];
-                    result[i] = new ReadOnlySpan<T>((byte*)dataPtr + offsets[i], checked((int)((nextOffset - offsets[i]) / (ulong)sizeof(T)))).ToArray();
-                }
-
-                return result;
-            }
+            _ctx.handle_error(Methods.tiledb_enumeration_get_type(ctxHandle, handle, &result));
+            return (DataType)result;
         }
+    }
 
-        /// <summary>
-        /// Returns a byte array with the raw data of the <see cref="Enumeration"/>'s members.
-        /// </summary>
-        /// <seealso cref="GetValues"/>
-        /// <seealso cref="GetRawOffsets"/>
-        public byte[] GetRawData()
+    /// <summary>
+    /// Whether the <see cref="Enumeration"/> should be considered as ordered.
+    /// </summary>
+    /// <remarks>
+    /// If <see langword="false"/>, prevents inequality operators in
+    /// <see cref="QueryCondition"/>s from being used with this enumeration.
+    /// </remarks>
+    public bool IsOrdered
+    {
+        get
         {
+            int result;
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            void* data;
-            ulong dataSize;
-            _ctx.handle_error(Methods.tiledb_enumeration_get_data(ctxHandle, handle, &data, &dataSize));
-            return new ReadOnlySpan<byte>(data, checked((int)dataSize)).ToArray();
+            _ctx.handle_error(Methods.tiledb_enumeration_get_ordered(ctxHandle, handle, &result));
+            return result != 0;
+        }
+    }
+
+    /// <summary>
+    /// Returns the name of the <see cref="Enumeration"/>.
+    /// </summary>
+    public string GetName()
+    {
+        using StringHandleHolder nameHolder = new();
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_enumeration_get_name(ctxHandle, handle, &nameHolder._handle));
+        return nameHolder.ToString();
+    }
+
+    /// <summary>
+    /// Returns the values of the <see cref="Enumeration"/>.
+    /// </summary>
+    /// <returns>
+    /// An array whose type depends on the enumeration's <see cref="DataType"/>
+    /// and <see cref="ValuesPerMember"/>:
+    /// <list type="bullet">
+    /// <item>If <see cref="DataType"/> is a string datatype, the
+    /// method will return an array of <see cref="string"/>.</item>
+    /// <item>If the enumeration's values have a fixed size (i.e. <see cref="ValuesPerMember"/>
+    /// is not equal to <see cref="VariableSized"/>), the method will return an array of
+    /// values of the underlying data type.</item>
+    /// <item>If the enumeration's values have a variable size (i.e. <see cref="ValuesPerMember"/>
+    /// is equal to <see cref="VariableSized"/>), the method will return an array of arrays of
+    /// values of the underlying data type.</item>
+    /// </list>
+    /// </returns>
+    public System.Array GetValues()
+    {
+        // Keep the handles acquired for the entire method.
+        // This prevents another thread freeing the data and offsets buffers.
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+
+        void* dataPtr;
+        ulong* offsetsPtr;
+        ulong dataSize, offsetsSize;
+        _ctx.handle_error(Methods.tiledb_enumeration_get_data(ctxHandle, handle, &dataPtr, &dataSize));
+        _ctx.handle_error(Methods.tiledb_enumeration_get_offsets(ctxHandle, handle, (void**)&offsetsPtr, &offsetsSize));
+
+        DataType datatype;
+        _ctx.handle_error(Methods.tiledb_enumeration_get_type(ctxHandle, handle, (tiledb_datatype_t*)&datatype));
+
+        if (EnumUtil.IsStringType(datatype))
+        {
+            ReadOnlySpan<ulong> offsets = new(offsetsPtr, checked((int)(offsetsSize / sizeof(ulong))));
+            string[] result = new string[offsets.Length];
+
+            for (int i = 0; i < offsets.Length; i++)
+            {
+                ulong nextOffset = i == offsets.Length - 1 ? dataSize : offsets[i + 1];
+                ReadOnlySpan<byte> bytes = new((byte*)dataPtr + offsets[i], checked((int)(nextOffset - offsets[i])));
+                result[i] = MarshaledStringOut.GetString(bytes, datatype);
+            }
+
+            return result;
         }
 
-        /// <summary>
-        /// Returns an array with the offsets to the first byte of each member of the <see cref="Enumeration"/>.
-        /// </summary>
-        /// <remarks>
-        /// In enumerations with fixed-size members (i.e. <see cref="ValuesPerMember"/> is not equal
-        /// to <see cref="VariableSized"/>, this method will return an empty array, as each member has the same size.
-        /// </remarks>
-        /// <seealso cref="GetValues"/>
-        /// <seealso cref="GetRawData"/>
-        public ulong[] GetRawOffsets()
+        Type type = EnumUtil.DataTypeToType(datatype);
+        if (type == typeof(sbyte))
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            void* data;
-            ulong dataSize;
-            _ctx.handle_error(Methods.tiledb_enumeration_get_offsets(ctxHandle, handle, &data, &dataSize));
-            return new ReadOnlySpan<ulong>(data, checked((int)(dataSize / sizeof(ulong)))).ToArray();
+            return GetValues<sbyte>(dataPtr, dataSize, offsetsPtr, offsetsSize);
         }
+        if (type == typeof(byte))
+        {
+            return GetValues<byte>(dataPtr, dataSize, offsetsPtr, offsetsSize);
+        }
+        if (type == typeof(short))
+        {
+            return GetValues<short>(dataPtr, dataSize, offsetsPtr, offsetsSize);
+        }
+        if (type == typeof(ushort))
+        {
+            return GetValues<ushort>(dataPtr, dataSize, offsetsPtr, offsetsSize);
+        }
+        if (type == typeof(int))
+        {
+            return GetValues<int>(dataPtr, dataSize, offsetsPtr, offsetsSize);
+        }
+        if (type == typeof(uint))
+        {
+            return GetValues<uint>(dataPtr, dataSize, offsetsPtr, offsetsSize);
+        }
+        if (type == typeof(long))
+        {
+            return GetValues<long>(dataPtr, dataSize, offsetsPtr, offsetsSize);
+        }
+        if (type == typeof(ulong))
+        {
+            return GetValues<ulong>(dataPtr, dataSize, offsetsPtr, offsetsSize);
+        }
+        if (type == typeof(float))
+        {
+            return GetValues<float>(dataPtr, dataSize, offsetsPtr, offsetsSize);
+        }
+        if (type == typeof(double))
+        {
+            return GetValues<double>(dataPtr, dataSize, offsetsPtr, offsetsSize);
+        }
+        throw new NotSupportedException($"Unsupported enumeration type: {type}. Please open a bug report.");
+
+        System.Array GetValues<T>(void* dataPtr, ulong dataSize, ulong* offsetsPtr, ulong offsetsSize)
+        {
+            uint cellValNum;
+            _ctx.handle_error(Methods.tiledb_enumeration_get_cell_val_num(ctxHandle, handle, &cellValNum));
+            if (cellValNum != VariableSized)
+            {
+                return new ReadOnlySpan<T>(dataPtr, checked((int)(dataSize / (ulong)sizeof(T)))).ToArray();
+            }
+
+            ReadOnlySpan<ulong> offsets = new(offsetsPtr, checked((int)(offsetsSize / sizeof(ulong))));
+            T[][] result = new T[offsets.Length][];
+            for (int i = 0; i < offsets.Length; i++)
+            {
+                ulong nextOffset = i == offsets.Length - 1 ? dataSize : offsets[i + 1];
+                result[i] = new ReadOnlySpan<T>((byte*)dataPtr + offsets[i], checked((int)((nextOffset - offsets[i]) / (ulong)sizeof(T)))).ToArray();
+            }
+
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// Returns a byte array with the raw data of the <see cref="Enumeration"/>'s members.
+    /// </summary>
+    /// <seealso cref="GetValues"/>
+    /// <seealso cref="GetRawOffsets"/>
+    public byte[] GetRawData()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        void* data;
+        ulong dataSize;
+        _ctx.handle_error(Methods.tiledb_enumeration_get_data(ctxHandle, handle, &data, &dataSize));
+        return new ReadOnlySpan<byte>(data, checked((int)dataSize)).ToArray();
+    }
+
+    /// <summary>
+    /// Returns an array with the offsets to the first byte of each member of the <see cref="Enumeration"/>.
+    /// </summary>
+    /// <remarks>
+    /// In enumerations with fixed-size members (i.e. <see cref="ValuesPerMember"/> is not equal
+    /// to <see cref="VariableSized"/>, this method will return an empty array, as each member has the same size.
+    /// </remarks>
+    /// <seealso cref="GetValues"/>
+    /// <seealso cref="GetRawData"/>
+    public ulong[] GetRawOffsets()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        void* data;
+        ulong dataSize;
+        _ctx.handle_error(Methods.tiledb_enumeration_get_offsets(ctxHandle, handle, &data, &dataSize));
+        return new ReadOnlySpan<ulong>(data, checked((int)(dataSize / sizeof(ulong)))).ToArray();
     }
 }

--- a/sources/TileDB.CSharp/Enums.cs
+++ b/sources/TileDB.CSharp/Enums.cs
@@ -3,1332 +3,1331 @@ using System.ComponentModel;
 using System.Text;
 using TileDB.Interop;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+// TODO Not sure why this is not automatically wrapped
+internal enum Status
 {
-    // TODO Not sure why this is not automatically wrapped
-    internal enum Status
+    TILEDB_OOM = -2,
+    TILEDB_ERR = -1,
+    TILEDB_OK = 0
+}
+
+/// <summary>
+/// Specifies the type of a TileDB object.
+/// </summary>
+public enum ObjectType : uint
+{
+    /// <summary>
+    /// Invalid object.
+    /// </summary>
+    Invalid = tiledb_object_t.TILEDB_INVALID,
+    /// <summary>
+    /// The object is a <see cref="Group"/>.
+    /// </summary>
+    Group = tiledb_object_t.TILEDB_GROUP,
+    /// <summary>
+    /// The object is an <see cref="Array"/>.
+    /// </summary>
+    Array = tiledb_object_t.TILEDB_ARRAY
+}
+
+/// <summary>
+/// Specifies the type of a <see cref="Query"/>.
+/// </summary>
+public enum QueryType : uint
+{
+    /// <summary>
+    /// Read query.
+    /// </summary>
+    Read = tiledb_query_type_t.TILEDB_READ,
+    /// <summary>
+    /// Write query.
+    /// </summary>
+    Write = tiledb_query_type_t.TILEDB_WRITE,
+    Delete = tiledb_query_type_t.TILEDB_DELETE,
+    Update = tiledb_query_type_t.TILEDB_UPDATE,
+    ModifyExclusive = tiledb_query_type_t.TILEDB_MODIFY_EXCLUSIVE
+}
+
+/// <summary>
+/// Specifies the status of a <see cref="Query"/>.
+/// </summary>
+public enum QueryStatus : uint
+{
+    /// <summary>
+    /// The query failed.
+    /// </summary>
+    Failed = tiledb_query_status_t.TILEDB_FAILED,
+    /// <summary>
+    /// The query completed and all data has been read.
+    /// </summary>
+    Completed = tiledb_query_status_t.TILEDB_COMPLETED,
+    /// <summary>
+    /// The query is in process.
+    /// </summary>
+    InProgress = tiledb_query_status_t.TILEDB_INPROGRESS,
+    /// <summary>
+    /// The query completed but not all data has been read.
+    /// </summary>
+    Incomplete = tiledb_query_status_t.TILEDB_INCOMPLETE,
+    /// <summary>
+    /// The query is not initialized.
+    /// </summary>
+    Uninitialized = tiledb_query_status_t.TILEDB_UNINITIALIZED,
+    /// <summary>
+    /// The query is initialized.
+    /// </summary>
+    Initialized = tiledb_query_status_t.TILEDB_INITIALIZED
+}
+
+/// <summary>
+/// Specifies the reason a <see cref="Query"/> cannot proceed.
+/// </summary>
+public enum QueryStatusDetailsReason : uint
+{
+    /// <summary>
+    /// There is no reason. This is the default value.
+    /// </summary>
+    None = tiledb_query_status_details_reason_t.TILEDB_REASON_NONE,
+    /// <summary>
+    /// The user-provided buffers are too small and need to be resized.
+    /// </summary>
+    UserBufferSize = tiledb_query_status_details_reason_t.TILEDB_REASON_USER_BUFFER_SIZE,
+    /// <summary>
+    /// The memory budget was exceeded. The query can be submitted again without resizing the buffers.
+    /// </summary>
+    MemoryBudget = tiledb_query_status_details_reason_t.TILEDB_REASON_MEMORY_BUDGET,
+}
+
+/// <summary>
+/// Specifies the relation type of a <see cref="QueryCondition"/> between its attribute and its value.
+/// </summary>
+public enum QueryConditionOperatorType : uint
+{
+    /// <summary>
+    /// The attribute is less than the value.
+    /// </summary>
+    LessThan = tiledb_query_condition_op_t.TILEDB_LT,
+    /// <summary>
+    /// The attribute is less than or equal to the value.
+    /// </summary>
+    LessThanOrEqual = tiledb_query_condition_op_t.TILEDB_LE,
+    /// <summary>
+    /// The attribute is greater than the value.
+    /// </summary>
+    GreaterThan = tiledb_query_condition_op_t.TILEDB_GT,
+    /// <summary>
+    /// The attribute is greater than or equal to the value.
+    /// </summary>
+    GreaterThanOrEqual = tiledb_query_condition_op_t.TILEDB_GE,
+    /// <summary>
+    /// The attribute is equal to the value.
+    /// </summary>
+    Equal = tiledb_query_condition_op_t.TILEDB_EQ,
+    /// <summary>
+    /// The attribute is not equal to the value.
+    /// </summary>
+    NotEqual = tiledb_query_condition_op_t.TILEDB_NE
+}
+
+/// <summary>
+/// Specifies the combination operator type of one or two <see cref="QueryCondition"/>s.
+/// </summary>
+public enum QueryConditionCombinationOperatorType : uint
+{
+    /// <summary>
+    /// Both conditions must be satisfied.
+    /// </summary>
+    And = tiledb_query_condition_combination_op_t.TILEDB_AND,
+    /// <summary>
+    /// Either of the two conditions must be satisfied.
+    /// </summary>
+    Or = tiledb_query_condition_combination_op_t.TILEDB_OR,
+    /// <summary>
+    /// The condition must not be satisfied.
+    /// </summary>
+    Not = tiledb_query_condition_combination_op_t.TILEDB_NOT
+}
+
+/// <summary>
+/// Specifies the type of a TileDB file system.
+/// </summary>
+public enum FileSystemType : uint
+{
+    /// <summary>
+    /// HDFS (Hadoop File System) file system.
+    /// </summary>
+    Hdfs = tiledb_filesystem_t.TILEDB_HDFS,
+    /// <summary>
+    /// S3 file system.
+    /// </summary>
+    S3 = tiledb_filesystem_t.TILEDB_S3,
+    /// <summary>
+    /// Azure filesystem.
+    /// </summary>
+    Azure = tiledb_filesystem_t.TILEDB_AZURE,
+    /// <summary>
+    /// Google Cloud Storage file system.
+    /// </summary>
+    GoogleCloudStorage = tiledb_filesystem_t.TILEDB_GCS,
+    /// <summary>
+    /// In-memory file system.
+    /// </summary>
+    InMemory = tiledb_filesystem_t.TILEDB_MEMFS
+}
+
+/// <summary>
+/// Specifies the data type of entities such as <see cref="Dimension"/>s, <see cref="Attribute"/>s,
+/// <see cref="ArrayMetadata"/> and <see cref="GroupMetadata"/>.
+/// </summary>
+public enum DataType : uint
+{
+    /// <summary>
+    /// A signed 32-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="int"/>.
+    /// </remarks>
+    Int32 = tiledb_datatype_t.TILEDB_INT32,
+    /// <summary>
+    /// A signed 64-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    Int64 = tiledb_datatype_t.TILEDB_INT64,
+    /// <summary>
+    /// A 32-bit floating-point number.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="float"/>.
+    /// </remarks>
+    Float32 = tiledb_datatype_t.TILEDB_FLOAT32,
+    /// <summary>
+    /// A 64-bit floating-point number.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="double"/>.
+    /// </remarks>
+    Float64 = tiledb_datatype_t.TILEDB_FLOAT64,
+    /// <summary>
+    /// A signed 8-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="sbyte"/>.
+    /// </remarks>
+    Int8 = tiledb_datatype_t.TILEDB_INT8,
+    /// <summary>
+    /// An unsigned 8-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="byte"/>.
+    /// </remarks>
+    UInt8 = tiledb_datatype_t.TILEDB_UINT8,
+    /// <summary>
+    /// A signed 16-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="short"/>.
+    /// </remarks>
+    Int16 = tiledb_datatype_t.TILEDB_INT16,
+    /// <summary>
+    /// An unsigned 16-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="ushort"/>.
+    /// </remarks>
+    UInt16 = tiledb_datatype_t.TILEDB_UINT16,
+    /// <summary>
+    /// An unsigned 32-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="uint"/>.
+    /// </remarks>
+    UInt32 = tiledb_datatype_t.TILEDB_UINT32,
+    /// <summary>
+    /// An unsigned 64-bit integer.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="ulong"/>.
+    /// </remarks>
+    UInt64 = tiledb_datatype_t.TILEDB_UINT64,
+    /// <summary>
+    /// An ASCII string.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="byte"/>.
+    /// </remarks>
+    StringAscii = tiledb_datatype_t.TILEDB_STRING_ASCII,
+    /// <summary>
+    /// A UTF-8 string.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="byte"/>.
+    /// </remarks>
+    StringUtf8 = tiledb_datatype_t.TILEDB_STRING_UTF8,
+    /// <summary>
+    /// A UTF-16 string.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="ushort"/> or <see cref="char"/>.
+    /// </remarks>
+    StringUtf16 = tiledb_datatype_t.TILEDB_STRING_UTF16,
+    /// <summary>
+    /// A UTF-32 string.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="uint"/>.
+    /// </remarks>
+    StringUtf32 = tiledb_datatype_t.TILEDB_STRING_UTF32,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// years since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    DateTimeYear = tiledb_datatype_t.TILEDB_DATETIME_YEAR,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// months since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    DateTimeMonth = tiledb_datatype_t.TILEDB_DATETIME_MONTH,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// weeks since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    DateTimeWeek = tiledb_datatype_t.TILEDB_DATETIME_WEEK,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// days since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    DateTimeDay = tiledb_datatype_t.TILEDB_DATETIME_DAY,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// hours since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    DateTimeHour = tiledb_datatype_t.TILEDB_DATETIME_HR,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// minutes since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    DateTimeMinute = tiledb_datatype_t.TILEDB_DATETIME_MIN,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// seconds since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    DateTimeSecond = tiledb_datatype_t.TILEDB_DATETIME_SEC,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// milliseconds since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    DateTimeMillisecond = tiledb_datatype_t.TILEDB_DATETIME_MS,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// microseconds since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    DateTimeMicrosecond = tiledb_datatype_t.TILEDB_DATETIME_US,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// nanoseconds since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    DateTimeNanosecond = tiledb_datatype_t.TILEDB_DATETIME_NS,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// picoseconds since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One second consists of one trillion picoseconds.
+    /// </para>
+    /// <para>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </para>
+    /// </remarks>
+    DateTimePicosecond = tiledb_datatype_t.TILEDB_DATETIME_PS,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// femtoseconds since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One second consists of one quadrillion femtoseconds.
+    /// </para>
+    /// <para>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </para>
+    /// </remarks>
+    DateTimeFemtosecond = tiledb_datatype_t.TILEDB_DATETIME_FS,
+    /// <summary>
+    /// A date and time, counted as the signed 64-bit number of
+    /// attoseconds since the Unix epoch (January 1 1970 at midnight).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One second consists of one quintillion attoseconds.
+    /// </para>
+    /// <para>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </para>
+    /// </remarks>
+    DateTimeAttosecond = tiledb_datatype_t.TILEDB_DATETIME_AS,
+    /// <summary>
+    /// A time of day counted in hours.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    TimeHour = tiledb_datatype_t.TILEDB_TIME_HR,
+    /// <summary>
+    /// A time of day counted in minutes.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    TimeMinute = tiledb_datatype_t.TILEDB_TIME_MIN,
+    /// <summary>
+    /// A time of day counted in seconds.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    TimeSecond = tiledb_datatype_t.TILEDB_TIME_SEC,
+    /// <summary>
+    /// A time of day counted in milliseconds.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    TimeMillisecond = tiledb_datatype_t.TILEDB_TIME_MS,
+    /// <summary>
+    /// A time of day counted in microseconds.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    TimeMicrosecond = tiledb_datatype_t.TILEDB_TIME_US,
+    /// <summary>
+    /// A time of day counted in nanoseconds.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="long"/>.
+    /// </remarks>
+    TimeNanosecond = tiledb_datatype_t.TILEDB_TIME_NS,
+    /// <summary>
+    /// A time of day counted in picoseconds.
+    /// </summary>
+    TimePicosecond = tiledb_datatype_t.TILEDB_TIME_PS,
+    /// <summary>
+    /// A time of day counted in femtoseconds.
+    /// </summary>
+    TimeFemtosecond = tiledb_datatype_t.TILEDB_TIME_FS,
+    /// <summary>
+    /// A time of day counted in attoseconds.
+    /// </summary>
+    TimeAttosecond = tiledb_datatype_t.TILEDB_TIME_AS,
+    /// <summary>
+    /// Binary data.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="byte"/>.
+    /// </remarks>
+    Blob = tiledb_datatype_t.TILEDB_BLOB,
+    /// <summary>
+    /// A boolean value.
+    /// </summary>
+    /// <remarks>
+    /// On generic methods operating to objects of this datatype,
+    /// this datatype can be used with <see cref="byte"/> or <see cref="bool"/>.
+    /// </remarks>
+    Boolean = tiledb_datatype_t.TILEDB_BOOL
+}
+
+/// <summary>
+/// Specifies the type of an <see cref="Array"/>.
+/// </summary>
+public enum ArrayType : uint
+{
+    /// <summary>
+    /// The array is dense.
+    /// </summary>
+    Dense = tiledb_array_type_t.TILEDB_DENSE,
+    /// <summary>
+    /// The array is sparse.
+    /// </summary>
+    Sparse = tiledb_array_type_t.TILEDB_SPARSE
+}
+
+/// <summary>
+/// Specifies the order of data stored in an <see cref="Array"/>
+/// or sent or retrieved from a <see cref="Query"/>.
+/// </summary>
+public enum LayoutType : uint
+{
+    /// <summary>
+    /// Data are in row-major order.
+    /// </summary>
+    RowMajor = tiledb_layout_t.TILEDB_ROW_MAJOR,
+    /// <summary>
+    /// Data are in column-major order.
+    /// </summary>
+    ColumnMajor = tiledb_layout_t.TILEDB_COL_MAJOR,
+    /// <summary>
+    /// Data are in global order.
+    /// </summary>
+    GlobalOrder = tiledb_layout_t.TILEDB_GLOBAL_ORDER,
+    /// <summary>
+    /// Data are unordered.
+    /// </summary>
+    // TODO: Make them more explanatory.
+    Unordered = tiledb_layout_t.TILEDB_UNORDERED,
+    /// <summary>
+    /// Data are ordered according to a Hilbert curve.
+    /// </summary>
+    Hilbert = tiledb_layout_t.TILEDB_HILBERT
+}
+
+/// <summary>
+/// Specifies the type of a <see cref="Filter"/>.
+/// </summary>
+public enum FilterType : uint
+{
+    /// <summary>
+    /// No-op filter.
+    /// </summary>
+    None = tiledb_filter_type_t.TILEDB_FILTER_NONE,
+    /// <summary>
+    /// Gzip compressor.
+    /// </summary>
+    Gzip = tiledb_filter_type_t.TILEDB_FILTER_GZIP,
+    /// <summary>
+    /// Zstandard compressor.
+    /// </summary>
+    Zstandard = tiledb_filter_type_t.TILEDB_FILTER_ZSTD,
+    /// <summary>
+    /// LZ4 compressor.
+    /// </summary>
+    Lz4 = tiledb_filter_type_t.TILEDB_FILTER_LZ4,
+    /// <summary>
+    /// Run-length encoding compressor.
+    /// </summary>
+    RunLengthEncoding = tiledb_filter_type_t.TILEDB_FILTER_RLE,
+    /// <summary>
+    /// Bzip2 compressor.
+    /// </summary>
+    Bzip2 = tiledb_filter_type_t.TILEDB_FILTER_BZIP2,
+    /// <summary>
+    /// Double-delta compressor.
+    /// </summary>
+    DoubleDelta = tiledb_filter_type_t.TILEDB_FILTER_DOUBLE_DELTA,
+    /// <summary>
+    /// Bit width reduction filter.
+    /// </summary>
+    BitWidthReduction = tiledb_filter_type_t.TILEDB_FILTER_BIT_WIDTH_REDUCTION,
+    /// <summary>
+    /// Bit shuffle filter.
+    /// </summary>
+    BitShuffle = tiledb_filter_type_t.TILEDB_FILTER_BITSHUFFLE,
+    /// <summary>
+    /// Byte shuffle filter.
+    /// </summary>
+    ByteShuffle = tiledb_filter_type_t.TILEDB_FILTER_BYTESHUFFLE,
+    /// <summary>
+    /// Positive delta filter.
+    /// </summary>
+    PositiveDelta = tiledb_filter_type_t.TILEDB_FILTER_POSITIVE_DELTA,
+    /// <summary>
+    /// MD5 checksum filter.
+    /// </summary>
+    ChecksumMd5 = tiledb_filter_type_t.TILEDB_FILTER_CHECKSUM_MD5,
+    /// <summary>
+    /// SHA-256 checksum filter.
+    /// </summary>
+    ChecksumSha256 = tiledb_filter_type_t.TILEDB_FILTER_CHECKSUM_SHA256,
+    /// <summary>
+    /// Dictionary encoding filter.
+    /// </summary>
+    Dictionary = tiledb_filter_type_t.TILEDB_FILTER_DICTIONARY,
+    /// <summary>
+    /// Float scaling filter.
+    /// </summary>
+    ScaleFloat = tiledb_filter_type_t.TILEDB_FILTER_SCALE_FLOAT,
+    /// <summary>
+    /// XOR filter.
+    /// </summary>
+    Xor = tiledb_filter_type_t.TILEDB_FILTER_XOR,
+    /// <summary>
+    /// WebP filter.
+    /// </summary>
+    Webp = tiledb_filter_type_t.TILEDB_FILTER_WEBP,
+    /// <summary>
+    /// Delta filter.
+    /// </summary>
+    Delta = tiledb_filter_type_t.TILEDB_FILTER_DELTA
+}
+
+public enum FilterOption : uint
+{
+    CompressionLevel = tiledb_filter_option_t.TILEDB_COMPRESSION_LEVEL,
+    BitWidthMaxWindow = tiledb_filter_option_t.TILEDB_BIT_WIDTH_MAX_WINDOW,
+    PositiveDeltaMaxWindow = tiledb_filter_option_t.TILEDB_POSITIVE_DELTA_MAX_WINDOW,
+    ScaleFloatByteWidth = tiledb_filter_option_t.TILEDB_SCALE_FLOAT_BYTEWIDTH,
+    ScaleFloatFactor = tiledb_filter_option_t.TILEDB_SCALE_FLOAT_FACTOR,
+    ScaleFloatOffset = tiledb_filter_option_t.TILEDB_SCALE_FLOAT_OFFSET,
+    /// <summary>
+    /// The WebP filter's compression quality.
+    /// </summary>
+    /// <remarks>
+    /// Must be a <see cref="float"/> between 1 and 100.
+    /// </remarks>
+    WebpQuality = tiledb_filter_option_t.TILEDB_WEBP_QUALITY,
+    /// <summary>
+    /// The WebP filter's input format.
+    /// </summary>
+    /// <remarks>
+    /// Must be a <see cref="WebpInputFormat"/>.
+    /// </remarks>
+    WebpInputFormat = tiledb_filter_option_t.TILEDB_WEBP_INPUT_FORMAT,
+    /// <summary>
+    /// Whether the WebP filter should perform lossless compression.
+    /// </summary>
+    /// <remarks>
+    /// Must be a <see cref="bool"/>.
+    /// </remarks>
+    WebpLossless = tiledb_filter_option_t.TILEDB_WEBP_LOSSLESS,
+    /// <summary>
+    /// The type to reinterpret data prior to compression.
+    /// </summary>
+    /// <remarks>
+    /// Must be a <see cref="DataType"/>.
+    /// </remarks>
+    // Documentation of the C API says this is a uint8_t. In the C# API, DataType is a UInt32
+    // but passing a pointer to the latter as the former will work on little-endian systems.
+    CompressionReinterpretDatatype = tiledb_filter_option_t.TILEDB_COMPRESSION_REINTERPRET_DATATYPE
+}
+
+/// <summary>
+/// Specifies an image format type for the WebP filter.
+/// </summary>
+/// <seealso cref="FilterOption.WebpInputFormat"/>
+public enum WebpInputFormat : byte
+{
+    /// <summary>
+    /// Unspecified format.
+    /// </summary>
+    Unspecified = tiledb_filter_webp_format_t.TILEDB_WEBP_NONE,
+    /// <summary>
+    /// RGB format.
+    /// </summary>
+    Rgb = tiledb_filter_webp_format_t.TILEDB_WEBP_RGB,
+    /// <summary>
+    /// BGR format.
+    /// </summary>
+    Bgr = tiledb_filter_webp_format_t.TILEDB_WEBP_BGR,
+    /// <summary>
+    /// RGBA format.
+    /// </summary>
+    Rgba = tiledb_filter_webp_format_t.TILEDB_WEBP_RGBA,
+    /// <summary>
+    /// BGRA format.
+    /// </summary>
+    Bgra = tiledb_filter_webp_format_t.TILEDB_WEBP_BGRA,
+}
+
+/// <summary>
+/// Specifies the kind of data encryption in an <see cref="Array"/>.
+/// </summary>
+public enum EncryptionType : uint
+{
+    /// <summary>
+    /// Data are not encrypted.
+    /// </summary>
+    NoEncryption = tiledb_encryption_type_t.TILEDB_NO_ENCRYPTION,
+    /// <summary>
+    /// Data are encrypted using the AES-256 block cipher in Galois Counter Mode (GCM).
+    /// </summary>
+    Aes256Gcm = tiledb_encryption_type_t.TILEDB_AES_256_GCM
+}
+
+/// <summary>
+/// Specifies the order objects are walked.
+/// </summary>
+public enum WalkOrderType : uint
+{
+    /// <summary>
+    /// The objects are walked in pre-order.
+    /// </summary>
+    PreOrder = tiledb_walk_order_t.TILEDB_PREORDER,
+    /// <summary>
+    /// The objects are walked in post-order.
+    /// </summary>
+    PostOrder = tiledb_walk_order_t.TILEDB_POSTORDER
+}
+
+/// <summary>
+/// Specifies the mode in which a <see cref="VFSFile"/> is opened.
+/// </summary>
+/// <seealso cref="VFS.Open"/>
+public enum VfsMode : uint
+{
+    /// <summary>
+    /// The file is opened for reading.
+    /// An exception will be thrown if it does not exist.
+    /// </summary>
+    Read = tiledb_vfs_mode_t.TILEDB_VFS_READ,
+    /// <summary>
+    /// The file is opened for writing.
+    /// If it exists, it will be overwritten.
+    /// </summary>
+    Write = tiledb_vfs_mode_t.TILEDB_VFS_WRITE,
+    /// <summary>
+    /// The file is opened for writing.
+    /// If it exists, the write will start from its end.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="FileSystemType.S3"/> does not support this
+    /// operation and, thus, an exception will be thrown in that case.
+    /// </remarks>
+    Append = tiledb_vfs_mode_t.TILEDB_VFS_APPEND
+}
+
+/// <summary>
+/// Specifies a MIME type.
+/// </summary>
+public enum MIMEType : uint
+{
+    /// <summary>
+    /// <c>application/pdf</c>
+    /// </summary>
+    Pdf = tiledb_mime_type_t.TILEDB_MIME_PDF,
+    /// <summary>
+    /// <c>image/tiff</c>
+    /// </summary>
+    Tiff = tiledb_mime_type_t.TILEDB_MIME_TIFF,
+    /// <summary>
+    /// Unspecified MIME type.
+    /// </summary>
+    AutoDetect = tiledb_mime_type_t.TILEDB_MIME_AUTODETECT
+}
+
+/// <summary>
+/// Specifies where a <see cref="QueryField"/> came from.
+/// </summary>
+public enum QueryFieldOrigin : uint
+{
+    /// <summary>
+    /// The field is an attribute from the array schema.
+    /// </summary>
+    Attribute,
+    /// <summary>
+    /// The field is a dimension from the array schema.
+    /// </summary>
+    Dimension,
+    /// <summary>
+    /// The field is an aggregate value, computed at the time the query is executed.
+    /// </summary>
+    Aggregate
+}
+
+public static class Constants
+{
+    /// <summary>
+    /// Referenced by <see cref="Attribute.VariableSized"/>
+    /// and <see cref="Dimension.VariableSized"/>.
+    /// </summary>
+    internal const uint VariableSizedImpl = uint.MaxValue;
+
+    #region File Api
+    public const string METADATA_SIZE_KEY = "file_size";
+    public const string FILE_DIMENSION_NAME = "position";
+    public const string FILE_ATTRIBUTE_NAME = "contents";
+    public const string FILE_METADATA_MIME_TYPE_KEY = "mime";
+    public const string FILE_METADATA_MIME_ENCODING_KEY = "mime_encoding";
+    public const string METADATA_ORIGINAL_FILE_NAME = "original_file_name";
+    #endregion File Api
+}
+
+/// <summary>
+/// Contains utility functions that operate on the library's enum types.
+/// </summary>
+public static unsafe class EnumUtil
+{
+    /// <summary>
+    /// Get string of QueryType.
+    /// </summary>
+    /// <param name="queryType"></param>
+    /// <returns></returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string QueryTypeToStr(QueryType queryType)
     {
-        TILEDB_OOM = -2,
-        TILEDB_ERR = -1,
-        TILEDB_OK = 0
+        tiledb_query_type_t tiledb_query_type = (tiledb_query_type_t)queryType;
+        sbyte* result;
+        Methods.tiledb_query_type_to_str(tiledb_query_type, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
     }
 
     /// <summary>
-    /// Specifies the type of a TileDB object.
+    /// Get QueryType from string.
     /// </summary>
-    public enum ObjectType : uint
+    /// <param name="str"></param>
+    /// <returns></returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static QueryType QueryTypeFromStr(string str)
     {
-        /// <summary>
-        /// Invalid object.
-        /// </summary>
-        Invalid = tiledb_object_t.TILEDB_INVALID,
-        /// <summary>
-        /// The object is a <see cref="Group"/>.
-        /// </summary>
-        Group = tiledb_object_t.TILEDB_GROUP,
-        /// <summary>
-        /// The object is an <see cref="Array"/>.
-        /// </summary>
-        Array = tiledb_object_t.TILEDB_ARRAY
+        tiledb_query_type_t tiledb_query_type;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_query_type_from_str(ms_str, &tiledb_query_type);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.QueryTypeFromStr, Invalid string:" + str);
+            }
+        }
+        return (QueryType)tiledb_query_type;
     }
 
     /// <summary>
-    /// Specifies the type of a <see cref="Query"/>.
+    /// Get string of ObjectType.
     /// </summary>
-    public enum QueryType : uint
+    /// <param name="objectType"></param>
+    /// <returns></returns>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string ObjectTypeToStr(ObjectType objectType)
     {
-        /// <summary>
-        /// Read query.
-        /// </summary>
-        Read = tiledb_query_type_t.TILEDB_READ,
-        /// <summary>
-        /// Write query.
-        /// </summary>
-        Write = tiledb_query_type_t.TILEDB_WRITE,
-        Delete = tiledb_query_type_t.TILEDB_DELETE,
-        Update = tiledb_query_type_t.TILEDB_UPDATE,
-        ModifyExclusive = tiledb_query_type_t.TILEDB_MODIFY_EXCLUSIVE
+        tiledb_object_t tiledb_object = (tiledb_object_t)objectType;
+        sbyte* result;
+        Methods.tiledb_object_type_to_str(tiledb_object, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static ObjectType ObjectTypeFromStr(string str)
+    {
+        tiledb_object_t tiledb_object;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_object_type_from_str(ms_str, &tiledb_object);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.ObjectTypeFromStr, Invalid string:" + str);
+            }
+        }
+        return (ObjectType)tiledb_object;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string FileSystemTypeToStr(FileSystemType fileSystemType)
+    {
+        tiledb_filesystem_t tiledb_filesystem = (tiledb_filesystem_t)fileSystemType;
+        sbyte* result;
+        Methods.tiledb_filesystem_to_str(tiledb_filesystem, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static FileSystemType FileSystemTypeFromStr(string str)
+    {
+        tiledb_filesystem_t tiledb_filesystem;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_filesystem_from_str(ms_str, &tiledb_filesystem);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.FileSystemTypeFromStr, Invalid string:" + str);
+            }
+        }
+        return (FileSystemType)tiledb_filesystem;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string DataTypeToStr(DataType dataType)
+    {
+        tiledb_datatype_t tiledb_datatype = (tiledb_datatype_t)dataType;
+        sbyte* result;
+        Methods.tiledb_datatype_to_str(tiledb_datatype, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static DataType DataTypeFromStr(string str)
+    {
+        tiledb_datatype_t tiledb_datatype;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_datatype_from_str(ms_str, &tiledb_datatype);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.DataTypeFromStr, Invalid string:" + str);
+            }
+        }
+        return (DataType)tiledb_datatype;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string ArrayTypeToStr(ArrayType arrayType)
+    {
+        tiledb_array_type_t tiledb_arraytype = (tiledb_array_type_t)arrayType;
+        sbyte* result;
+        Methods.tiledb_array_type_to_str(tiledb_arraytype, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static ArrayType ArrayTypeFromStr(string str)
+    {
+        tiledb_array_type_t tiledb_arraytype;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_array_type_from_str(ms_str, &tiledb_arraytype);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.ArrayTypeFromStr, Invalid string:" + str);
+            }
+        }
+        return (ArrayType)tiledb_arraytype;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string LayoutTypeToStr(LayoutType layoutType)
+    {
+        tiledb_layout_t tiledb_layout = (tiledb_layout_t)layoutType;
+        sbyte* result;
+        Methods.tiledb_layout_to_str(tiledb_layout, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static LayoutType LayoutTypeFromStr(string str)
+    {
+        tiledb_layout_t tiledb_layout;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_layout_from_str(ms_str, &tiledb_layout);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.LayoutTypeFromStr, Invalid string:" + str);
+            }
+        }
+        return (LayoutType)tiledb_layout;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string FilterTypeToStr(FilterType filterType)
+    {
+        tiledb_filter_type_t tiledb_filtertype = (tiledb_filter_type_t)filterType;
+        sbyte* result;
+        Methods.tiledb_filter_type_to_str(tiledb_filtertype, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static FilterType FilterTypeFromStr(string str)
+    {
+        tiledb_filter_type_t tiledb_filtertype;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_filter_type_from_str(ms_str, &tiledb_filtertype);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.FilterTypeFromStr, Invalid string:" + str);
+            }
+        }
+        return (FilterType)tiledb_filtertype;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string FilterOptionToStr(FilterOption filterOption)
+    {
+        tiledb_filter_option_t tiledb_filteroption = (tiledb_filter_option_t)filterOption;
+        sbyte* result;
+        Methods.tiledb_filter_option_to_str(tiledb_filteroption, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static FilterOption FilterOptionFromStr(string str)
+    {
+        tiledb_filter_option_t tiledb_filteroption;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_filter_option_from_str(ms_str, &tiledb_filteroption);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.FilterOptionFromStr, Invalid string:" + str);
+            }
+        }
+        return (FilterOption)tiledb_filteroption;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string EncryptionTypeToStr(EncryptionType encryptionType)
+    {
+        tiledb_encryption_type_t tiledb_encryptiontype = (tiledb_encryption_type_t)encryptionType;
+        sbyte* result;
+        Methods.tiledb_encryption_type_to_str(tiledb_encryptiontype, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static EncryptionType EncryptionTypeFromStr(string str)
+    {
+        tiledb_encryption_type_t tiledb_encryptiontype;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_encryption_type_from_str(ms_str, &tiledb_encryptiontype);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.EncryptionTypeFromStr, Invalid string:" + str);
+            }
+        }
+        return (EncryptionType)tiledb_encryptiontype;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string QueryStatusToStr(QueryStatus queryStatus)
+    {
+        tiledb_query_status_t tiledb_querystatus = (tiledb_query_status_t)queryStatus;
+        sbyte* result;
+        Methods.tiledb_query_status_to_str(tiledb_querystatus, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static QueryStatus QueryStatusFromStr(string str)
+    {
+        tiledb_query_status_t tiledb_querystatus;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_query_status_from_str(ms_str, &tiledb_querystatus);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.QueryStatusFromStr, Invalid string:" + str);
+            }
+        }
+        return (QueryStatus)tiledb_querystatus;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string WalkOrderTypeToStr(WalkOrderType walkOrderType)
+    {
+        tiledb_walk_order_t tiledb_walkorder = (tiledb_walk_order_t)walkOrderType;
+        sbyte* result;
+        Methods.tiledb_walk_order_to_str(tiledb_walkorder, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static WalkOrderType WalkOrderTypeFromStr(string str)
+    {
+        tiledb_walk_order_t tiledb_walkorder;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_walk_order_from_str(ms_str, &tiledb_walkorder);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new System.ArgumentException("EnumUtil.WalkOrderFromStr, Invalid string:" + str);
+            }
+        }
+        return (WalkOrderType)tiledb_walkorder;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static string VfsModeToStr(VfsMode vfsMode)
+    {
+        tiledb_vfs_mode_t tiledb_vfsmode = (tiledb_vfs_mode_t)vfsMode;
+        sbyte* result;
+        Methods.tiledb_vfs_mode_to_str(tiledb_vfsmode, &result);
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static VfsMode VfsModeFromStr(string str)
+    {
+        tiledb_vfs_mode_t tiledb_vfsmode;
+        using var ms_str = new MarshaledString(str);
+        unsafe
+        {
+            int status = Methods.tiledb_vfs_mode_from_str(ms_str, &tiledb_vfsmode);
+            if (status != (int)Status.TILEDB_OK)
+            {
+                throw new ArgumentException("EnumUtil.VfsModeFromStr, Invalid string:" + str);
+            }
+        }
+        return (VfsMode)tiledb_vfsmode;
     }
 
     /// <summary>
-    /// Specifies the status of a <see cref="Query"/>.
+    /// Converts a <see cref="Type"/> to a <see cref="DataType"/> enum value.
     /// </summary>
-    public enum QueryStatus : uint
+    /// <param name="t">The type to convert.</param>
+    /// <exception cref="NotSupportedException"><paramref name="t"/> is unsupported.</exception>
+    [Obsolete(Obsoletions.DataTypeTypeConversionsMessage, DiagnosticId = Obsoletions.DataTypeTypeConversionsDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+    public static DataType TypeToDataType(Type t)
     {
-        /// <summary>
-        /// The query failed.
-        /// </summary>
-        Failed = tiledb_query_status_t.TILEDB_FAILED,
-        /// <summary>
-        /// The query completed and all data has been read.
-        /// </summary>
-        Completed = tiledb_query_status_t.TILEDB_COMPLETED,
-        /// <summary>
-        /// The query is in process.
-        /// </summary>
-        InProgress = tiledb_query_status_t.TILEDB_INPROGRESS,
-        /// <summary>
-        /// The query completed but not all data has been read.
-        /// </summary>
-        Incomplete = tiledb_query_status_t.TILEDB_INCOMPLETE,
-        /// <summary>
-        /// The query is not initialized.
-        /// </summary>
-        Uninitialized = tiledb_query_status_t.TILEDB_UNINITIALIZED,
-        /// <summary>
-        /// The query is initialized.
-        /// </summary>
-        Initialized = tiledb_query_status_t.TILEDB_INITIALIZED
+        if (t == typeof(int))
+        {
+            return DataType.Int32;
+        }
+        else if (t == typeof(long))
+        {
+            return DataType.Int64;
+        }
+        else if (t == typeof(float))
+        {
+            return DataType.Float32;
+        }
+        else if (t == typeof(double))
+        {
+            return DataType.Float64;
+        }
+        else if (t == typeof(byte))
+        {
+            return DataType.UInt8;
+        }
+        else if (t == typeof(sbyte))
+        {
+            return DataType.Int8;
+        }
+        else if (t == typeof(short))
+        {
+            return DataType.Int16;
+        }
+        else if (t == typeof(ushort))
+        {
+            return DataType.UInt16;
+        }
+        else if (t == typeof(uint))
+        {
+            return DataType.UInt32;
+        }
+        else if (t == typeof(ulong))
+        {
+            return DataType.UInt64;
+        }
+        else if (t == typeof(string))
+        {
+            return DataType.StringAscii;
+        }
+        else if (t == typeof(bool))
+        {
+            return DataType.Boolean;
+        }
+        else
+        {
+            ThrowHelpers.ThrowTypeNotSupported();
+            return default; // unreachable
+        }
     }
 
-    /// <summary>
-    /// Specifies the reason a <see cref="Query"/> cannot proceed.
-    /// </summary>
-    public enum QueryStatusDetailsReason : uint
+    [Obsolete(Obsoletions.DataTypeTypeConversionsMessage, DiagnosticId = Obsoletions.DataTypeTypeConversionsDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+    public static Type DataTypeToType(DataType datatype)
     {
-        /// <summary>
-        /// There is no reason. This is the default value.
-        /// </summary>
-        None = tiledb_query_status_details_reason_t.TILEDB_REASON_NONE,
-        /// <summary>
-        /// The user-provided buffers are too small and need to be resized.
-        /// </summary>
-        UserBufferSize = tiledb_query_status_details_reason_t.TILEDB_REASON_USER_BUFFER_SIZE,
-        /// <summary>
-        /// The memory budget was exceeded. The query can be submitted again without resizing the buffers.
-        /// </summary>
-        MemoryBudget = tiledb_query_status_details_reason_t.TILEDB_REASON_MEMORY_BUDGET,
+        switch (datatype)
+        {
+            case DataType.DateTimeAttosecond:
+            case DataType.DateTimeDay:
+            case DataType.DateTimeFemtosecond:
+            case DataType.DateTimeHour:
+            case DataType.DateTimeMinute:
+            case DataType.DateTimeMonth:
+            case DataType.DateTimeMillisecond:
+            case DataType.DateTimeNanosecond:
+            case DataType.DateTimePicosecond:
+            case DataType.DateTimeSecond:
+            case DataType.DateTimeMicrosecond:
+            case DataType.DateTimeWeek:
+            case DataType.DateTimeYear:
+                return typeof(long);
+            case DataType.Float32:
+                return typeof(float);
+            case DataType.Float64:
+                return typeof(double);
+            case DataType.Int16:
+                return typeof(short);
+            case DataType.Int32:
+                return typeof(int);
+            case DataType.Int64:
+                return typeof(long);
+            case DataType.Int8:
+                return typeof(sbyte);
+            case DataType.StringAscii:
+            case DataType.StringUtf16:
+            case DataType.StringUtf32:
+            case DataType.StringUtf8:
+                return typeof(sbyte);
+            case DataType.TimeAttosecond:
+            case DataType.TimeFemtosecond:
+            case DataType.TimeHour:
+            case DataType.TimeMinute:
+            case DataType.TimeMillisecond:
+            case DataType.TimeNanosecond:
+            case DataType.TimePicosecond:
+            case DataType.TimeSecond:
+            case DataType.TimeMicrosecond:
+                return typeof(long);
+            case DataType.UInt16:
+                return typeof(ushort);
+            case DataType.UInt32:
+                return typeof(uint);
+            case DataType.UInt64:
+                return typeof(ulong);
+            case DataType.UInt8:
+                return typeof(byte);
+            case DataType.Blob:
+                return typeof(byte);
+            case DataType.Boolean:
+                return typeof(byte);
+            default:
+                return typeof(byte);
+        }
     }
 
-    /// <summary>
-    /// Specifies the relation type of a <see cref="QueryCondition"/> between its attribute and its value.
-    /// </summary>
-    public enum QueryConditionOperatorType : uint
+    // Same with DataTypeToType, but returns the correct corresponding numeric type for strings.
+    internal static Type DataTypeToNumericType(DataType datatype)
     {
-        /// <summary>
-        /// The attribute is less than the value.
-        /// </summary>
-        LessThan = tiledb_query_condition_op_t.TILEDB_LT,
-        /// <summary>
-        /// The attribute is less than or equal to the value.
-        /// </summary>
-        LessThanOrEqual = tiledb_query_condition_op_t.TILEDB_LE,
-        /// <summary>
-        /// The attribute is greater than the value.
-        /// </summary>
-        GreaterThan = tiledb_query_condition_op_t.TILEDB_GT,
-        /// <summary>
-        /// The attribute is greater than or equal to the value.
-        /// </summary>
-        GreaterThanOrEqual = tiledb_query_condition_op_t.TILEDB_GE,
-        /// <summary>
-        /// The attribute is equal to the value.
-        /// </summary>
-        Equal = tiledb_query_condition_op_t.TILEDB_EQ,
-        /// <summary>
-        /// The attribute is not equal to the value.
-        /// </summary>
-        NotEqual = tiledb_query_condition_op_t.TILEDB_NE
+        switch (datatype)
+        {
+            case DataType.DateTimeAttosecond:
+            case DataType.DateTimeDay:
+            case DataType.DateTimeFemtosecond:
+            case DataType.DateTimeHour:
+            case DataType.DateTimeMinute:
+            case DataType.DateTimeMonth:
+            case DataType.DateTimeMillisecond:
+            case DataType.DateTimeNanosecond:
+            case DataType.DateTimePicosecond:
+            case DataType.DateTimeSecond:
+            case DataType.DateTimeMicrosecond:
+            case DataType.DateTimeWeek:
+            case DataType.DateTimeYear:
+                return typeof(long);
+            case DataType.Float32:
+                return typeof(float);
+            case DataType.Float64:
+                return typeof(double);
+            case DataType.Int16:
+                return typeof(short);
+            case DataType.Int32:
+                return typeof(int);
+            case DataType.Int64:
+                return typeof(long);
+            case DataType.Int8:
+                return typeof(sbyte);
+            case DataType.StringAscii:
+            case DataType.StringUtf8:
+                return typeof(byte);
+            case DataType.StringUtf16:
+                return typeof(ushort);
+            case DataType.StringUtf32:
+                return typeof(uint);
+            case DataType.TimeAttosecond:
+            case DataType.TimeFemtosecond:
+            case DataType.TimeHour:
+            case DataType.TimeMinute:
+            case DataType.TimeMillisecond:
+            case DataType.TimeNanosecond:
+            case DataType.TimePicosecond:
+            case DataType.TimeSecond:
+            case DataType.TimeMicrosecond:
+                return typeof(long);
+            case DataType.UInt16:
+                return typeof(ushort);
+            case DataType.UInt32:
+                return typeof(uint);
+            case DataType.UInt64:
+                return typeof(ulong);
+            case DataType.UInt8:
+                return typeof(byte);
+            case DataType.Blob:
+                return typeof(byte);
+            case DataType.Boolean:
+                return typeof(byte);
+            default:
+                return typeof(byte);
+        }
     }
 
-    /// <summary>
-    /// Specifies the combination operator type of one or two <see cref="QueryCondition"/>s.
-    /// </summary>
-    public enum QueryConditionCombinationOperatorType : uint
+    public static bool IsStringType(DataType datatype)
     {
-        /// <summary>
-        /// Both conditions must be satisfied.
-        /// </summary>
-        And = tiledb_query_condition_combination_op_t.TILEDB_AND,
-        /// <summary>
-        /// Either of the two conditions must be satisfied.
-        /// </summary>
-        Or = tiledb_query_condition_combination_op_t.TILEDB_OR,
-        /// <summary>
-        /// The condition must not be satisfied.
-        /// </summary>
-        Not = tiledb_query_condition_combination_op_t.TILEDB_NOT
+        return datatype == DataType.StringAscii
+            || datatype == DataType.StringUtf16
+            || datatype == DataType.StringUtf32
+            || datatype == DataType.StringUtf8;
     }
 
-    /// <summary>
-    /// Specifies the type of a TileDB file system.
-    /// </summary>
-    public enum FileSystemType : uint
-    {
-        /// <summary>
-        /// HDFS (Hadoop File System) file system.
-        /// </summary>
-        Hdfs = tiledb_filesystem_t.TILEDB_HDFS,
-        /// <summary>
-        /// S3 file system.
-        /// </summary>
-        S3 = tiledb_filesystem_t.TILEDB_S3,
-        /// <summary>
-        /// Azure filesystem.
-        /// </summary>
-        Azure = tiledb_filesystem_t.TILEDB_AZURE,
-        /// <summary>
-        /// Google Cloud Storage file system.
-        /// </summary>
-        GoogleCloudStorage = tiledb_filesystem_t.TILEDB_GCS,
-        /// <summary>
-        /// In-memory file system.
-        /// </summary>
-        InMemory = tiledb_filesystem_t.TILEDB_MEMFS
-    }
-
-    /// <summary>
-    /// Specifies the data type of entities such as <see cref="Dimension"/>s, <see cref="Attribute"/>s,
-    /// <see cref="ArrayMetadata"/> and <see cref="GroupMetadata"/>.
-    /// </summary>
-    public enum DataType : uint
-    {
-        /// <summary>
-        /// A signed 32-bit integer.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="int"/>.
-        /// </remarks>
-        Int32 = tiledb_datatype_t.TILEDB_INT32,
-        /// <summary>
-        /// A signed 64-bit integer.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        Int64 = tiledb_datatype_t.TILEDB_INT64,
-        /// <summary>
-        /// A 32-bit floating-point number.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="float"/>.
-        /// </remarks>
-        Float32 = tiledb_datatype_t.TILEDB_FLOAT32,
-        /// <summary>
-        /// A 64-bit floating-point number.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="double"/>.
-        /// </remarks>
-        Float64 = tiledb_datatype_t.TILEDB_FLOAT64,
-        /// <summary>
-        /// A signed 8-bit integer.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="sbyte"/>.
-        /// </remarks>
-        Int8 = tiledb_datatype_t.TILEDB_INT8,
-        /// <summary>
-        /// An unsigned 8-bit integer.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="byte"/>.
-        /// </remarks>
-        UInt8 = tiledb_datatype_t.TILEDB_UINT8,
-        /// <summary>
-        /// A signed 16-bit integer.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="short"/>.
-        /// </remarks>
-        Int16 = tiledb_datatype_t.TILEDB_INT16,
-        /// <summary>
-        /// An unsigned 16-bit integer.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="ushort"/>.
-        /// </remarks>
-        UInt16 = tiledb_datatype_t.TILEDB_UINT16,
-        /// <summary>
-        /// An unsigned 32-bit integer.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="uint"/>.
-        /// </remarks>
-        UInt32 = tiledb_datatype_t.TILEDB_UINT32,
-        /// <summary>
-        /// An unsigned 64-bit integer.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="ulong"/>.
-        /// </remarks>
-        UInt64 = tiledb_datatype_t.TILEDB_UINT64,
-        /// <summary>
-        /// An ASCII string.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="byte"/>.
-        /// </remarks>
-        StringAscii = tiledb_datatype_t.TILEDB_STRING_ASCII,
-        /// <summary>
-        /// A UTF-8 string.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="byte"/>.
-        /// </remarks>
-        StringUtf8 = tiledb_datatype_t.TILEDB_STRING_UTF8,
-        /// <summary>
-        /// A UTF-16 string.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="ushort"/> or <see cref="char"/>.
-        /// </remarks>
-        StringUtf16 = tiledb_datatype_t.TILEDB_STRING_UTF16,
-        /// <summary>
-        /// A UTF-32 string.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="uint"/>.
-        /// </remarks>
-        StringUtf32 = tiledb_datatype_t.TILEDB_STRING_UTF32,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// years since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        DateTimeYear = tiledb_datatype_t.TILEDB_DATETIME_YEAR,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// months since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        DateTimeMonth = tiledb_datatype_t.TILEDB_DATETIME_MONTH,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// weeks since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        DateTimeWeek = tiledb_datatype_t.TILEDB_DATETIME_WEEK,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// days since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        DateTimeDay = tiledb_datatype_t.TILEDB_DATETIME_DAY,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// hours since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        DateTimeHour = tiledb_datatype_t.TILEDB_DATETIME_HR,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// minutes since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        DateTimeMinute = tiledb_datatype_t.TILEDB_DATETIME_MIN,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// seconds since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        DateTimeSecond = tiledb_datatype_t.TILEDB_DATETIME_SEC,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// milliseconds since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        DateTimeMillisecond = tiledb_datatype_t.TILEDB_DATETIME_MS,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// microseconds since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        DateTimeMicrosecond = tiledb_datatype_t.TILEDB_DATETIME_US,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// nanoseconds since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        DateTimeNanosecond = tiledb_datatype_t.TILEDB_DATETIME_NS,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// picoseconds since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// One second consists of one trillion picoseconds.
-        /// </para>
-        /// <para>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </para>
-        /// </remarks>
-        DateTimePicosecond = tiledb_datatype_t.TILEDB_DATETIME_PS,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// femtoseconds since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// One second consists of one quadrillion femtoseconds.
-        /// </para>
-        /// <para>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </para>
-        /// </remarks>
-        DateTimeFemtosecond = tiledb_datatype_t.TILEDB_DATETIME_FS,
-        /// <summary>
-        /// A date and time, counted as the signed 64-bit number of
-        /// attoseconds since the Unix epoch (January 1 1970 at midnight).
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// One second consists of one quintillion attoseconds.
-        /// </para>
-        /// <para>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </para>
-        /// </remarks>
-        DateTimeAttosecond = tiledb_datatype_t.TILEDB_DATETIME_AS,
-        /// <summary>
-        /// A time of day counted in hours.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        TimeHour = tiledb_datatype_t.TILEDB_TIME_HR,
-        /// <summary>
-        /// A time of day counted in minutes.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        TimeMinute = tiledb_datatype_t.TILEDB_TIME_MIN,
-        /// <summary>
-        /// A time of day counted in seconds.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        TimeSecond = tiledb_datatype_t.TILEDB_TIME_SEC,
-        /// <summary>
-        /// A time of day counted in milliseconds.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        TimeMillisecond = tiledb_datatype_t.TILEDB_TIME_MS,
-        /// <summary>
-        /// A time of day counted in microseconds.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        TimeMicrosecond = tiledb_datatype_t.TILEDB_TIME_US,
-        /// <summary>
-        /// A time of day counted in nanoseconds.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="long"/>.
-        /// </remarks>
-        TimeNanosecond = tiledb_datatype_t.TILEDB_TIME_NS,
-        /// <summary>
-        /// A time of day counted in picoseconds.
-        /// </summary>
-        TimePicosecond = tiledb_datatype_t.TILEDB_TIME_PS,
-        /// <summary>
-        /// A time of day counted in femtoseconds.
-        /// </summary>
-        TimeFemtosecond = tiledb_datatype_t.TILEDB_TIME_FS,
-        /// <summary>
-        /// A time of day counted in attoseconds.
-        /// </summary>
-        TimeAttosecond = tiledb_datatype_t.TILEDB_TIME_AS,
-        /// <summary>
-        /// Binary data.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="byte"/>.
-        /// </remarks>
-        Blob = tiledb_datatype_t.TILEDB_BLOB,
-        /// <summary>
-        /// A boolean value.
-        /// </summary>
-        /// <remarks>
-        /// On generic methods operating to objects of this datatype,
-        /// this datatype can be used with <see cref="byte"/> or <see cref="bool"/>.
-        /// </remarks>
-        Boolean = tiledb_datatype_t.TILEDB_BOOL
-    }
-
-    /// <summary>
-    /// Specifies the type of an <see cref="Array"/>.
-    /// </summary>
-    public enum ArrayType : uint
-    {
-        /// <summary>
-        /// The array is dense.
-        /// </summary>
-        Dense = tiledb_array_type_t.TILEDB_DENSE,
-        /// <summary>
-        /// The array is sparse.
-        /// </summary>
-        Sparse = tiledb_array_type_t.TILEDB_SPARSE
-    }
-
-    /// <summary>
-    /// Specifies the order of data stored in an <see cref="Array"/>
-    /// or sent or retrieved from a <see cref="Query"/>.
-    /// </summary>
-    public enum LayoutType : uint
-    {
-        /// <summary>
-        /// Data are in row-major order.
-        /// </summary>
-        RowMajor = tiledb_layout_t.TILEDB_ROW_MAJOR,
-        /// <summary>
-        /// Data are in column-major order.
-        /// </summary>
-        ColumnMajor = tiledb_layout_t.TILEDB_COL_MAJOR,
-        /// <summary>
-        /// Data are in global order.
-        /// </summary>
-        GlobalOrder = tiledb_layout_t.TILEDB_GLOBAL_ORDER,
-        /// <summary>
-        /// Data are unordered.
-        /// </summary>
-        // TODO: Make them more explanatory.
-        Unordered = tiledb_layout_t.TILEDB_UNORDERED,
-        /// <summary>
-        /// Data are ordered according to a Hilbert curve.
-        /// </summary>
-        Hilbert = tiledb_layout_t.TILEDB_HILBERT
-    }
-
-    /// <summary>
-    /// Specifies the type of a <see cref="Filter"/>.
-    /// </summary>
-    public enum FilterType : uint
-    {
-        /// <summary>
-        /// No-op filter.
-        /// </summary>
-        None = tiledb_filter_type_t.TILEDB_FILTER_NONE,
-        /// <summary>
-        /// Gzip compressor.
-        /// </summary>
-        Gzip = tiledb_filter_type_t.TILEDB_FILTER_GZIP,
-        /// <summary>
-        /// Zstandard compressor.
-        /// </summary>
-        Zstandard = tiledb_filter_type_t.TILEDB_FILTER_ZSTD,
-        /// <summary>
-        /// LZ4 compressor.
-        /// </summary>
-        Lz4 = tiledb_filter_type_t.TILEDB_FILTER_LZ4,
-        /// <summary>
-        /// Run-length encoding compressor.
-        /// </summary>
-        RunLengthEncoding = tiledb_filter_type_t.TILEDB_FILTER_RLE,
-        /// <summary>
-        /// Bzip2 compressor.
-        /// </summary>
-        Bzip2 = tiledb_filter_type_t.TILEDB_FILTER_BZIP2,
-        /// <summary>
-        /// Double-delta compressor.
-        /// </summary>
-        DoubleDelta = tiledb_filter_type_t.TILEDB_FILTER_DOUBLE_DELTA,
-        /// <summary>
-        /// Bit width reduction filter.
-        /// </summary>
-        BitWidthReduction = tiledb_filter_type_t.TILEDB_FILTER_BIT_WIDTH_REDUCTION,
-        /// <summary>
-        /// Bit shuffle filter.
-        /// </summary>
-        BitShuffle = tiledb_filter_type_t.TILEDB_FILTER_BITSHUFFLE,
-        /// <summary>
-        /// Byte shuffle filter.
-        /// </summary>
-        ByteShuffle = tiledb_filter_type_t.TILEDB_FILTER_BYTESHUFFLE,
-        /// <summary>
-        /// Positive delta filter.
-        /// </summary>
-        PositiveDelta = tiledb_filter_type_t.TILEDB_FILTER_POSITIVE_DELTA,
-        /// <summary>
-        /// MD5 checksum filter.
-        /// </summary>
-        ChecksumMd5 = tiledb_filter_type_t.TILEDB_FILTER_CHECKSUM_MD5,
-        /// <summary>
-        /// SHA-256 checksum filter.
-        /// </summary>
-        ChecksumSha256 = tiledb_filter_type_t.TILEDB_FILTER_CHECKSUM_SHA256,
-        /// <summary>
-        /// Dictionary encoding filter.
-        /// </summary>
-        Dictionary = tiledb_filter_type_t.TILEDB_FILTER_DICTIONARY,
-        /// <summary>
-        /// Float scaling filter.
-        /// </summary>
-        ScaleFloat = tiledb_filter_type_t.TILEDB_FILTER_SCALE_FLOAT,
-        /// <summary>
-        /// XOR filter.
-        /// </summary>
-        Xor = tiledb_filter_type_t.TILEDB_FILTER_XOR,
-        /// <summary>
-        /// WebP filter.
-        /// </summary>
-        Webp = tiledb_filter_type_t.TILEDB_FILTER_WEBP,
-        /// <summary>
-        /// Delta filter.
-        /// </summary>
-        Delta = tiledb_filter_type_t.TILEDB_FILTER_DELTA
-    }
-
-    public enum FilterOption : uint
-    {
-        CompressionLevel = tiledb_filter_option_t.TILEDB_COMPRESSION_LEVEL,
-        BitWidthMaxWindow = tiledb_filter_option_t.TILEDB_BIT_WIDTH_MAX_WINDOW,
-        PositiveDeltaMaxWindow = tiledb_filter_option_t.TILEDB_POSITIVE_DELTA_MAX_WINDOW,
-        ScaleFloatByteWidth = tiledb_filter_option_t.TILEDB_SCALE_FLOAT_BYTEWIDTH,
-        ScaleFloatFactor = tiledb_filter_option_t.TILEDB_SCALE_FLOAT_FACTOR,
-        ScaleFloatOffset = tiledb_filter_option_t.TILEDB_SCALE_FLOAT_OFFSET,
-        /// <summary>
-        /// The WebP filter's compression quality.
-        /// </summary>
-        /// <remarks>
-        /// Must be a <see cref="float"/> between 1 and 100.
-        /// </remarks>
-        WebpQuality = tiledb_filter_option_t.TILEDB_WEBP_QUALITY,
-        /// <summary>
-        /// The WebP filter's input format.
-        /// </summary>
-        /// <remarks>
-        /// Must be a <see cref="WebpInputFormat"/>.
-        /// </remarks>
-        WebpInputFormat = tiledb_filter_option_t.TILEDB_WEBP_INPUT_FORMAT,
-        /// <summary>
-        /// Whether the WebP filter should perform lossless compression.
-        /// </summary>
-        /// <remarks>
-        /// Must be a <see cref="bool"/>.
-        /// </remarks>
-        WebpLossless = tiledb_filter_option_t.TILEDB_WEBP_LOSSLESS,
-        /// <summary>
-        /// The type to reinterpret data prior to compression.
-        /// </summary>
-        /// <remarks>
-        /// Must be a <see cref="DataType"/>.
-        /// </remarks>
-        // Documentation of the C API says this is a uint8_t. In the C# API, DataType is a UInt32
-        // but passing a pointer to the latter as the former will work on little-endian systems.
-        CompressionReinterpretDatatype = tiledb_filter_option_t.TILEDB_COMPRESSION_REINTERPRET_DATATYPE
-    }
-
-    /// <summary>
-    /// Specifies an image format type for the WebP filter.
-    /// </summary>
-    /// <seealso cref="FilterOption.WebpInputFormat"/>
-    public enum WebpInputFormat : byte
-    {
-        /// <summary>
-        /// Unspecified format.
-        /// </summary>
-        Unspecified = tiledb_filter_webp_format_t.TILEDB_WEBP_NONE,
-        /// <summary>
-        /// RGB format.
-        /// </summary>
-        Rgb = tiledb_filter_webp_format_t.TILEDB_WEBP_RGB,
-        /// <summary>
-        /// BGR format.
-        /// </summary>
-        Bgr = tiledb_filter_webp_format_t.TILEDB_WEBP_BGR,
-        /// <summary>
-        /// RGBA format.
-        /// </summary>
-        Rgba = tiledb_filter_webp_format_t.TILEDB_WEBP_RGBA,
-        /// <summary>
-        /// BGRA format.
-        /// </summary>
-        Bgra = tiledb_filter_webp_format_t.TILEDB_WEBP_BGRA,
-    }
-
-    /// <summary>
-    /// Specifies the kind of data encryption in an <see cref="Array"/>.
-    /// </summary>
-    public enum EncryptionType : uint
-    {
-        /// <summary>
-        /// Data are not encrypted.
-        /// </summary>
-        NoEncryption = tiledb_encryption_type_t.TILEDB_NO_ENCRYPTION,
-        /// <summary>
-        /// Data are encrypted using the AES-256 block cipher in Galois Counter Mode (GCM).
-        /// </summary>
-        Aes256Gcm = tiledb_encryption_type_t.TILEDB_AES_256_GCM
-    }
-
-    /// <summary>
-    /// Specifies the order objects are walked.
-    /// </summary>
-    public enum WalkOrderType : uint
-    {
-        /// <summary>
-        /// The objects are walked in pre-order.
-        /// </summary>
-        PreOrder = tiledb_walk_order_t.TILEDB_PREORDER,
-        /// <summary>
-        /// The objects are walked in post-order.
-        /// </summary>
-        PostOrder = tiledb_walk_order_t.TILEDB_POSTORDER
-    }
-
-    /// <summary>
-    /// Specifies the mode in which a <see cref="VFSFile"/> is opened.
-    /// </summary>
-    /// <seealso cref="VFS.Open"/>
-    public enum VfsMode : uint
-    {
-        /// <summary>
-        /// The file is opened for reading.
-        /// An exception will be thrown if it does not exist.
-        /// </summary>
-        Read = tiledb_vfs_mode_t.TILEDB_VFS_READ,
-        /// <summary>
-        /// The file is opened for writing.
-        /// If it exists, it will be overwritten.
-        /// </summary>
-        Write = tiledb_vfs_mode_t.TILEDB_VFS_WRITE,
-        /// <summary>
-        /// The file is opened for writing.
-        /// If it exists, the write will start from its end.
-        /// </summary>
-        /// <remarks>
-        /// <see cref="FileSystemType.S3"/> does not support this
-        /// operation and, thus, an exception will be thrown in that case.
-        /// </remarks>
-        Append = tiledb_vfs_mode_t.TILEDB_VFS_APPEND
-    }
-
-    /// <summary>
-    /// Specifies a MIME type.
-    /// </summary>
-    public enum MIMEType : uint
-    {
-        /// <summary>
-        /// <c>application/pdf</c>
-        /// </summary>
-        Pdf = tiledb_mime_type_t.TILEDB_MIME_PDF,
-        /// <summary>
-        /// <c>image/tiff</c>
-        /// </summary>
-        Tiff = tiledb_mime_type_t.TILEDB_MIME_TIFF,
-        /// <summary>
-        /// Unspecified MIME type.
-        /// </summary>
-        AutoDetect = tiledb_mime_type_t.TILEDB_MIME_AUTODETECT
-    }
-
-    /// <summary>
-    /// Specifies where a <see cref="QueryField"/> came from.
-    /// </summary>
-    public enum QueryFieldOrigin : uint
-    {
-        /// <summary>
-        /// The field is an attribute from the array schema.
-        /// </summary>
-        Attribute,
-        /// <summary>
-        /// The field is a dimension from the array schema.
-        /// </summary>
-        Dimension,
-        /// <summary>
-        /// The field is an aggregate value, computed at the time the query is executed.
-        /// </summary>
-        Aggregate
-    }
-
-    public static class Constants
-    {
-        /// <summary>
-        /// Referenced by <see cref="Attribute.VariableSized"/>
-        /// and <see cref="Dimension.VariableSized"/>.
-        /// </summary>
-        internal const uint VariableSizedImpl = uint.MaxValue;
-
-        #region File Api
-        public const string METADATA_SIZE_KEY = "file_size";
-        public const string FILE_DIMENSION_NAME = "position";
-        public const string FILE_ATTRIBUTE_NAME = "contents";
-        public const string FILE_METADATA_MIME_TYPE_KEY = "mime";
-        public const string FILE_METADATA_MIME_ENCODING_KEY = "mime_encoding";
-        public const string METADATA_ORIGINAL_FILE_NAME = "original_file_name";
-        #endregion File Api
-    }
-
-    /// <summary>
-    /// Contains utility functions that operate on the library's enum types.
-    /// </summary>
-    public static unsafe class EnumUtil
-    {
-        /// <summary>
-        /// Get string of QueryType.
-        /// </summary>
-        /// <param name="queryType"></param>
-        /// <returns></returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string QueryTypeToStr(QueryType queryType)
-        {
-            tiledb_query_type_t tiledb_query_type = (tiledb_query_type_t)queryType;
-            sbyte* result;
-            Methods.tiledb_query_type_to_str(tiledb_query_type, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        /// <summary>
-        /// Get QueryType from string.
-        /// </summary>
-        /// <param name="str"></param>
-        /// <returns></returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static QueryType QueryTypeFromStr(string str)
-        {
-            tiledb_query_type_t tiledb_query_type;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_query_type_from_str(ms_str, &tiledb_query_type);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.QueryTypeFromStr, Invalid string:" + str);
-                }
-            }
-            return (QueryType)tiledb_query_type;
-        }
-
-        /// <summary>
-        /// Get string of ObjectType.
-        /// </summary>
-        /// <param name="objectType"></param>
-        /// <returns></returns>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string ObjectTypeToStr(ObjectType objectType)
-        {
-            tiledb_object_t tiledb_object = (tiledb_object_t)objectType;
-            sbyte* result;
-            Methods.tiledb_object_type_to_str(tiledb_object, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static ObjectType ObjectTypeFromStr(string str)
-        {
-            tiledb_object_t tiledb_object;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_object_type_from_str(ms_str, &tiledb_object);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.ObjectTypeFromStr, Invalid string:" + str);
-                }
-            }
-            return (ObjectType)tiledb_object;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string FileSystemTypeToStr(FileSystemType fileSystemType)
-        {
-            tiledb_filesystem_t tiledb_filesystem = (tiledb_filesystem_t)fileSystemType;
-            sbyte* result;
-            Methods.tiledb_filesystem_to_str(tiledb_filesystem, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static FileSystemType FileSystemTypeFromStr(string str)
-        {
-            tiledb_filesystem_t tiledb_filesystem;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_filesystem_from_str(ms_str, &tiledb_filesystem);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.FileSystemTypeFromStr, Invalid string:" + str);
-                }
-            }
-            return (FileSystemType)tiledb_filesystem;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string DataTypeToStr(DataType dataType)
-        {
-            tiledb_datatype_t tiledb_datatype = (tiledb_datatype_t)dataType;
-            sbyte* result;
-            Methods.tiledb_datatype_to_str(tiledb_datatype, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static DataType DataTypeFromStr(string str)
-        {
-            tiledb_datatype_t tiledb_datatype;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_datatype_from_str(ms_str, &tiledb_datatype);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.DataTypeFromStr, Invalid string:" + str);
-                }
-            }
-            return (DataType)tiledb_datatype;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string ArrayTypeToStr(ArrayType arrayType)
-        {
-            tiledb_array_type_t tiledb_arraytype = (tiledb_array_type_t)arrayType;
-            sbyte* result;
-            Methods.tiledb_array_type_to_str(tiledb_arraytype, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static ArrayType ArrayTypeFromStr(string str)
-        {
-            tiledb_array_type_t tiledb_arraytype;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_array_type_from_str(ms_str, &tiledb_arraytype);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.ArrayTypeFromStr, Invalid string:" + str);
-                }
-            }
-            return (ArrayType)tiledb_arraytype;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string LayoutTypeToStr(LayoutType layoutType)
-        {
-            tiledb_layout_t tiledb_layout = (tiledb_layout_t)layoutType;
-            sbyte* result;
-            Methods.tiledb_layout_to_str(tiledb_layout, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static LayoutType LayoutTypeFromStr(string str)
-        {
-            tiledb_layout_t tiledb_layout;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_layout_from_str(ms_str, &tiledb_layout);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.LayoutTypeFromStr, Invalid string:" + str);
-                }
-            }
-            return (LayoutType)tiledb_layout;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string FilterTypeToStr(FilterType filterType)
-        {
-            tiledb_filter_type_t tiledb_filtertype = (tiledb_filter_type_t)filterType;
-            sbyte* result;
-            Methods.tiledb_filter_type_to_str(tiledb_filtertype, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static FilterType FilterTypeFromStr(string str)
-        {
-            tiledb_filter_type_t tiledb_filtertype;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_filter_type_from_str(ms_str, &tiledb_filtertype);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.FilterTypeFromStr, Invalid string:" + str);
-                }
-            }
-            return (FilterType)tiledb_filtertype;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string FilterOptionToStr(FilterOption filterOption)
-        {
-            tiledb_filter_option_t tiledb_filteroption = (tiledb_filter_option_t)filterOption;
-            sbyte* result;
-            Methods.tiledb_filter_option_to_str(tiledb_filteroption, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static FilterOption FilterOptionFromStr(string str)
-        {
-            tiledb_filter_option_t tiledb_filteroption;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_filter_option_from_str(ms_str, &tiledb_filteroption);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.FilterOptionFromStr, Invalid string:" + str);
-                }
-            }
-            return (FilterOption)tiledb_filteroption;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string EncryptionTypeToStr(EncryptionType encryptionType)
-        {
-            tiledb_encryption_type_t tiledb_encryptiontype = (tiledb_encryption_type_t)encryptionType;
-            sbyte* result;
-            Methods.tiledb_encryption_type_to_str(tiledb_encryptiontype, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static EncryptionType EncryptionTypeFromStr(string str)
-        {
-            tiledb_encryption_type_t tiledb_encryptiontype;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_encryption_type_from_str(ms_str, &tiledb_encryptiontype);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.EncryptionTypeFromStr, Invalid string:" + str);
-                }
-            }
-            return (EncryptionType)tiledb_encryptiontype;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string QueryStatusToStr(QueryStatus queryStatus)
-        {
-            tiledb_query_status_t tiledb_querystatus = (tiledb_query_status_t)queryStatus;
-            sbyte* result;
-            Methods.tiledb_query_status_to_str(tiledb_querystatus, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static QueryStatus QueryStatusFromStr(string str)
-        {
-            tiledb_query_status_t tiledb_querystatus;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_query_status_from_str(ms_str, &tiledb_querystatus);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.QueryStatusFromStr, Invalid string:" + str);
-                }
-            }
-            return (QueryStatus)tiledb_querystatus;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string WalkOrderTypeToStr(WalkOrderType walkOrderType)
-        {
-            tiledb_walk_order_t tiledb_walkorder = (tiledb_walk_order_t)walkOrderType;
-            sbyte* result;
-            Methods.tiledb_walk_order_to_str(tiledb_walkorder, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static WalkOrderType WalkOrderTypeFromStr(string str)
-        {
-            tiledb_walk_order_t tiledb_walkorder;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_walk_order_from_str(ms_str, &tiledb_walkorder);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("EnumUtil.WalkOrderFromStr, Invalid string:" + str);
-                }
-            }
-            return (WalkOrderType)tiledb_walkorder;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static string VfsModeToStr(VfsMode vfsMode)
-        {
-            tiledb_vfs_mode_t tiledb_vfsmode = (tiledb_vfs_mode_t)vfsMode;
-            sbyte* result;
-            Methods.tiledb_vfs_mode_to_str(tiledb_vfsmode, &result);
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static VfsMode VfsModeFromStr(string str)
-        {
-            tiledb_vfs_mode_t tiledb_vfsmode;
-            using var ms_str = new MarshaledString(str);
-            unsafe
-            {
-                int status = Methods.tiledb_vfs_mode_from_str(ms_str, &tiledb_vfsmode);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new ArgumentException("EnumUtil.VfsModeFromStr, Invalid string:" + str);
-                }
-            }
-            return (VfsMode)tiledb_vfsmode;
-        }
-
-        /// <summary>
-        /// Converts a <see cref="Type"/> to a <see cref="DataType"/> enum value.
-        /// </summary>
-        /// <param name="t">The type to convert.</param>
-        /// <exception cref="NotSupportedException"><paramref name="t"/> is unsupported.</exception>
-        [Obsolete(Obsoletions.DataTypeTypeConversionsMessage, DiagnosticId = Obsoletions.DataTypeTypeConversionsDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
-        public static DataType TypeToDataType(Type t)
-        {
-            if (t == typeof(int))
-            {
-                return DataType.Int32;
-            }
-            else if (t == typeof(long))
-            {
-                return DataType.Int64;
-            }
-            else if (t == typeof(float))
-            {
-                return DataType.Float32;
-            }
-            else if (t == typeof(double))
-            {
-                return DataType.Float64;
-            }
-            else if (t == typeof(byte))
-            {
-                return DataType.UInt8;
-            }
-            else if (t == typeof(sbyte))
-            {
-                return DataType.Int8;
-            }
-            else if (t == typeof(short))
-            {
-                return DataType.Int16;
-            }
-            else if (t == typeof(ushort))
-            {
-                return DataType.UInt16;
-            }
-            else if (t == typeof(uint))
-            {
-                return DataType.UInt32;
-            }
-            else if (t == typeof(ulong))
-            {
-                return DataType.UInt64;
-            }
-            else if (t == typeof(string))
-            {
-                return DataType.StringAscii;
-            }
-            else if (t == typeof(bool))
-            {
-                return DataType.Boolean;
-            }
-            else
-            {
-                ThrowHelpers.ThrowTypeNotSupported();
-                return default; // unreachable
-            }
-        }
-
-        [Obsolete(Obsoletions.DataTypeTypeConversionsMessage, DiagnosticId = Obsoletions.DataTypeTypeConversionsDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
-        public static Type DataTypeToType(DataType datatype)
-        {
-            switch (datatype)
-            {
-                case DataType.DateTimeAttosecond:
-                case DataType.DateTimeDay:
-                case DataType.DateTimeFemtosecond:
-                case DataType.DateTimeHour:
-                case DataType.DateTimeMinute:
-                case DataType.DateTimeMonth:
-                case DataType.DateTimeMillisecond:
-                case DataType.DateTimeNanosecond:
-                case DataType.DateTimePicosecond:
-                case DataType.DateTimeSecond:
-                case DataType.DateTimeMicrosecond:
-                case DataType.DateTimeWeek:
-                case DataType.DateTimeYear:
-                    return typeof(long);
-                case DataType.Float32:
-                    return typeof(float);
-                case DataType.Float64:
-                    return typeof(double);
-                case DataType.Int16:
-                    return typeof(short);
-                case DataType.Int32:
-                    return typeof(int);
-                case DataType.Int64:
-                    return typeof(long);
-                case DataType.Int8:
-                    return typeof(sbyte);
-                case DataType.StringAscii:
-                case DataType.StringUtf16:
-                case DataType.StringUtf32:
-                case DataType.StringUtf8:
-                    return typeof(sbyte);
-                case DataType.TimeAttosecond:
-                case DataType.TimeFemtosecond:
-                case DataType.TimeHour:
-                case DataType.TimeMinute:
-                case DataType.TimeMillisecond:
-                case DataType.TimeNanosecond:
-                case DataType.TimePicosecond:
-                case DataType.TimeSecond:
-                case DataType.TimeMicrosecond:
-                    return typeof(long);
-                case DataType.UInt16:
-                    return typeof(ushort);
-                case DataType.UInt32:
-                    return typeof(uint);
-                case DataType.UInt64:
-                    return typeof(ulong);
-                case DataType.UInt8:
-                    return typeof(byte);
-                case DataType.Blob:
-                    return typeof(byte);
-                case DataType.Boolean:
-                    return typeof(byte);
-                default:
-                    return typeof(byte);
-            }
-        }
-
-        // Same with DataTypeToType, but returns the correct corresponding numeric type for strings.
-        internal static Type DataTypeToNumericType(DataType datatype)
-        {
-            switch (datatype)
-            {
-                case DataType.DateTimeAttosecond:
-                case DataType.DateTimeDay:
-                case DataType.DateTimeFemtosecond:
-                case DataType.DateTimeHour:
-                case DataType.DateTimeMinute:
-                case DataType.DateTimeMonth:
-                case DataType.DateTimeMillisecond:
-                case DataType.DateTimeNanosecond:
-                case DataType.DateTimePicosecond:
-                case DataType.DateTimeSecond:
-                case DataType.DateTimeMicrosecond:
-                case DataType.DateTimeWeek:
-                case DataType.DateTimeYear:
-                    return typeof(long);
-                case DataType.Float32:
-                    return typeof(float);
-                case DataType.Float64:
-                    return typeof(double);
-                case DataType.Int16:
-                    return typeof(short);
-                case DataType.Int32:
-                    return typeof(int);
-                case DataType.Int64:
-                    return typeof(long);
-                case DataType.Int8:
-                    return typeof(sbyte);
-                case DataType.StringAscii:
-                case DataType.StringUtf8:
-                    return typeof(byte);
-                case DataType.StringUtf16:
-                    return typeof(ushort);
-                case DataType.StringUtf32:
-                    return typeof(uint);
-                case DataType.TimeAttosecond:
-                case DataType.TimeFemtosecond:
-                case DataType.TimeHour:
-                case DataType.TimeMinute:
-                case DataType.TimeMillisecond:
-                case DataType.TimeNanosecond:
-                case DataType.TimePicosecond:
-                case DataType.TimeSecond:
-                case DataType.TimeMicrosecond:
-                    return typeof(long);
-                case DataType.UInt16:
-                    return typeof(ushort);
-                case DataType.UInt32:
-                    return typeof(uint);
-                case DataType.UInt64:
-                    return typeof(ulong);
-                case DataType.UInt8:
-                    return typeof(byte);
-                case DataType.Blob:
-                    return typeof(byte);
-                case DataType.Boolean:
-                    return typeof(byte);
-                default:
-                    return typeof(byte);
-            }
-        }
-
-        public static bool IsStringType(DataType datatype)
-        {
-            return datatype == DataType.StringAscii
-                || datatype == DataType.StringUtf16
-                || datatype == DataType.StringUtf32
-                || datatype == DataType.StringUtf8;
-        }
-
-        public static ulong DataTypeSize(DataType datatype) =>
-            Methods.tiledb_datatype_size((tiledb_datatype_t)datatype);
-    }
+    public static ulong DataTypeSize(DataType datatype) =>
+        Methods.tiledb_datatype_size((tiledb_datatype_t)datatype);
 }

--- a/sources/TileDB.CSharp/ErrorHandling.cs
+++ b/sources/TileDB.CSharp/ErrorHandling.cs
@@ -5,90 +5,89 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using TileDB.Interop;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+internal static class ErrorHandling
 {
-    internal static class ErrorHandling
+    public static void ThrowIfNull([NotNull] object? obj, [CallerArgumentExpression(nameof(obj))] string? paramName = null)
     {
-        public static void ThrowIfNull([NotNull] object? obj, [CallerArgumentExpression(nameof(obj))] string? paramName = null)
+        if (obj == null)
         {
-            if (obj == null)
-            {
-                ThrowHelpers.ThrowArgumentNull(paramName);
-            }
+            ThrowHelpers.ThrowArgumentNull(paramName);
+        }
+    }
+
+    public static void ThrowOnError(int errorCode)
+    {
+        if (errorCode == (int)Status.TILEDB_OK)
+        {
+            return;
+        }
+        throw new TileDBException($"Operation failed with error code {errorCode}.") { StatusCode = errorCode };
+    }
+
+    public static unsafe void CheckLastError(tiledb_error_t** error, int status)
+    {
+        if (status == (int)Status.TILEDB_OK)
+        {
+            Debug.Assert(*error is null);
+            return;
         }
 
-        public static void ThrowOnError(int errorCode)
+        ThrowLastError(error, status);
+
+        [DoesNotReturn]
+        static void ThrowLastError(tiledb_error_t** error, int status)
         {
-            if (errorCode == (int)Status.TILEDB_OK)
-            {
-                return;
-            }
-            throw new TileDBException($"Operation failed with error code {errorCode}.") { StatusCode = errorCode };
+            sbyte* messagePtr;
+            int messageResult = Methods.tiledb_error_message(*error, &messagePtr);
+            Debug.Assert(messageResult == (int)Status.TILEDB_OK);
+            string message = MarshaledStringOut.GetStringFromNullTerminated(messagePtr);
+            Methods.tiledb_error_free(error);
+            throw new TileDBException(message) { StatusCode = status };
         }
+    }
 
-        public static unsafe void CheckLastError(tiledb_error_t** error, int status)
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is managed.</exception>
+    public static void ThrowIfManagedType<T>()
+    {
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
         {
-            if (status == (int)Status.TILEDB_OK)
-            {
-                Debug.Assert(*error is null);
-                return;
-            }
-
-            ThrowLastError(error, status);
-
-            [DoesNotReturn]
-            static void ThrowLastError(tiledb_error_t** error, int status)
-            {
-                sbyte* messagePtr;
-                int messageResult = Methods.tiledb_error_message(*error, &messagePtr);
-                Debug.Assert(messageResult == (int)Status.TILEDB_OK);
-                string message = MarshaledStringOut.GetStringFromNullTerminated(messagePtr);
-                Methods.tiledb_error_free(error);
-                throw new TileDBException(message) { StatusCode = status };
-            }
+            ThrowHelpers.ThrowManagedType();
         }
+    }
 
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is managed.</exception>
-        public static void ThrowIfManagedType<T>()
+    /// <summary>
+    /// Returns whether values of type <typeparamref name="T"/> can be stored or
+    /// retrieved from a TileDB buffer of type <paramref name="dataType"/>.
+    /// </summary>
+    private static unsafe bool AreTypesCompatible<T>(DataType dataType)
+    {
+        if (EnumUtil.DataTypeToNumericType(dataType) == typeof(T))
         {
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
-            {
-                ThrowHelpers.ThrowManagedType();
-            }
+            return true;
         }
-
-        /// <summary>
-        /// Returns whether values of type <typeparamref name="T"/> can be stored or
-        /// retrieved from a TileDB buffer of type <paramref name="dataType"/>.
-        /// </summary>
-        private static unsafe bool AreTypesCompatible<T>(DataType dataType)
+        if (typeof(T) == typeof(bool) && dataType == DataType.Boolean)
         {
-            if (EnumUtil.DataTypeToNumericType(dataType) == typeof(T))
-            {
-                return true;
-            }
-            if (typeof(T) == typeof(bool) && dataType == DataType.Boolean)
-            {
-                return true;
-            }
-            if (typeof(T) == typeof(char) && dataType == DataType.StringUtf16)
-            {
-                return true;
-            }
-            return false;
+            return true;
         }
-
-        /// <summary>
-        /// Throws if values of type <typeparamref name="T"/> cannot be stored or
-        /// retrieved from a TileDB buffer of type <paramref name="dataType"/>.
-        /// </summary>
-        public static void CheckDataType<T>(DataType dataType)
+        if (typeof(T) == typeof(char) && dataType == DataType.StringUtf16)
         {
-            ThrowIfManagedType<T>();
-            if (!AreTypesCompatible<T>(dataType))
-            {
-                ThrowHelpers.ThrowTypeMismatch(dataType);
-            }
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Throws if values of type <typeparamref name="T"/> cannot be stored or
+    /// retrieved from a TileDB buffer of type <paramref name="dataType"/>.
+    /// </summary>
+    public static void CheckDataType<T>(DataType dataType)
+    {
+        ThrowIfManagedType<T>();
+        if (!AreTypesCompatible<T>(dataType))
+        {
+            ThrowHelpers.ThrowTypeMismatch(dataType);
         }
     }
 }

--- a/sources/TileDB.CSharp/File.cs
+++ b/sources/TileDB.CSharp/File.cs
@@ -3,138 +3,137 @@ using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 using ArraySchemaHandle = TileDB.CSharp.Marshalling.SafeHandles.ArraySchemaHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+public sealed unsafe class File
 {
-    public sealed unsafe class File
+    private readonly Context _ctx;
+
+    public File(Context ctx)
     {
-        private readonly Context _ctx;
+        _ctx = ctx;
+    }
 
-        public File(Context ctx)
+    public ArraySchema SchemaCreate(string uri)
+    {
+        var handle = new ArraySchemaHandle();
+        var successful = false;
+        tiledb_array_schema_t* array_schema_p = null;
+        try
         {
-            _ctx = ctx;
-        }
-
-        public ArraySchema SchemaCreate(string uri)
-        {
-            var handle = new ArraySchemaHandle();
-            var successful = false;
-            tiledb_array_schema_t* array_schema_p = null;
-            try
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var ms_uri = new MarshaledString(uri))
             {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var ms_uri = new MarshaledString(uri))
-                {
-                    _ctx.handle_error(Methods.tiledb_filestore_schema_create(ctxHandle, ms_uri, &array_schema_p));
-                }
-                successful = true;
+                _ctx.handle_error(Methods.tiledb_filestore_schema_create(ctxHandle, ms_uri, &array_schema_p));
             }
-            finally
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                if (successful)
-                {
-                    handle.InitHandle(array_schema_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.InitHandle(array_schema_p);
             }
-            return new ArraySchema(_ctx, handle);
-        }
-
-        public void URIImport(string arrayURI, string fileURI, MIMEType mimeType)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var ms_arrayURI = new MarshaledString(arrayURI);
-            using var ms_fileURI = new MarshaledString(fileURI);
-            var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
-            _ctx.handle_error(Methods.tiledb_filestore_uri_import(ctxHandle, ms_arrayURI, ms_fileURI, tiledb_mime_type));
-        }
-
-        public void URIExport(string fileURI, string arrayURI)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var ms_fileURI = new MarshaledString(fileURI);
-            using var ms_arrayURI = new MarshaledString(arrayURI);
-            _ctx.handle_error(Methods.tiledb_filestore_uri_export(ctxHandle, ms_fileURI, ms_arrayURI));
-        }
-
-        public void BufferImport<T>(string arrayURI, T value, ulong size, MIMEType mimeType) where T : struct
-        {
-            ErrorHandling.ThrowIfManagedType<T>();
-            if (size > (ulong)sizeof(T))
+            else
             {
-                ThrowHelpers.ThrowTooBigSize(size);
+                handle.SetHandleAsInvalid();
             }
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var ms_arrayURI = new MarshaledString(arrayURI);
-            var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
-            _ctx.handle_error(Methods.tiledb_filestore_buffer_import(
-                ctxHandle,
-                ms_arrayURI,
-                &value,
-                checked((nuint)size),
-                tiledb_mime_type));
         }
+        return new ArraySchema(_ctx, handle);
+    }
 
-        public T BufferExport<T>(string arrayURI, ulong offset, ulong size) where T : struct
+    public void URIImport(string arrayURI, string fileURI, MIMEType mimeType)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var ms_arrayURI = new MarshaledString(arrayURI);
+        using var ms_fileURI = new MarshaledString(fileURI);
+        var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
+        _ctx.handle_error(Methods.tiledb_filestore_uri_import(ctxHandle, ms_arrayURI, ms_fileURI, tiledb_mime_type));
+    }
+
+    public void URIExport(string fileURI, string arrayURI)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var ms_fileURI = new MarshaledString(fileURI);
+        using var ms_arrayURI = new MarshaledString(arrayURI);
+        _ctx.handle_error(Methods.tiledb_filestore_uri_export(ctxHandle, ms_fileURI, ms_arrayURI));
+    }
+
+    public void BufferImport<T>(string arrayURI, T value, ulong size, MIMEType mimeType) where T : struct
+    {
+        ErrorHandling.ThrowIfManagedType<T>();
+        if (size > (ulong)sizeof(T))
         {
-            ErrorHandling.ThrowIfManagedType<T>();
-            if (size > (ulong)sizeof(T))
+            ThrowHelpers.ThrowTooBigSize(size);
+        }
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var ms_arrayURI = new MarshaledString(arrayURI);
+        var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
+        _ctx.handle_error(Methods.tiledb_filestore_buffer_import(
+            ctxHandle,
+            ms_arrayURI,
+            &value,
+            checked((nuint)size),
+            tiledb_mime_type));
+    }
+
+    public T BufferExport<T>(string arrayURI, ulong offset, ulong size) where T : struct
+    {
+        ErrorHandling.ThrowIfManagedType<T>();
+        if (size > (ulong)sizeof(T))
+        {
+            ThrowHelpers.ThrowTooBigSize(size);
+        }
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var ms_arrayURI = new MarshaledString(arrayURI);
+        T result;
+        _ctx.handle_error(Methods.tiledb_filestore_buffer_export(
+            ctxHandle,
+            ms_arrayURI,
+            checked((nuint)offset),
+            &result,
+            checked((nuint)size)));
+
+        return result;
+    }
+
+    public ulong Size(string arrayURI)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var ms_arrayURI = new MarshaledString(arrayURI);
+        nuint size;
+        _ctx.handle_error(Methods.tiledb_filestore_size(
+            ctxHandle,
+            ms_arrayURI,
+            &size));
+
+        return size;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public string MIMETypeToStr(MIMEType mimeType)
+    {
+        var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
+        sbyte* result;
+        Methods.tiledb_mime_type_to_str(tiledb_mime_type, &result);
+
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static MIMEType MIMETypeFromStr(string str)
+    {
+        tiledb_mime_type_t mimeType;
+        using var ms_str = new MarshaledString(str);
+
+        unsafe
+        {
+            int status = TileDB.Interop.Methods.tiledb_mime_type_from_str(ms_str, &mimeType);
+            if (status != (int)Status.TILEDB_OK)
             {
-                ThrowHelpers.ThrowTooBigSize(size);
+                throw new System.ArgumentException("MIMETypeFromStr, Invalid string:" + str);
             }
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var ms_arrayURI = new MarshaledString(arrayURI);
-            T result;
-            _ctx.handle_error(Methods.tiledb_filestore_buffer_export(
-                ctxHandle,
-                ms_arrayURI,
-                checked((nuint)offset),
-                &result,
-                checked((nuint)size)));
-
-            return result;
         }
-
-        public ulong Size(string arrayURI)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var ms_arrayURI = new MarshaledString(arrayURI);
-            nuint size;
-            _ctx.handle_error(Methods.tiledb_filestore_size(
-                ctxHandle,
-                ms_arrayURI,
-                &size));
-
-            return size;
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public string MIMETypeToStr(MIMEType mimeType)
-        {
-            var tiledb_mime_type = (tiledb_mime_type_t)mimeType;
-            sbyte* result;
-            Methods.tiledb_mime_type_to_str(tiledb_mime_type, &result);
-
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public static MIMEType MIMETypeFromStr(string str)
-        {
-            tiledb_mime_type_t mimeType;
-            using var ms_str = new MarshaledString(str);
-
-            unsafe
-            {
-                int status = TileDB.Interop.Methods.tiledb_mime_type_from_str(ms_str, &mimeType);
-                if (status != (int)Status.TILEDB_OK)
-                {
-                    throw new System.ArgumentException("MIMETypeFromStr, Invalid string:" + str);
-                }
-            }
-            return (MIMEType)mimeType;
-        }
+        return (MIMEType)mimeType;
     }
 }

--- a/sources/TileDB.CSharp/FileStoreUtil.cs
+++ b/sources/TileDB.CSharp/FileStoreUtil.cs
@@ -4,77 +4,76 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+public static class FileStoreUtil
 {
-    public static class FileStoreUtil
+    public static void SaveFileToArray(Context ctx, string array_uri, string file)
     {
-        public static void SaveFileToArray(Context ctx, string array_uri, string file)
+        if (string.IsNullOrEmpty(array_uri) || string.IsNullOrEmpty(file))
         {
-            if (string.IsNullOrEmpty(array_uri) || string.IsNullOrEmpty(file))
-            {
-                return;
-            }
-
-            if (ctx == null)
-            {
-                Config cfg = new Config();
-                ctx = new Context(cfg);
-            }
-
-            File f = new File(ctx);
-            var arraySchema = f.SchemaCreate(file);
-            Array.Create(ctx, array_uri, arraySchema);
-            f.URIImport(
-                array_uri,
-                file,
-                MIMEType.AutoDetect
-            );
+            return;
         }
 
-        public static void SaveFileToCloudArray(Context ctx, string name_space, string array_uri, string file)
+        if (ctx == null)
         {
-            if (string.IsNullOrEmpty(name_space) || string.IsNullOrEmpty(array_uri) || string.IsNullOrEmpty(file))
-            {
-                return;
-            }
-
-            if (ctx == null)
-            {
-                Config cfg = new Config();
-                ctx = new Context(cfg);
-            }
-
-            var array_name = array_uri.Split('/').Last();
-            var uri_create = string.Format("tiledb://{0}/{1}", name_space, array_uri);
-            var uri_write = string.Format("tiledb://{0}/{1}", name_space, array_name);
-
-            File f = new File(ctx);
-            var arraySchema = f.SchemaCreate(file);
-            Array.Create(ctx, uri_create, arraySchema);
-            f.URIImport(
-                uri_write,
-                file,
-                MIMEType.AutoDetect
-            );
+            Config cfg = new Config();
+            ctx = new Context(cfg);
         }
 
-        public static void ExportArrayToFile(Context ctx, string file, string array_uri)
-        {
-            if (string.IsNullOrEmpty(array_uri) || string.IsNullOrEmpty(file))
-            {
-                return;
-            }
-            if (ctx == null)
-            {
-                Config cfg = new Config();
-                ctx = new Context(cfg);
-            }
+        File f = new File(ctx);
+        var arraySchema = f.SchemaCreate(file);
+        Array.Create(ctx, array_uri, arraySchema);
+        f.URIImport(
+            array_uri,
+            file,
+            MIMEType.AutoDetect
+        );
+    }
 
-            File f = new File(ctx);
-            f.URIExport(
-                file,
-                array_uri
-            );
+    public static void SaveFileToCloudArray(Context ctx, string name_space, string array_uri, string file)
+    {
+        if (string.IsNullOrEmpty(name_space) || string.IsNullOrEmpty(array_uri) || string.IsNullOrEmpty(file))
+        {
+            return;
         }
+
+        if (ctx == null)
+        {
+            Config cfg = new Config();
+            ctx = new Context(cfg);
+        }
+
+        var array_name = array_uri.Split('/').Last();
+        var uri_create = string.Format("tiledb://{0}/{1}", name_space, array_uri);
+        var uri_write = string.Format("tiledb://{0}/{1}", name_space, array_name);
+
+        File f = new File(ctx);
+        var arraySchema = f.SchemaCreate(file);
+        Array.Create(ctx, uri_create, arraySchema);
+        f.URIImport(
+            uri_write,
+            file,
+            MIMEType.AutoDetect
+        );
+    }
+
+    public static void ExportArrayToFile(Context ctx, string file, string array_uri)
+    {
+        if (string.IsNullOrEmpty(array_uri) || string.IsNullOrEmpty(file))
+        {
+            return;
+        }
+        if (ctx == null)
+        {
+            Config cfg = new Config();
+            ctx = new Context(cfg);
+        }
+
+        File f = new File(ctx);
+        f.URIExport(
+            file,
+            array_uri
+        );
     }
 }

--- a/sources/TileDB.CSharp/Filter.cs
+++ b/sources/TileDB.CSharp/Filter.cs
@@ -5,122 +5,121 @@ using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 using FilterHandle = TileDB.CSharp.Marshalling.SafeHandles.FilterHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+public sealed unsafe class Filter : IDisposable
 {
-    public sealed unsafe class Filter : IDisposable
+
+    private readonly FilterHandle _handle;
+    private readonly Context _ctx;
+    private bool _disposed;
+
+
+    public Filter(Context ctx, FilterType filterType)
     {
+        _ctx = ctx;
+        _handle = FilterHandle.Create(_ctx, (tiledb_filter_type_t)(filterType));
+    }
 
-        private readonly FilterHandle _handle;
-        private readonly Context _ctx;
-        private bool _disposed;
+    internal Filter(Context ctx, FilterHandle handle)
+    {
+        _ctx = ctx;
+        _handle = handle;
+    }
 
 
-        public Filter(Context ctx, FilterType filterType)
+    public void Dispose()
+    {
+        Dispose(true);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing && (!_handle.IsInvalid))
         {
-            _ctx = ctx;
-            _handle = FilterHandle.Create(_ctx, (tiledb_filter_type_t)(filterType));
+            _handle.Dispose();
         }
 
-        internal Filter(Context ctx, FilterHandle handle)
+        _disposed = true;
+    }
+
+    internal FilterHandle Handle => _handle;
+
+    /// <summary>
+    /// Get filter type.
+    /// </summary>
+    /// <returns></returns>
+    public FilterType FilterType()
+    {
+        var tiledb_filter_type= tiledb_filter_type_t.TILEDB_FILTER_NONE;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_filter_get_type(ctxHandle, handle, &tiledb_filter_type));
+        return (FilterType)tiledb_filter_type;
+    }
+
+    /// <summary>
+    /// Check expected type for filter option matches type of T
+    /// </summary>
+    /// <typeparam name="T">Type of filter option value</typeparam>
+    /// <param name="filterOption">Filter option to run type check against</param>
+    /// <exception cref="System.NotSupportedException">Filter option does not support values of type T</exception>
+    private void check_filter_option<T>(FilterOption filterOption)
+    {
+        //check for filter option
+        var ok =
+            (filterOption == FilterOption.CompressionLevel && typeof(T) == typeof(int)) ||
+            (filterOption == FilterOption.BitWidthMaxWindow && typeof(T) == typeof(uint)) ||
+            (filterOption == FilterOption.PositiveDeltaMaxWindow && typeof(T) == typeof(uint)) ||
+            (filterOption == FilterOption.ScaleFloatByteWidth && typeof(T) == typeof(ulong)) ||
+            (filterOption == FilterOption.ScaleFloatFactor && typeof(T) == typeof(double)) ||
+            (filterOption == FilterOption.ScaleFloatOffset && typeof(T) == typeof(double)) ||
+            (filterOption == FilterOption.WebpQuality && typeof(T) == typeof(float)) ||
+            (filterOption == FilterOption.WebpInputFormat && typeof(T) == typeof(WebpInputFormat)) ||
+            (filterOption == FilterOption.WebpLossless && typeof(T) == typeof(bool)) ||
+            (filterOption == FilterOption.CompressionReinterpretDatatype && typeof(T) == typeof(DataType));
+
+        if (!ok)
         {
-            _ctx = ctx;
-            _handle = handle;
+            throw new NotSupportedException($"Unsupported type for filter option: {filterOption}");
         }
+    }
 
+    /// <summary>
+    /// Set filter option.
+    /// </summary>
+    /// <typeparam name="T">Type of option value we intend to set</typeparam>
+    /// <param name="filterOption">Filter option to set</param>
+    /// <param name="value">Filter option value</param>
+    public void SetOption<T>(FilterOption filterOption, T value) where T: struct
+    {
+        //check for filter option
+        check_filter_option<T>(filterOption);
 
-        public void Dispose()
-        {
-            Dispose(true);
-        }
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        var tiledb_filter_option = (tiledb_filter_option_t)filterOption;
+        _ctx.handle_error(Methods.tiledb_filter_set_option(ctxHandle, handle, tiledb_filter_option, &value));
+    }
 
-        private void Dispose(bool disposing)
-        {
-            if (_disposed) return;
-            if (disposing && (!_handle.IsInvalid))
-            {
-                _handle.Dispose();
-            }
+    /// <summary>
+    /// Get filter option.
+    /// </summary>
+    /// <typeparam name="T">Type of option value we intend to get</typeparam>
+    /// <param name="filterOption">Filter option to get</param>
+    public T GetOption<T>(FilterOption filterOption) where T: struct
+    {
+        //check for filter option
+        check_filter_option<T>(filterOption);
 
-            _disposed = true;
-        }
+        var tiledb_filter_option = (tiledb_filter_option_t)filterOption;
 
-        internal FilterHandle Handle => _handle;
+        T result;
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_filter_get_option(ctxHandle, handle, tiledb_filter_option, &result));
 
-        /// <summary>
-        /// Get filter type.
-        /// </summary>
-        /// <returns></returns>
-        public FilterType FilterType()
-        {
-            var tiledb_filter_type= tiledb_filter_type_t.TILEDB_FILTER_NONE;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_filter_get_type(ctxHandle, handle, &tiledb_filter_type));
-            return (FilterType)tiledb_filter_type;
-        }
-
-        /// <summary>
-        /// Check expected type for filter option matches type of T
-        /// </summary>
-        /// <typeparam name="T">Type of filter option value</typeparam>
-        /// <param name="filterOption">Filter option to run type check against</param>
-        /// <exception cref="System.NotSupportedException">Filter option does not support values of type T</exception>
-        private void check_filter_option<T>(FilterOption filterOption)
-        {
-            //check for filter option
-            var ok =
-                (filterOption == FilterOption.CompressionLevel && typeof(T) == typeof(int)) ||
-                (filterOption == FilterOption.BitWidthMaxWindow && typeof(T) == typeof(uint)) ||
-                (filterOption == FilterOption.PositiveDeltaMaxWindow && typeof(T) == typeof(uint)) ||
-                (filterOption == FilterOption.ScaleFloatByteWidth && typeof(T) == typeof(ulong)) ||
-                (filterOption == FilterOption.ScaleFloatFactor && typeof(T) == typeof(double)) ||
-                (filterOption == FilterOption.ScaleFloatOffset && typeof(T) == typeof(double)) ||
-                (filterOption == FilterOption.WebpQuality && typeof(T) == typeof(float)) ||
-                (filterOption == FilterOption.WebpInputFormat && typeof(T) == typeof(WebpInputFormat)) ||
-                (filterOption == FilterOption.WebpLossless && typeof(T) == typeof(bool)) ||
-                (filterOption == FilterOption.CompressionReinterpretDatatype && typeof(T) == typeof(DataType));
-
-            if (!ok)
-            {
-                throw new NotSupportedException($"Unsupported type for filter option: {filterOption}");
-            }
-        }
-
-        /// <summary>
-        /// Set filter option.
-        /// </summary>
-        /// <typeparam name="T">Type of option value we intend to set</typeparam>
-        /// <param name="filterOption">Filter option to set</param>
-        /// <param name="value">Filter option value</param>
-        public void SetOption<T>(FilterOption filterOption, T value) where T: struct
-        {
-            //check for filter option
-            check_filter_option<T>(filterOption);
-
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            var tiledb_filter_option = (tiledb_filter_option_t)filterOption;
-            _ctx.handle_error(Methods.tiledb_filter_set_option(ctxHandle, handle, tiledb_filter_option, &value));
-        }
-
-        /// <summary>
-        /// Get filter option.
-        /// </summary>
-        /// <typeparam name="T">Type of option value we intend to get</typeparam>
-        /// <param name="filterOption">Filter option to get</param>
-        public T GetOption<T>(FilterOption filterOption) where T: struct
-        {
-            //check for filter option
-            check_filter_option<T>(filterOption);
-
-            var tiledb_filter_option = (tiledb_filter_option_t)filterOption;
-
-            T result;
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_filter_get_option(ctxHandle, handle, tiledb_filter_option, &result));
-
-            return result;
-        }
+        return result;
     }
 }

--- a/sources/TileDB.CSharp/FilterList.cs
+++ b/sources/TileDB.CSharp/FilterList.cs
@@ -4,126 +4,125 @@ using TileDB.Interop;
 using FilterHandle = TileDB.CSharp.Marshalling.SafeHandles.FilterHandle;
 using FilterListHandle = TileDB.CSharp.Marshalling.SafeHandles.FilterListHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+public sealed unsafe class FilterList : IDisposable
 {
-    public sealed unsafe class FilterList : IDisposable
+    private readonly FilterListHandle _handle;
+    private readonly Context _ctx;
+    private bool _disposed;
+
+    public FilterList(Context ctx) 
     {
-        private readonly FilterListHandle _handle;
-        private readonly Context _ctx;
-        private bool _disposed;
-
-        public FilterList(Context ctx) 
-        {
-            _ctx = ctx;
-            _handle = FilterListHandle.Create(_ctx);
-        }
-
-        internal FilterList(Context ctx, FilterListHandle handle) 
-        {
-            _ctx = ctx;
-            _handle = handle;
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (_disposed) return;
-            if (disposing && (!_handle.IsInvalid))
-            {
-                _handle.Dispose();
-            }
-
-            _disposed = true;
-        }
-
-        internal FilterListHandle Handle => _handle;
-
-        /// <summary>
-        /// Add a filter.
-        /// </summary>
-        /// <param name="filter"></param>
-        public void AddFilter(Filter filter)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var filterHandle = filter.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_filter_list_add_filter(ctxHandle, handle, filterHandle));
-        }
-
-        /// <summary>
-        /// Set maximum chunk size.
-        /// </summary>
-        /// <param name="maxChunkSize"></param>
-        public void SetMaxChunkSize(uint maxChunkSize)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_filter_list_set_max_chunk_size(ctxHandle, handle, maxChunkSize));
-        }
-
-        /// <summary>
-        /// Get maximum chunk size.
-        /// </summary>
-        /// <returns></returns>
-        public uint MaxChunkSize()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            uint result;
-            _ctx.handle_error(Methods.tiledb_filter_list_get_max_chunk_size(ctxHandle, handle, &result));
-            return result;
-        }
-
-        /// <summary>
-        /// Get number of filter.
-        /// </summary>
-        /// <returns></returns>
-        public uint NFilters()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            uint result;
-            _ctx.handle_error(Methods.tiledb_filter_list_get_nfilters(ctxHandle, handle, &result));
-            return result;
-        }
-
-        /// <summary>
-        /// Get filter from index.
-        /// </summary>
-        /// <param name="filterIndex"></param>
-        /// <returns></returns>
-        public Filter Filter(uint filterIndex)
-        {
-            var handle = new FilterHandle();
-            var successful = false;
-            tiledb_filter_t* filter_p = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var filterListHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_filter_list_get_filter_from_index(ctxHandle, filterListHandle, filterIndex, &filter_p));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(filter_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return new Filter(_ctx, handle);
-        }
-
+        _ctx = ctx;
+        _handle = FilterListHandle.Create(_ctx);
     }
+
+    internal FilterList(Context ctx, FilterListHandle handle) 
+    {
+        _ctx = ctx;
+        _handle = handle;
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing && (!_handle.IsInvalid))
+        {
+            _handle.Dispose();
+        }
+
+        _disposed = true;
+    }
+
+    internal FilterListHandle Handle => _handle;
+
+    /// <summary>
+    /// Add a filter.
+    /// </summary>
+    /// <param name="filter"></param>
+    public void AddFilter(Filter filter)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var filterHandle = filter.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_filter_list_add_filter(ctxHandle, handle, filterHandle));
+    }
+
+    /// <summary>
+    /// Set maximum chunk size.
+    /// </summary>
+    /// <param name="maxChunkSize"></param>
+    public void SetMaxChunkSize(uint maxChunkSize)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_filter_list_set_max_chunk_size(ctxHandle, handle, maxChunkSize));
+    }
+
+    /// <summary>
+    /// Get maximum chunk size.
+    /// </summary>
+    /// <returns></returns>
+    public uint MaxChunkSize()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        uint result;
+        _ctx.handle_error(Methods.tiledb_filter_list_get_max_chunk_size(ctxHandle, handle, &result));
+        return result;
+    }
+
+    /// <summary>
+    /// Get number of filter.
+    /// </summary>
+    /// <returns></returns>
+    public uint NFilters()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        uint result;
+        _ctx.handle_error(Methods.tiledb_filter_list_get_nfilters(ctxHandle, handle, &result));
+        return result;
+    }
+
+    /// <summary>
+    /// Get filter from index.
+    /// </summary>
+    /// <param name="filterIndex"></param>
+    /// <returns></returns>
+    public Filter Filter(uint filterIndex)
+    {
+        var handle = new FilterHandle();
+        var successful = false;
+        tiledb_filter_t* filter_p = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var filterListHandle = _handle.Acquire())
+            {
+                _ctx.handle_error(Methods.tiledb_filter_list_get_filter_from_index(ctxHandle, filterListHandle, filterIndex, &filter_p));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(filter_p);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+
+        return new Filter(_ctx, handle);
+    }
+
 }

--- a/sources/TileDB.CSharp/FragmentInfo.cs
+++ b/sources/TileDB.CSharp/FragmentInfo.cs
@@ -6,670 +6,669 @@ using TileDB.Interop;
 using ArraySchemaHandle = TileDB.CSharp.Marshalling.SafeHandles.ArraySchemaHandle;
 using ConfigHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB fragment info object.
+/// </summary>
+public unsafe sealed class FragmentInfo : IDisposable
 {
+    private readonly Context _ctx;
+    private readonly FragmentInfoHandle _handle;
+
+    internal FragmentInfoHandle Handle => _handle;
+
     /// <summary>
-    /// Represents a TileDB fragment info object.
+    /// Creates a <see cref="FragmentInfo"/> object.
     /// </summary>
-    public unsafe sealed class FragmentInfo : IDisposable
+    /// <param name="ctx">The <see cref="Context"/> associated with this object.</param>
+    /// <param name="uri">The URI of the array to load the fragment info for.</param>
+    public FragmentInfo(Context ctx, string uri)
     {
-        private readonly Context _ctx;
-        private readonly FragmentInfoHandle _handle;
+        _ctx = ctx;
+        using var uri_ms = new MarshaledString(uri);
+        _handle = FragmentInfoHandle.Create(ctx, uri_ms);
+    }
 
-        internal FragmentInfoHandle Handle => _handle;
+    /// <summary>
+    /// Disposes this <see cref="FragmentInfo"/> object.
+    /// </summary>
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
 
-        /// <summary>
-        /// Creates a <see cref="FragmentInfo"/> object.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with this object.</param>
-        /// <param name="uri">The URI of the array to load the fragment info for.</param>
-        public FragmentInfo(Context ctx, string uri)
+    /// <summary>
+    /// Loads the fragment info.
+    /// </summary>
+    public void Load()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_fragment_info_load(ctxHandle, handle));
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Config"/> object that contains this <see cref="FragmentInfo"/>'s configuration.
+    /// </summary>
+    public Config GetConfig()
+    {
+        var handle = new ConfigHandle();
+        bool successful = false;
+        tiledb_config_t* config = null;
+        try
         {
-            _ctx = ctx;
-            using var uri_ms = new MarshaledString(uri);
-            _handle = FragmentInfoHandle.Create(ctx, uri_ms);
-        }
-
-        /// <summary>
-        /// Disposes this <see cref="FragmentInfo"/> object.
-        /// </summary>
-        public void Dispose()
-        {
-            _handle.Dispose();
-        }
-
-        /// <summary>
-        /// Loads the fragment info.
-        /// </summary>
-        public void Load()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_fragment_info_load(ctxHandle, handle));
-        }
-
-        /// <summary>
-        /// Creates a <see cref="Config"/> object that contains this <see cref="FragmentInfo"/>'s configuration.
-        /// </summary>
-        public Config GetConfig()
-        {
-            var handle = new ConfigHandle();
-            bool successful = false;
-            tiledb_config_t* config = null;
-            try
+            using (var ctx = _ctx.Handle.Acquire())
+            using (var fragmentInfoHandle = _handle.Acquire())
             {
-                using (var ctx = _ctx.Handle.Acquire())
-                using (var fragmentInfoHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_fragment_info_get_config(ctx, fragmentInfoHandle, &config));
-                }
-                successful = true;
+                _ctx.handle_error(Methods.tiledb_fragment_info_get_config(ctx, fragmentInfoHandle, &config));
             }
-            finally
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                if (successful)
-                {
-                    handle.InitHandle(config);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.InitHandle(config);
             }
-
-            return new Config(handle);
-        }
-
-        /// <summary>
-        /// Set the fragment info object's <see cref="Config"/>.
-        /// </summary>
-        /// <param name="config">The <see cref="Config"/> object to set.</param>
-        public void SetConfig(Config config)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var configHandle = config.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_fragment_info_set_config(ctxHandle, handle, configHandle));
-        }
-
-        /// <summary>
-        /// The number of fragments in the array.
-        /// </summary>
-        public uint FragmentCount
-        {
-            get
+            else
             {
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var handle = _handle.Acquire();
-                uint result;
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_num(ctxHandle, handle, &result));
-                return result;
+                handle.SetHandleAsInvalid();
             }
         }
 
-        /// <summary>
-        /// The number of fragments to vacuum in the array.
-        /// </summary>
-        public uint FragmentToVacuumCount
-        {
-            get
-            {
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var handle = _handle.Acquire();
-                uint result;
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_to_vacuum_num(ctxHandle, handle, &result));
-                return result;
-            }
-        }
+        return new Config(handle);
+    }
 
-        /// <summary>
-        /// The number of fragments with unconsolidated metadata in the array.
-        /// </summary>
-        public uint FragmentWithUnconsolidatedMetadataCount
-        {
-            get
-            {
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var handle = _handle.Acquire();
-                uint result;
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_unconsolidated_metadata_num(ctxHandle, handle, &result));
-                return result;
-            }
-        }
+    /// <summary>
+    /// Set the fragment info object's <see cref="Config"/>.
+    /// </summary>
+    /// <param name="config">The <see cref="Config"/> object to set.</param>
+    public void SetConfig(Config config)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var configHandle = config.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_fragment_info_set_config(ctxHandle, handle, configHandle));
+    }
 
-        /// <summary>
-        /// The number of cells written to the fragments by the user.
-        /// </summary>
-        public ulong TotalCellCount
-        {
-            get
-            {
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var handle = _handle.Acquire();
-                ulong result;
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_total_cell_num(ctxHandle, handle, &result));
-                return result;
-            }
-        }
-
-        /// <summary>
-        /// Gets the <see cref="ArraySchema"/> of a fragment.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public ArraySchema GetSchema(uint fragmentIndex)
-        {
-            var handle = new ArraySchemaHandle();
-            var successful = false;
-            tiledb_array_schema_t* schema = null;
-            var ctx = _ctx;
-            try
-            {
-                using var ctxHandle = ctx.Handle.Acquire();
-                using var fragmentInfoHandle = _handle.Acquire();
-                ctx.handle_error(Methods.tiledb_fragment_info_get_array_schema(ctxHandle, fragmentInfoHandle, fragmentIndex, &schema));
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(schema);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return new ArraySchema(ctx, handle);
-        }
-
-        /// <summary>
-        /// Gets the schema name of a fragment.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public string GetSchemaName(uint fragmentIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            sbyte* name;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_array_schema_name(ctxHandle, handle, fragmentIndex, &name));
-            return MarshaledStringOut.GetStringFromNullTerminated(name);
-        }
-
-        /// <summary>
-        /// Gets the number of cells written in a fragment.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public ulong GetCellsWritten(uint fragmentIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong result;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_cell_num(ctxHandle, handle, fragmentIndex, &result));
-            return result;
-        }
-
-        /// <summary>
-        /// Gets the URI of a fragment to vacuum.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentToVacuumCount"/> property.
-        /// </remarks>
-        public string GetFragmentToVacuumUri(uint fragmentIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            sbyte* uri;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_to_vacuum_uri(ctxHandle, handle, fragmentIndex, &uri));
-            return MarshaledStringOut.GetStringFromNullTerminated(uri);
-        }
-
-        /// <summary>
-        /// Gets the name of a fragment.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        /// <seealso cref="Array.ConsolidateFragments"/>
-        public string GetFragmentName(uint fragmentIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var nameHolder = new StringHandleHolder();
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_name_v2(ctxHandle, handle, fragmentIndex, &nameHolder._handle));
-            return nameHolder.ToString();
-        }
-
-        /// <summary>
-        /// Gets the URI of a fragment.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public string GetFragmentUri(uint fragmentIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            sbyte* uri;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_uri(ctxHandle, handle, fragmentIndex, &uri));
-            return MarshaledStringOut.GetStringFromNullTerminated(uri);
-        }
-
-        /// <summary>
-        /// Gets the format version of a fragment.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public uint GetFormatVersion(uint fragmentIndex)
+    /// <summary>
+    /// The number of fragments in the array.
+    /// </summary>
+    public uint FragmentCount
+    {
+        get
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             uint result;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_version(ctxHandle, handle, fragmentIndex, &result));
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_num(ctxHandle, handle, &result));
             return result;
         }
+    }
 
-        /// <summary>
-        /// Gets the size in bytes of a fragment.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public ulong GetFragmentSize(uint fragmentIndex)
+    /// <summary>
+    /// The number of fragments to vacuum in the array.
+    /// </summary>
+    public uint FragmentToVacuumCount
+    {
+        get
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            uint result;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_to_vacuum_num(ctxHandle, handle, &result));
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// The number of fragments with unconsolidated metadata in the array.
+    /// </summary>
+    public uint FragmentWithUnconsolidatedMetadataCount
+    {
+        get
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            uint result;
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_unconsolidated_metadata_num(ctxHandle, handle, &result));
+            return result;
+        }
+    }
+
+    /// <summary>
+    /// The number of cells written to the fragments by the user.
+    /// </summary>
+    public ulong TotalCellCount
+    {
+        get
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
             ulong result;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_size(ctxHandle, handle, fragmentIndex, &result));
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_total_cell_num(ctxHandle, handle, &result));
             return result;
         }
+    }
 
-        /// <summary>
-        /// Checks whether a fragment has consolidated metadata.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public bool HasConsolidatedMetadata(uint fragmentIndex)
+    /// <summary>
+    /// Gets the <see cref="ArraySchema"/> of a fragment.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public ArraySchema GetSchema(uint fragmentIndex)
+    {
+        var handle = new ArraySchemaHandle();
+        var successful = false;
+        tiledb_array_schema_t* schema = null;
+        var ctx = _ctx;
+        try
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            int result;
-            _ctx.handle_error(Methods.tiledb_fragment_info_has_consolidated_metadata(ctxHandle, handle, fragmentIndex, &result));
-            return result == 1;
+            using var ctxHandle = ctx.Handle.Acquire();
+            using var fragmentInfoHandle = _handle.Acquire();
+            ctx.handle_error(Methods.tiledb_fragment_info_get_array_schema(ctxHandle, fragmentInfoHandle, fragmentIndex, &schema));
+            successful = true;
         }
-
-        /// <summary>
-        /// Checks whether a fragment is dense.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public bool IsDense(uint fragmentIndex)
+        finally
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            int result;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_dense(ctxHandle, handle, fragmentIndex, &result));
-            return result == 1;
-        }
-
-        /// <summary>
-        /// Checks whether a fragment is sparse.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public bool IsSparse(uint fragmentIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            int result;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_sparse(ctxHandle, handle, fragmentIndex, &result));
-            return result == 1;
-        }
-
-        /// <summary>
-        /// Gets the timestamp range of a fragment.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <returns>The start and end timestamps of the fragment.</returns>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public (ulong Start, ulong End) GetTimestampRange(uint fragmentIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong start, end;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_timestamp_range(ctxHandle, handle, fragmentIndex, &start, &end));
-            return (start, end);
-        }
-
-        /// <summary>
-        /// Gets the number of Minimum Bounded Rectangles (MBRs) of a fragment.
-        /// </summary>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <remarks>
-        /// The maximum value <paramref name="fragmentIndex"/> can take
-        /// is determined by the <see cref="FragmentCount"/> property.
-        /// </remarks>
-        public ulong GetMinimumBoundedRectangleCount(uint fragmentIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong result;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_num(ctxHandle, handle, fragmentIndex, &result));
-            return result;
-        }
-
-        /// <summary>
-        /// Gets the Minimum Bounded Rectangle (MBR) from one of a fragment's dimensions, identified by its index.
-        /// </summary>
-        /// <typeparam name="T">The dimension's data type.</typeparam>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <param name="minimumBoundedRectangleIndex">The index of the MBR of interest.</param>
-        /// <param name="dimensionIndex">The index of the dimension of interest, following
-        /// the order as it was defined in the domain of the array schema.</param>
-        /// <returns>The start and end values of the MBR, inclusive.</returns>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is unsupported.</exception>
-        /// <exception cref="InvalidOperationException"><typeparamref name="T"/> is incompatible
-        /// with the dimension's data type.</exception>
-        public (T Start, T End) GetMinimumBoundedRectangle<T>(uint fragmentIndex, uint minimumBoundedRectangleIndex, uint dimensionIndex)
-        {
-            DataType dataType = GetDimensionType(fragmentIndex, dimensionIndex);
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            if (successful)
             {
-                if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
-                {
-                    (string startStr, string endStr) =
-                        GetStringMinimumBoundedRectangle(fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, dataType);
-                    return ((T)(object)startStr, (T)(object)endStr);
-                }
-                ThrowHelpers.ThrowTypeMismatch(dataType);
-                return default;
+                handle.InitHandle(schema);
             }
-            ValidateDomainType<T>(dataType);
-
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            // We always allocate twice the maximum possible data type to avoid buffer overflows.
-            // If the dimension is of type uint64 and we pass a buffer of two bytes, it will write past the buffer's boundaries.
-            byte* mbr = stackalloc byte[sizeof(ulong) * 2];
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_from_index(ctxHandle, handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, mbr));
-
-            var start = Unsafe.ReadUnaligned<T>(mbr);
-            var end = Unsafe.ReadUnaligned<T>(mbr + Unsafe.SizeOf<T>());
-            return (start, end);
-        }
-
-        /// <summary>
-        /// Gets the Minimum Bounded Rectangle (MBR) from one of a fragment's dimensions, identified by its name.
-        /// </summary>
-        /// <typeparam name="T">The dimension's data type.</typeparam>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <param name="minimumBoundedRectangleIndex">The index of the MBR of interest.</param>
-        /// <param name="dimensionName">The name of the dimension of interest.</param>
-        /// <returns>The start and end values of the MBR, inclusive.</returns>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is unsupported.</exception>
-        /// <exception cref="InvalidOperationException"><typeparamref name="T"/> is incompatible
-        /// with the dimension's data type.</exception>
-        public (T Start, T End) GetMinimumBoundedRectangle<T>(uint fragmentIndex, uint minimumBoundedRectangleIndex, string dimensionName)
-        {
-            DataType dataType = GetDimensionType(fragmentIndex, dimensionName);
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            else
             {
-                if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
-                {
-                    (string startStr, string endStr) =
-                        GetStringMinimumBoundedRectangle(fragmentIndex, minimumBoundedRectangleIndex, dimensionName, dataType);
-                    return ((T)(object)startStr, (T)(object)endStr);
-                }
-                ThrowHelpers.ThrowTypeMismatch(dataType);
-                return default;
+                handle.SetHandleAsInvalid();
             }
-            ValidateDomainType<T>(dataType);
-
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_dimensionName = new MarshaledString(dimensionName);
-            // We always allocate twice the maximum possible data type to avoid buffer overflows.
-            // If the dimension is of type uint64 and we pass a buffer of two bytes, it will write past the buffer's boundaries.
-            byte* mbr = stackalloc byte[sizeof(ulong) * 2];
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_from_name(ctxHandle,
-                handle, fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, mbr));
-
-            var start = Unsafe.ReadUnaligned<T>(mbr);
-            var end = Unsafe.ReadUnaligned<T>(mbr + Unsafe.SizeOf<T>());
-            return (start, end);
         }
 
-        private (string Start, string End) GetStringMinimumBoundedRectangle(uint fragmentIndex, uint minimumBoundedRectangleIndex, uint dimensionIndex, DataType dataType)
+        return new ArraySchema(ctx, handle);
+    }
+
+    /// <summary>
+    /// Gets the schema name of a fragment.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public string GetSchemaName(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        sbyte* name;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_array_schema_name(ctxHandle, handle, fragmentIndex, &name));
+        return MarshaledStringOut.GetStringFromNullTerminated(name);
+    }
+
+    /// <summary>
+    /// Gets the number of cells written in a fragment.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public ulong GetCellsWritten(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong result;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_cell_num(ctxHandle, handle, fragmentIndex, &result));
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the URI of a fragment to vacuum.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentToVacuumCount"/> property.
+    /// </remarks>
+    public string GetFragmentToVacuumUri(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        sbyte* uri;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_to_vacuum_uri(ctxHandle, handle, fragmentIndex, &uri));
+        return MarshaledStringOut.GetStringFromNullTerminated(uri);
+    }
+
+    /// <summary>
+    /// Gets the name of a fragment.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    /// <seealso cref="Array.ConsolidateFragments"/>
+    public string GetFragmentName(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var nameHolder = new StringHandleHolder();
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_name_v2(ctxHandle, handle, fragmentIndex, &nameHolder._handle));
+        return nameHolder.ToString();
+    }
+
+    /// <summary>
+    /// Gets the URI of a fragment.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public string GetFragmentUri(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        sbyte* uri;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_uri(ctxHandle, handle, fragmentIndex, &uri));
+        return MarshaledStringOut.GetStringFromNullTerminated(uri);
+    }
+
+    /// <summary>
+    /// Gets the format version of a fragment.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public uint GetFormatVersion(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        uint result;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_version(ctxHandle, handle, fragmentIndex, &result));
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the size in bytes of a fragment.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public ulong GetFragmentSize(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong result;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_fragment_size(ctxHandle, handle, fragmentIndex, &result));
+        return result;
+    }
+
+    /// <summary>
+    /// Checks whether a fragment has consolidated metadata.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public bool HasConsolidatedMetadata(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        int result;
+        _ctx.handle_error(Methods.tiledb_fragment_info_has_consolidated_metadata(ctxHandle, handle, fragmentIndex, &result));
+        return result == 1;
+    }
+
+    /// <summary>
+    /// Checks whether a fragment is dense.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public bool IsDense(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        int result;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_dense(ctxHandle, handle, fragmentIndex, &result));
+        return result == 1;
+    }
+
+    /// <summary>
+    /// Checks whether a fragment is sparse.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public bool IsSparse(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        int result;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_sparse(ctxHandle, handle, fragmentIndex, &result));
+        return result == 1;
+    }
+
+    /// <summary>
+    /// Gets the timestamp range of a fragment.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <returns>The start and end timestamps of the fragment.</returns>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public (ulong Start, ulong End) GetTimestampRange(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong start, end;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_timestamp_range(ctxHandle, handle, fragmentIndex, &start, &end));
+        return (start, end);
+    }
+
+    /// <summary>
+    /// Gets the number of Minimum Bounded Rectangles (MBRs) of a fragment.
+    /// </summary>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <remarks>
+    /// The maximum value <paramref name="fragmentIndex"/> can take
+    /// is determined by the <see cref="FragmentCount"/> property.
+    /// </remarks>
+    public ulong GetMinimumBoundedRectangleCount(uint fragmentIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong result;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_num(ctxHandle, handle, fragmentIndex, &result));
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the Minimum Bounded Rectangle (MBR) from one of a fragment's dimensions, identified by its index.
+    /// </summary>
+    /// <typeparam name="T">The dimension's data type.</typeparam>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <param name="minimumBoundedRectangleIndex">The index of the MBR of interest.</param>
+    /// <param name="dimensionIndex">The index of the dimension of interest, following
+    /// the order as it was defined in the domain of the array schema.</param>
+    /// <returns>The start and end values of the MBR, inclusive.</returns>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is unsupported.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> is incompatible
+    /// with the dimension's data type.</exception>
+    public (T Start, T End) GetMinimumBoundedRectangle<T>(uint fragmentIndex, uint minimumBoundedRectangleIndex, uint dimensionIndex)
+    {
+        DataType dataType = GetDimensionType(fragmentIndex, dimensionIndex);
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong startSize64, endSize64;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_var_size_from_index(ctxHandle,
-                handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, &startSize64, &endSize64));
-            int startSize = checked((int)startSize64);
-            int endSize = checked((int)endSize64);
-            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
-            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
-            fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
+            if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
             {
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_var_from_index(ctxHandle,
-                    handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, startBufPtr, endBufPtr));
+                (string startStr, string endStr) =
+                    GetStringMinimumBoundedRectangle(fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, dataType);
+                return ((T)(object)startStr, (T)(object)endStr);
             }
-
-            string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
-            return (startStr, endStr);
+            ThrowHelpers.ThrowTypeMismatch(dataType);
+            return default;
         }
+        ValidateDomainType<T>(dataType);
 
-        private (string Start, string End) GetStringMinimumBoundedRectangle(uint fragmentIndex, uint minimumBoundedRectangleIndex, string dimensionName, DataType dataType)
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        // We always allocate twice the maximum possible data type to avoid buffer overflows.
+        // If the dimension is of type uint64 and we pass a buffer of two bytes, it will write past the buffer's boundaries.
+        byte* mbr = stackalloc byte[sizeof(ulong) * 2];
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_from_index(ctxHandle, handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, mbr));
+
+        var start = Unsafe.ReadUnaligned<T>(mbr);
+        var end = Unsafe.ReadUnaligned<T>(mbr + Unsafe.SizeOf<T>());
+        return (start, end);
+    }
+
+    /// <summary>
+    /// Gets the Minimum Bounded Rectangle (MBR) from one of a fragment's dimensions, identified by its name.
+    /// </summary>
+    /// <typeparam name="T">The dimension's data type.</typeparam>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <param name="minimumBoundedRectangleIndex">The index of the MBR of interest.</param>
+    /// <param name="dimensionName">The name of the dimension of interest.</param>
+    /// <returns>The start and end values of the MBR, inclusive.</returns>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is unsupported.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> is incompatible
+    /// with the dimension's data type.</exception>
+    public (T Start, T End) GetMinimumBoundedRectangle<T>(uint fragmentIndex, uint minimumBoundedRectangleIndex, string dimensionName)
+    {
+        DataType dataType = GetDimensionType(fragmentIndex, dimensionName);
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_dimensionName = new MarshaledString(dimensionName);
-            ulong startSize64, endSize64;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_var_size_from_name(ctxHandle,
-                handle, fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, &startSize64, &endSize64));
-            int startSize = checked((int)startSize64);
-            int endSize = checked((int)endSize64);
-            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
-            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
-            fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
+            if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
             {
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_var_from_name(ctxHandle, handle,
-                    fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, startBufPtr, endBufPtr));
+                (string startStr, string endStr) =
+                    GetStringMinimumBoundedRectangle(fragmentIndex, minimumBoundedRectangleIndex, dimensionName, dataType);
+                return ((T)(object)startStr, (T)(object)endStr);
             }
+            ThrowHelpers.ThrowTypeMismatch(dataType);
+            return default;
+        }
+        ValidateDomainType<T>(dataType);
 
-            string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
-            return (startStr, endStr);
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_dimensionName = new MarshaledString(dimensionName);
+        // We always allocate twice the maximum possible data type to avoid buffer overflows.
+        // If the dimension is of type uint64 and we pass a buffer of two bytes, it will write past the buffer's boundaries.
+        byte* mbr = stackalloc byte[sizeof(ulong) * 2];
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_from_name(ctxHandle,
+            handle, fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, mbr));
+
+        var start = Unsafe.ReadUnaligned<T>(mbr);
+        var end = Unsafe.ReadUnaligned<T>(mbr + Unsafe.SizeOf<T>());
+        return (start, end);
+    }
+
+    private (string Start, string End) GetStringMinimumBoundedRectangle(uint fragmentIndex, uint minimumBoundedRectangleIndex, uint dimensionIndex, DataType dataType)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong startSize64, endSize64;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_var_size_from_index(ctxHandle,
+            handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, &startSize64, &endSize64));
+        int startSize = checked((int)startSize64);
+        int endSize = checked((int)endSize64);
+        using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
+        using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
+        fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
+        {
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_var_from_index(ctxHandle,
+                handle, fragmentIndex, minimumBoundedRectangleIndex, dimensionIndex, startBufPtr, endBufPtr));
         }
 
-        /// <summary>
-        /// Gets the non-empty domain from one of a fragment's dimensions, identified by its index.
-        /// </summary>
-        /// <typeparam name="T">The dimension's data type.</typeparam>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <param name="dimensionIndex">The index of the dimension of interest, following
-        /// the order as it was defined in the domain of the array schema.</param>
-        /// <returns>The start and end values of the domain, inclusive.</returns>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is unsupported.</exception>
-        /// <exception cref="InvalidOperationException"><typeparamref name="T"/> is incompatible
-        /// with the dimension's data type.</exception>
-        public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, uint dimensionIndex)
+        string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
+        string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
+        return (startStr, endStr);
+    }
+
+    private (string Start, string End) GetStringMinimumBoundedRectangle(uint fragmentIndex, uint minimumBoundedRectangleIndex, string dimensionName, DataType dataType)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_dimensionName = new MarshaledString(dimensionName);
+        ulong startSize64, endSize64;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_var_size_from_name(ctxHandle,
+            handle, fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, &startSize64, &endSize64));
+        int startSize = checked((int)startSize64);
+        int endSize = checked((int)endSize64);
+        using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
+        using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
+        fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
         {
-            DataType dataType = GetDimensionType(fragmentIndex, dimensionIndex);
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_mbr_var_from_name(ctxHandle, handle,
+                fragmentIndex, minimumBoundedRectangleIndex, ms_dimensionName, startBufPtr, endBufPtr));
+        }
+
+        string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
+        string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
+        return (startStr, endStr);
+    }
+
+    /// <summary>
+    /// Gets the non-empty domain from one of a fragment's dimensions, identified by its index.
+    /// </summary>
+    /// <typeparam name="T">The dimension's data type.</typeparam>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <param name="dimensionIndex">The index of the dimension of interest, following
+    /// the order as it was defined in the domain of the array schema.</param>
+    /// <returns>The start and end values of the domain, inclusive.</returns>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is unsupported.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> is incompatible
+    /// with the dimension's data type.</exception>
+    public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, uint dimensionIndex)
+    {
+        DataType dataType = GetDimensionType(fragmentIndex, dimensionIndex);
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+        {
+            if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
             {
-                if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
-                {
-                    (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionIndex, dataType);
-                    return ((T)(object)startStr, (T)(object)endStr);
-                }
-                ThrowHelpers.ThrowTypeMismatch(dataType);
-                return default;
+                (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionIndex, dataType);
+                return ((T)(object)startStr, (T)(object)endStr);
             }
-            ValidateDomainType<T>(dataType);
-
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            // We always allocate twice the maximum possible data type to avoid buffer overflows.
-            // If the dimension is of type uint64 and we pass a buffer of two bytes, it will write past the buffer's boundaries.
-            byte* domain = stackalloc byte[sizeof(ulong) * 2];
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_index(ctxHandle,
-                handle, fragmentIndex, dimensionIndex, domain));
-
-            var start = Unsafe.ReadUnaligned<T>(domain);
-            var end = Unsafe.ReadUnaligned<T>(domain + Unsafe.SizeOf<T>());
-            return (start, end);
+            ThrowHelpers.ThrowTypeMismatch(dataType);
+            return default;
         }
+        ValidateDomainType<T>(dataType);
 
-        /// <summary>
-        /// Gets the non-empty domain from one of a fragment's dimensions, identified by its index.
-        /// </summary>
-        /// <typeparam name="T">The dimension's data type.</typeparam>
-        /// <param name="fragmentIndex">The index of the fragment of interest.</param>
-        /// <param name="dimensionName">The name of the dimension of interest.</param>
-        /// <returns>The start and end values of the domain, inclusive.</returns>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is unsupported.</exception>
-        /// <exception cref="InvalidOperationException"><typeparamref name="T"/> is incompatible
-        /// with the dimension's data type.</exception>
-        public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, string dimensionName)
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        // We always allocate twice the maximum possible data type to avoid buffer overflows.
+        // If the dimension is of type uint64 and we pass a buffer of two bytes, it will write past the buffer's boundaries.
+        byte* domain = stackalloc byte[sizeof(ulong) * 2];
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_index(ctxHandle,
+            handle, fragmentIndex, dimensionIndex, domain));
+
+        var start = Unsafe.ReadUnaligned<T>(domain);
+        var end = Unsafe.ReadUnaligned<T>(domain + Unsafe.SizeOf<T>());
+        return (start, end);
+    }
+
+    /// <summary>
+    /// Gets the non-empty domain from one of a fragment's dimensions, identified by its index.
+    /// </summary>
+    /// <typeparam name="T">The dimension's data type.</typeparam>
+    /// <param name="fragmentIndex">The index of the fragment of interest.</param>
+    /// <param name="dimensionName">The name of the dimension of interest.</param>
+    /// <returns>The start and end values of the domain, inclusive.</returns>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is unsupported.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> is incompatible
+    /// with the dimension's data type.</exception>
+    public (T Start, T End) GetNonEmptyDomain<T>(uint fragmentIndex, string dimensionName)
+    {
+        DataType dataType = GetDimensionType(fragmentIndex, dimensionName);
+        if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
         {
-            DataType dataType = GetDimensionType(fragmentIndex, dimensionName);
-            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
             {
-                if (typeof(T) == typeof(string) && EnumUtil.IsStringType(dataType))
-                {
-                    (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionName, dataType);
-                    return ((T)(object)startStr, (T)(object)endStr);
-                }
-                ThrowHelpers.ThrowTypeMismatch(dataType);
-                return default;
+                (string startStr, string endStr) = GetStringNonEmptyDomain(fragmentIndex, dimensionName, dataType);
+                return ((T)(object)startStr, (T)(object)endStr);
             }
-            ValidateDomainType<T>(dataType);
-
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_dimensionName = new MarshaledString(dimensionName);
-            // We always allocate twice the maximum possible data type to avoid buffer overflows.
-            // If the dimension is of type uint64 and we pass a buffer of two bytes, it will write past the buffer's boundaries.
-            byte* domain = stackalloc byte[sizeof(ulong) * 2];
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_name(ctxHandle,
-                handle, fragmentIndex, ms_dimensionName, domain));
-
-            var start = Unsafe.ReadUnaligned<T>(domain);
-            var end = Unsafe.ReadUnaligned<T>(domain + Unsafe.SizeOf<T>());
-            return (start, end);
+            ThrowHelpers.ThrowTypeMismatch(dataType);
+            return default;
         }
+        ValidateDomainType<T>(dataType);
 
-        private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, uint dimensionIndex, DataType dataType)
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_dimensionName = new MarshaledString(dimensionName);
+        // We always allocate twice the maximum possible data type to avoid buffer overflows.
+        // If the dimension is of type uint64 and we pass a buffer of two bytes, it will write past the buffer's boundaries.
+        byte* domain = stackalloc byte[sizeof(ulong) * 2];
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_from_name(ctxHandle,
+            handle, fragmentIndex, ms_dimensionName, domain));
+
+        var start = Unsafe.ReadUnaligned<T>(domain);
+        var end = Unsafe.ReadUnaligned<T>(domain + Unsafe.SizeOf<T>());
+        return (start, end);
+    }
+
+    private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, uint dimensionIndex, DataType dataType)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong startSize64, endSize64;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(ctxHandle,
+            handle, fragmentIndex, dimensionIndex, &startSize64, &endSize64));
+        int startSize = checked((int)startSize64);
+        int endSize = checked((int)endSize64);
+        using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
+        using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
+        fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong startSize64, endSize64;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_size_from_index(ctxHandle,
-                handle, fragmentIndex, dimensionIndex, &startSize64, &endSize64));
-            int startSize = checked((int)startSize64);
-            int endSize = checked((int)endSize64);
-            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
-            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
-            fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
-            {
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_index(ctxHandle,
-                    handle, fragmentIndex, dimensionIndex, startBufPtr, endBufPtr));
-            }
-
-            string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
-            return (startStr, endStr);
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_index(ctxHandle,
+                handle, fragmentIndex, dimensionIndex, startBufPtr, endBufPtr));
         }
 
-        private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, string dimensionName, DataType dataType)
+        string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
+        string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
+        return (startStr, endStr);
+    }
+
+    private (string Start, string End) GetStringNonEmptyDomain(uint fragmentIndex, string dimensionName, DataType dataType)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_dimensionName = new MarshaledString(dimensionName);
+        ulong startSize64, endSize64;
+        _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(ctxHandle,
+            handle, fragmentIndex, ms_dimensionName, &startSize64, &endSize64));
+        int startSize = checked((int)startSize64);
+        int endSize = checked((int)endSize64);
+        using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
+        using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
+        fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_dimensionName = new MarshaledString(dimensionName);
-            ulong startSize64, endSize64;
-            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_size_from_name(ctxHandle,
-                handle, fragmentIndex, ms_dimensionName, &startSize64, &endSize64));
-            int startSize = checked((int)startSize64);
-            int endSize = checked((int)endSize64);
-            using var startBuf = new ScratchBuffer<byte>(startSize, stackalloc byte[128], exactSize: true);
-            using var endBuf = new ScratchBuffer<byte>(endSize, stackalloc byte[128], exactSize: true);
-            fixed (byte* startBufPtr = startBuf, endBufPtr = endBuf)
-            {
-                _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_name(ctxHandle,
-                    handle, fragmentIndex, ms_dimensionName, startBufPtr, endBufPtr));
-            }
-
-            string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
-            string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
-            return (startStr, endStr);
+            _ctx.handle_error(Methods.tiledb_fragment_info_get_non_empty_domain_var_from_name(ctxHandle,
+                handle, fragmentIndex, ms_dimensionName, startBufPtr, endBufPtr));
         }
 
-        private static void ValidateDomainType<T>(DataType dataType)
+        string startStr = MarshaledStringOut.GetString(startBuf.Span, dataType);
+        string endStr = MarshaledStringOut.GetString(endBuf.Span, dataType);
+        return (startStr, endStr);
+    }
+
+    private static void ValidateDomainType<T>(DataType dataType)
+    {
+        if (Unsafe.SizeOf<T>() > sizeof(ulong))
         {
-            if (Unsafe.SizeOf<T>() > sizeof(ulong))
-            {
-                ThrowHelpers.ThrowTypeNotSupported();
-            }
-            if (typeof(T) == typeof(string) && !EnumUtil.IsStringType(dataType))
-            {
-                ThrowHelpers.ThrowStringTypeMismatch(dataType);
-            }
-            ErrorHandling.CheckDataType<T>(dataType);
+            ThrowHelpers.ThrowTypeNotSupported();
         }
-
-        private DataType GetDimensionType(uint fragmentIndex, uint dimensionIndex)
+        if (typeof(T) == typeof(string) && !EnumUtil.IsStringType(dataType))
         {
-            using var schema = GetSchema(fragmentIndex);
-            using var domain = schema.Domain();
-            using var dimension = domain.Dimension(dimensionIndex);
-            return dimension.Type();
+            ThrowHelpers.ThrowStringTypeMismatch(dataType);
         }
+        ErrorHandling.CheckDataType<T>(dataType);
+    }
 
-        private DataType GetDimensionType(uint fragmentIndex, string dimensionName)
-        {
-            using var schema = GetSchema(fragmentIndex);
-            using var domain = schema.Domain();
-            using var dimension = domain.Dimension(dimensionName);
-            return dimension.Type();
-        }
+    private DataType GetDimensionType(uint fragmentIndex, uint dimensionIndex)
+    {
+        using var schema = GetSchema(fragmentIndex);
+        using var domain = schema.Domain();
+        using var dimension = domain.Dimension(dimensionIndex);
+        return dimension.Type();
+    }
+
+    private DataType GetDimensionType(uint fragmentIndex, string dimensionName)
+    {
+        using var schema = GetSchema(fragmentIndex);
+        using var domain = schema.Domain();
+        using var dimension = domain.Dimension(dimensionName);
+        return dimension.Type();
     }
 }

--- a/sources/TileDB.CSharp/Group.cs
+++ b/sources/TileDB.CSharp/Group.cs
@@ -4,365 +4,364 @@ using TileDB.Interop;
 using GroupHandle = TileDB.CSharp.Marshalling.SafeHandles.GroupHandle;
 using ConfigHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+public sealed unsafe class Group : IDisposable
 {
-    public sealed unsafe class Group : IDisposable
+    private readonly GroupHandle _handle;
+    private readonly Context _ctx;
+    private bool _disposed;
+
+    private readonly GroupMetadata _metadata;
+
+    public Group(Context ctx, string uri)
     {
-        private readonly GroupHandle _handle;
-        private readonly Context _ctx;
-        private bool _disposed;
-
-        private readonly GroupMetadata _metadata;
-
-        public Group(Context ctx, string uri)
-        {
-            _ctx = ctx;
-            using var ms_uri = new MarshaledString(uri);
-            _handle = GroupHandle.Create(_ctx, ms_uri);
-            _disposed = false;
-            _metadata = new GroupMetadata(this);
-        }
-
-        internal Group(Context ctx, GroupHandle handle)
-        {
-            _ctx = ctx;
-            _handle = handle;
-            _disposed = false;
-            _metadata = new GroupMetadata(this);
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (_disposed) return;
-            if (disposing && (!_handle.IsInvalid))
-            {
-                _handle.Dispose();
-            }
-
-            _disposed = true;
-
-        }
-
-        internal GroupHandle Handle => _handle;
-
-        /// <summary>
-        /// Get context.
-        /// </summary>
-        /// <returns></returns>
-        public Context Context()
-        {
-            return _ctx;
-        }
-
-        #region capi functions
-        public static void Create(Context ctx, string uri)
-        {
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            ctx.handle_error(Methods.tiledb_group_create(ctxHandle, ms_uri));
-        }
-
-        /// <summary>
-        /// Open the group.
-        /// </summary>
-        /// <param name="queryType"></param>
-        public void Open(QueryType queryType)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            var tiledb_query_type = (tiledb_query_type_t)queryType;
-            _ctx.handle_error(Methods.tiledb_group_open(ctxHandle, handle, tiledb_query_type));
-        }
-
-        /// <summary>
-        /// Close the group.
-        /// </summary>
-        public void Close()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_group_close(ctxHandle, handle));
-        }
-
-        /// <summary>
-        /// Set config.
-        /// </summary>
-        /// <param name="config"></param>
-        public void SetConfig(Config config)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var configHandle = config.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_group_set_config(ctxHandle, handle, configHandle));
-        }
-
-        /// <summary>
-        /// Get config.
-        /// </summary>
-        /// <returns></returns>
-        public Config Config()
-        {
-            var handle = new ConfigHandle();
-            tiledb_config_t* config = null;
-            var successful = false;
-            try
-            {
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var groupHandle = _handle.Acquire();
-                _ctx.handle_error(Methods.tiledb_group_get_config(ctxHandle, groupHandle, &config));
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(config);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-            return new Config(handle);
-        }
-
-        /// <summary>
-        /// Put metadata array.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="key"></param>
-        /// <param name="data"></param>
-        public void PutMetadata<T>(string key, T[] data) where T : struct
-        {
-            _metadata.PutMetadata<T>(key, data);
-        }
-
-        /// <summary>
-        /// Put a sigle value metadata.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="key"></param>
-        /// <param name="v"></param>
-        public void PutMetadata<T>(string key, T v) where T : struct
-        {
-            _metadata.PutMetadata<T>(key, v);
-        }
-
-        /// <summary>
-        /// Put string metadata.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        public void PutMetadata(string key, string value)
-        {
-            _metadata.PutMetadata(key, value);
-        }
-
-        /// <summary>
-        /// Delete metadata.
-        /// </summary>
-        /// <param name="key"></param>
-        public void DeleteMetadata(string key)
-        {
-            _metadata.DeleteMetadata(key);
-        }
-
-        /// <summary>
-        /// Get metadata list.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public T[] GetMetadata<T>(string key) where T : struct
-        {
-            return _metadata.GetMetadata<T>(key);
-        }
-
-        /// <summary>
-        /// Get string metadata
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public string GetMetadata(string key)
-        {
-            return _metadata.GetMetadata(key);
-        }
-
-        /// <summary>
-        /// Get number of metadata.
-        /// </summary>
-        /// <returns></returns>
-        public ulong MetadataNum()
-        {
-            return _metadata.MetadataNum();
-        }
-
-        /// <summary>
-        /// Get metadata from index.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="index"></param>
-        /// <returns></returns>
-        public (string key, T[] data) GetMetadataFromIndex<T>(ulong index) where T : struct
-        {
-            return _metadata.GetMetadataFromIndex<T>(index);
-        }
-
-        /// <summary>
-        /// Get metadata keys.
-        /// </summary>
-        /// <returns></returns>
-        public string[] MetadataKeys()
-        {
-            return _metadata.MetadataKeys();
-        }
-
-        /// <summary>
-        /// Test if a metadata with key exists or not.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public (bool has_key, DataType datatype) HasMetadata(string key)
-        {
-            return _metadata.HasMetadata(key);
-        }
-
-        /// <summary>
-        /// Add a member to a group
-        /// </summary>
-        /// <param name="uri"></param>
-        /// <param name="relative"></param>
-        public void AddMember(string uri, bool relative, string name)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            using var ms_name = new MarshaledString(name);
-            byte byte_relative = relative ? (byte)1 : (byte)0;
-            _ctx.handle_error(Methods.tiledb_group_add_member(
-                ctxHandle, handle, ms_uri, byte_relative, ms_name));
-        }
-
-        /// <summary>
-        /// Remove a member of the group
-        /// </summary>
-        /// <param name="name">Name of member to remove. If the member has no name, this
-        /// parameter should be set to the URI of the member.In that case, only the
-        /// unnamed member with the given URI will be removed.</param>
-        public void RemoveMember(string name)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(name);
-            _ctx.handle_error(Methods.tiledb_group_remove_member(ctxHandle, handle, ms_name));
-        }
-
-        /// <summary>
-        /// Get count of members.
-        /// </summary>
-        /// <returns></returns>
-        public ulong MemberCount()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong num;
-            _ctx.handle_error(Methods.tiledb_group_get_member_count(ctxHandle, handle, &num));
-            return num;
-        }
-
-        /// <summary>
-        /// Get member by index.
-        /// </summary>
-        /// <param name="index"></param>
-        /// <returns></returns>
-        (string uri, ObjectType object_type, string name) MemberByIndex(ulong index)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            sbyte* uriPtr;
-            sbyte* namePtr;
-            tiledb_object_t tiledb_objecttype;
-            _ctx.handle_error(Methods.tiledb_group_get_member_by_index(
-                ctxHandle, handle, index, &uriPtr, &tiledb_objecttype, &namePtr));
-
-            string uri = MarshaledStringOut.GetStringFromNullTerminated(uriPtr);
-            string name = MarshaledStringOut.GetStringFromNullTerminated(namePtr);
-            return (uri, (ObjectType)tiledb_objecttype, name);
-        }
-
-        /// <summary>
-        /// Returns if this group is open or not.
-        /// </summary>
-        public bool IsOpen()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            int int_open;
-            _ctx.handle_error(Methods.tiledb_group_is_open(ctxHandle, handle, &int_open));
-            return int_open > 0;
-        }
-
-        /// <summary>
-        /// Returns if the given URI is relative to this group.
-        /// </summary>
-        /// <param name="uri">The URI to test.</param>
-        public bool IsUriRelative(string uri)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            byte result;
-            _ctx.handle_error(Methods.tiledb_group_get_is_relative_uri_by_name(ctxHandle, handle, ms_uri, &result));
-            return result > 0;
-        }
-
-        /// <summary>
-        /// Get uri.
-        /// </summary>
-        /// <returns></returns>
-        public string Uri()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            sbyte* result;
-            _ctx.handle_error(Methods.tiledb_group_get_uri(ctxHandle, handle, &result));
-
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-
-        /// <summary>
-        /// Get query type.
-        /// </summary>
-        /// <returns></returns>
-        public QueryType QueryType()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_query_type_t tiledb_query_type;
-            _ctx.handle_error(Methods.tiledb_group_get_query_type(ctxHandle, handle, &tiledb_query_type));
-            return (QueryType)tiledb_query_type;
-        }
-
-        /// <summary>
-        /// Dump to string
-        /// </summary>
-        /// <param name="recursive"></param>
-        /// <returns></returns>
-        public string Dump(bool recursive)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            sbyte* result;
-            byte int_recursive = (byte)(recursive ? 1 : 0);
-            _ctx.handle_error(Methods.tiledb_group_dump_str(ctxHandle, handle, &result, int_recursive));
-
-            return MarshaledStringOut.GetStringFromNullTerminated(result);
-        }
-        #endregion
+        _ctx = ctx;
+        using var ms_uri = new MarshaledString(uri);
+        _handle = GroupHandle.Create(_ctx, ms_uri);
+        _disposed = false;
+        _metadata = new GroupMetadata(this);
     }
+
+    internal Group(Context ctx, GroupHandle handle)
+    {
+        _ctx = ctx;
+        _handle = handle;
+        _disposed = false;
+        _metadata = new GroupMetadata(this);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (_disposed) return;
+        if (disposing && (!_handle.IsInvalid))
+        {
+            _handle.Dispose();
+        }
+
+        _disposed = true;
+
+    }
+
+    internal GroupHandle Handle => _handle;
+
+    /// <summary>
+    /// Get context.
+    /// </summary>
+    /// <returns></returns>
+    public Context Context()
+    {
+        return _ctx;
+    }
+
+    #region capi functions
+    public static void Create(Context ctx, string uri)
+    {
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        ctx.handle_error(Methods.tiledb_group_create(ctxHandle, ms_uri));
+    }
+
+    /// <summary>
+    /// Open the group.
+    /// </summary>
+    /// <param name="queryType"></param>
+    public void Open(QueryType queryType)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        var tiledb_query_type = (tiledb_query_type_t)queryType;
+        _ctx.handle_error(Methods.tiledb_group_open(ctxHandle, handle, tiledb_query_type));
+    }
+
+    /// <summary>
+    /// Close the group.
+    /// </summary>
+    public void Close()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_group_close(ctxHandle, handle));
+    }
+
+    /// <summary>
+    /// Set config.
+    /// </summary>
+    /// <param name="config"></param>
+    public void SetConfig(Config config)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var configHandle = config.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_group_set_config(ctxHandle, handle, configHandle));
+    }
+
+    /// <summary>
+    /// Get config.
+    /// </summary>
+    /// <returns></returns>
+    public Config Config()
+    {
+        var handle = new ConfigHandle();
+        tiledb_config_t* config = null;
+        var successful = false;
+        try
+        {
+            using var ctxHandle = _ctx.Handle.Acquire();
+            using var groupHandle = _handle.Acquire();
+            _ctx.handle_error(Methods.tiledb_group_get_config(ctxHandle, groupHandle, &config));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(config);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+        return new Config(handle);
+    }
+
+    /// <summary>
+    /// Put metadata array.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="key"></param>
+    /// <param name="data"></param>
+    public void PutMetadata<T>(string key, T[] data) where T : struct
+    {
+        _metadata.PutMetadata<T>(key, data);
+    }
+
+    /// <summary>
+    /// Put a sigle value metadata.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="key"></param>
+    /// <param name="v"></param>
+    public void PutMetadata<T>(string key, T v) where T : struct
+    {
+        _metadata.PutMetadata<T>(key, v);
+    }
+
+    /// <summary>
+    /// Put string metadata.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    public void PutMetadata(string key, string value)
+    {
+        _metadata.PutMetadata(key, value);
+    }
+
+    /// <summary>
+    /// Delete metadata.
+    /// </summary>
+    /// <param name="key"></param>
+    public void DeleteMetadata(string key)
+    {
+        _metadata.DeleteMetadata(key);
+    }
+
+    /// <summary>
+    /// Get metadata list.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public T[] GetMetadata<T>(string key) where T : struct
+    {
+        return _metadata.GetMetadata<T>(key);
+    }
+
+    /// <summary>
+    /// Get string metadata
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public string GetMetadata(string key)
+    {
+        return _metadata.GetMetadata(key);
+    }
+
+    /// <summary>
+    /// Get number of metadata.
+    /// </summary>
+    /// <returns></returns>
+    public ulong MetadataNum()
+    {
+        return _metadata.MetadataNum();
+    }
+
+    /// <summary>
+    /// Get metadata from index.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    public (string key, T[] data) GetMetadataFromIndex<T>(ulong index) where T : struct
+    {
+        return _metadata.GetMetadataFromIndex<T>(index);
+    }
+
+    /// <summary>
+    /// Get metadata keys.
+    /// </summary>
+    /// <returns></returns>
+    public string[] MetadataKeys()
+    {
+        return _metadata.MetadataKeys();
+    }
+
+    /// <summary>
+    /// Test if a metadata with key exists or not.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public (bool has_key, DataType datatype) HasMetadata(string key)
+    {
+        return _metadata.HasMetadata(key);
+    }
+
+    /// <summary>
+    /// Add a member to a group
+    /// </summary>
+    /// <param name="uri"></param>
+    /// <param name="relative"></param>
+    public void AddMember(string uri, bool relative, string name)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        using var ms_name = new MarshaledString(name);
+        byte byte_relative = relative ? (byte)1 : (byte)0;
+        _ctx.handle_error(Methods.tiledb_group_add_member(
+            ctxHandle, handle, ms_uri, byte_relative, ms_name));
+    }
+
+    /// <summary>
+    /// Remove a member of the group
+    /// </summary>
+    /// <param name="name">Name of member to remove. If the member has no name, this
+    /// parameter should be set to the URI of the member.In that case, only the
+    /// unnamed member with the given URI will be removed.</param>
+    public void RemoveMember(string name)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(name);
+        _ctx.handle_error(Methods.tiledb_group_remove_member(ctxHandle, handle, ms_name));
+    }
+
+    /// <summary>
+    /// Get count of members.
+    /// </summary>
+    /// <returns></returns>
+    public ulong MemberCount()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong num;
+        _ctx.handle_error(Methods.tiledb_group_get_member_count(ctxHandle, handle, &num));
+        return num;
+    }
+
+    /// <summary>
+    /// Get member by index.
+    /// </summary>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    (string uri, ObjectType object_type, string name) MemberByIndex(ulong index)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        sbyte* uriPtr;
+        sbyte* namePtr;
+        tiledb_object_t tiledb_objecttype;
+        _ctx.handle_error(Methods.tiledb_group_get_member_by_index(
+            ctxHandle, handle, index, &uriPtr, &tiledb_objecttype, &namePtr));
+
+        string uri = MarshaledStringOut.GetStringFromNullTerminated(uriPtr);
+        string name = MarshaledStringOut.GetStringFromNullTerminated(namePtr);
+        return (uri, (ObjectType)tiledb_objecttype, name);
+    }
+
+    /// <summary>
+    /// Returns if this group is open or not.
+    /// </summary>
+    public bool IsOpen()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        int int_open;
+        _ctx.handle_error(Methods.tiledb_group_is_open(ctxHandle, handle, &int_open));
+        return int_open > 0;
+    }
+
+    /// <summary>
+    /// Returns if the given URI is relative to this group.
+    /// </summary>
+    /// <param name="uri">The URI to test.</param>
+    public bool IsUriRelative(string uri)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        byte result;
+        _ctx.handle_error(Methods.tiledb_group_get_is_relative_uri_by_name(ctxHandle, handle, ms_uri, &result));
+        return result > 0;
+    }
+
+    /// <summary>
+    /// Get uri.
+    /// </summary>
+    /// <returns></returns>
+    public string Uri()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        sbyte* result;
+        _ctx.handle_error(Methods.tiledb_group_get_uri(ctxHandle, handle, &result));
+
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    /// <summary>
+    /// Get query type.
+    /// </summary>
+    /// <returns></returns>
+    public QueryType QueryType()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        tiledb_query_type_t tiledb_query_type;
+        _ctx.handle_error(Methods.tiledb_group_get_query_type(ctxHandle, handle, &tiledb_query_type));
+        return (QueryType)tiledb_query_type;
+    }
+
+    /// <summary>
+    /// Dump to string
+    /// </summary>
+    /// <param name="recursive"></param>
+    /// <returns></returns>
+    public string Dump(bool recursive)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        sbyte* result;
+        byte int_recursive = (byte)(recursive ? 1 : 0);
+        _ctx.handle_error(Methods.tiledb_group_dump_str(ctxHandle, handle, &result, int_recursive));
+
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+    #endregion
 }

--- a/sources/TileDB.CSharp/GroupMetadata.cs
+++ b/sources/TileDB.CSharp/GroupMetadata.cs
@@ -6,344 +6,178 @@ using System.Runtime.InteropServices;
 using System.Text;
 using TileDB.Interop;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+public unsafe class GroupMetadata : IDictionary<string, byte[]>
 {
-    public unsafe class GroupMetadata : IDictionary<string, byte[]>
+    protected Group _group;
+
+    #region Constructors
+    public GroupMetadata(Group group)
     {
-        protected Group _group;
+        _group = group;
+    }
+    #endregion
 
-        #region Constructors
-        public GroupMetadata(Group group)
+    #region User api
+    /// <summary>
+    /// Put metadata array.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="key"></param>
+    /// <param name="data"></param>
+    public void PutMetadata<T>(string key, T[] data) where T : struct
+    {
+        var tiledb_datatype = (tiledb_datatype_t)EnumUtil.TypeToDataType(typeof(T));
+        put_metadata(key, data, tiledb_datatype);
+    }
+
+    /// <summary>
+    /// Put a single value metadata.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="key"></param>
+    /// <param name="v"></param>
+    public void PutMetadata<T>(string key, T v) where T : struct
+    {
+        T[] data = [v];
+        PutMetadata(key, data);
+    }
+
+    /// <summary>
+    /// Put string metadata.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="value"></param>
+    public void PutMetadata(string key, string value)
+    {
+        var tiledb_datatype = tiledb_datatype_t.TILEDB_STRING_UTF8;
+        var data = Encoding.UTF8.GetBytes(value);
+        put_metadata(key, data, tiledb_datatype);
+    }
+
+    /// <summary>
+    /// Delete metadata.
+    /// </summary>
+    /// <param name="key"></param>
+    public void DeleteMetadata(string key)
+    {
+        var ctx = _group.Context();
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var groupHandle = _group.Handle.Acquire();
+        using var ms_key = new MarshaledString(key);
+        ctx.handle_error(Methods.tiledb_group_delete_metadata(ctxHandle, groupHandle, ms_key));
+    }
+
+    /// <summary>
+    /// Get metadata list.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public T[] GetMetadata<T>(string key) where T : struct
+    {
+        var (k, value, dataType, valueNum) = get_metadata(key);
+        Span<byte> valueSpan = value;
+
+        var span = MemoryMarshal.Cast<byte, T>(valueSpan);
+        return span.ToArray();
+    }
+
+    /// <summary>
+    /// Get string metadata
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public string GetMetadata(string key)
+    {
+        var (_, byte_array, datatype, _) = get_metadata(key);
+        return MarshaledStringOut.GetString(byte_array, (DataType)datatype);
+    }
+
+    /// <summary>
+    /// Get number of metadata.
+    /// </summary>
+    /// <returns></returns>
+    public ulong MetadataNum()
+    {
+        var ctx = _group.Context();
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var groupHandle = _group.Handle.Acquire();
+        ulong num;
+        ctx.handle_error(Methods.tiledb_group_get_metadata_num(ctxHandle, groupHandle, &num));
+        return num;
+    }
+
+    /// <summary>
+    /// Get metadata from index.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="index"></param>
+    /// <returns></returns>
+    public (string key, T[] data) GetMetadataFromIndex<T>(ulong index) where T : struct
+    {
+        var (key, value, dataType, valueNum) = get_metadata_from_index(index);
+        Span<byte> valueSpan = value;
+
+        var span = MemoryMarshal.Cast<byte, T>(valueSpan);
+        return (key, span.ToArray());
+
+    }
+
+    /// <summary>
+    /// Get metadata keys.
+    /// </summary>
+    /// <returns></returns>
+    public string[] MetadataKeys()
+    {
+        var num = MetadataNum();
+        var ret = new string[(int)num];
+        for (ulong i = 0; i < num; ++i)
         {
-            _group = group;
+            var (key, _, _, _) = get_metadata_from_index(i);
+            ret[i] = key;
         }
-        #endregion
+        return ret;
+    }
 
-        #region User api
-        /// <summary>
-        /// Put metadata array.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="key"></param>
-        /// <param name="data"></param>
-        public void PutMetadata<T>(string key, T[] data) where T : struct
-        {
-            var tiledb_datatype = (tiledb_datatype_t)EnumUtil.TypeToDataType(typeof(T));
-            put_metadata(key, data, tiledb_datatype);
-        }
+    /// <summary>
+    /// Test if a metadata with key exists or not.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    public (bool has_key, DataType datatype) HasMetadata(string key)
+    {
+        var ctx = _group.Context();
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var groupHandle = _group.Handle.Acquire();
+        using var ms_key = new MarshaledString(key);
+        tiledb_datatype_t tiledb_datatype;
+        var has_key = 0;
+        ctx.handle_error(Methods.tiledb_group_has_metadata_key(ctxHandle, groupHandle, ms_key, &tiledb_datatype, &has_key));
 
-        /// <summary>
-        /// Put a single value metadata.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="key"></param>
-        /// <param name="v"></param>
-        public void PutMetadata<T>(string key, T v) where T : struct
-        {
-            T[] data = [v];
-            PutMetadata(key, data);
-        }
+        return (has_key > 0, (DataType)tiledb_datatype);
+    }
 
-        /// <summary>
-        /// Put string metadata.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <param name="value"></param>
-        public void PutMetadata(string key, string value)
-        {
-            var tiledb_datatype = tiledb_datatype_t.TILEDB_STRING_UTF8;
-            var data = Encoding.UTF8.GetBytes(value);
-            put_metadata(key, data, tiledb_datatype);
-        }
+    /// <summary>
+    /// Consolidate metadata.
+    /// </summary>
+    /// <param name="ctx"></param>
+    /// <param name="uri"></param>
+    /// <param name="config"></param>
+    public static void ConsolidateMetadata(Context ctx, string uri, Config config)
+    {
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        using var configHandle = config.Handle.Acquire();
+        ctx.handle_error(Methods.tiledb_group_consolidate_metadata(ctxHandle, ms_uri, configHandle));
+    }
+    #endregion
 
-        /// <summary>
-        /// Delete metadata.
-        /// </summary>
-        /// <param name="key"></param>
-        public void DeleteMetadata(string key)
-        {
-            var ctx = _group.Context();
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var groupHandle = _group.Handle.Acquire();
-            using var ms_key = new MarshaledString(key);
-            ctx.handle_error(Methods.tiledb_group_delete_metadata(ctxHandle, groupHandle, ms_key));
-        }
-
-        /// <summary>
-        /// Get metadata list.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public T[] GetMetadata<T>(string key) where T : struct
-        {
-            var (k, value, dataType, valueNum) = get_metadata(key);
-            Span<byte> valueSpan = value;
-
-            var span = MemoryMarshal.Cast<byte, T>(valueSpan);
-            return span.ToArray();
-        }
-
-        /// <summary>
-        /// Get string metadata
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public string GetMetadata(string key)
-        {
-            var (_, byte_array, datatype, _) = get_metadata(key);
-            return MarshaledStringOut.GetString(byte_array, (DataType)datatype);
-        }
-
-        /// <summary>
-        /// Get number of metadata.
-        /// </summary>
-        /// <returns></returns>
-        public ulong MetadataNum()
-        {
-            var ctx = _group.Context();
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var groupHandle = _group.Handle.Acquire();
-            ulong num;
-            ctx.handle_error(Methods.tiledb_group_get_metadata_num(ctxHandle, groupHandle, &num));
-            return num;
-        }
-
-        /// <summary>
-        /// Get metadata from index.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="index"></param>
-        /// <returns></returns>
-        public (string key, T[] data) GetMetadataFromIndex<T>(ulong index) where T : struct
-        {
-            var (key, value, dataType, valueNum) = get_metadata_from_index(index);
-            Span<byte> valueSpan = value;
-
-            var span = MemoryMarshal.Cast<byte, T>(valueSpan);
-            return (key, span.ToArray());
-
-        }
-
-        /// <summary>
-        /// Get metadata keys.
-        /// </summary>
-        /// <returns></returns>
-        public string[] MetadataKeys()
-        {
-            var num = MetadataNum();
-            var ret = new string[(int)num];
-            for (ulong i = 0; i < num; ++i)
-            {
-                var (key, _, _, _) = get_metadata_from_index(i);
-                ret[i] = key;
-            }
-            return ret;
-        }
-
-        /// <summary>
-        /// Test if a metadata with key exists or not.
-        /// </summary>
-        /// <param name="key"></param>
-        /// <returns></returns>
-        public (bool has_key, DataType datatype) HasMetadata(string key)
-        {
-            var ctx = _group.Context();
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var groupHandle = _group.Handle.Acquire();
-            using var ms_key = new MarshaledString(key);
-            tiledb_datatype_t tiledb_datatype;
-            var has_key = 0;
-            ctx.handle_error(Methods.tiledb_group_has_metadata_key(ctxHandle, groupHandle, ms_key, &tiledb_datatype, &has_key));
-
-            return (has_key > 0, (DataType)tiledb_datatype);
-        }
-
-        /// <summary>
-        /// Consolidate metadata.
-        /// </summary>
-        /// <param name="ctx"></param>
-        /// <param name="uri"></param>
-        /// <param name="config"></param>
-        public static void ConsolidateMetadata(Context ctx, string uri, Config config)
-        {
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            using var configHandle = config.Handle.Acquire();
-            ctx.handle_error(Methods.tiledb_group_consolidate_metadata(ctxHandle, ms_uri, configHandle));
-        }
-        #endregion
-
-        #region IDictionary interface
-        public byte[] this[string key]
-        {
-            get
-            {
-                var ctx = _group.Context();
-                using var ctxHandle = ctx.Handle.Acquire();
-                using var groupHandle = _group.Handle.Acquire();
-                void* value_p;
-                using var ms_key = new MarshaledString(key);
-                tiledb_datatype_t datatype;
-
-                int has_key = 0;
-                ctx.handle_error(Methods.tiledb_group_has_metadata_key(ctxHandle, groupHandle, ms_key, &datatype, &has_key));
-                if (has_key <= 0)
-                {
-                    return new byte[0];
-                }
-
-                uint value_num = 0;
-                ctx.handle_error(Methods.tiledb_group_get_metadata(ctxHandle, groupHandle, ms_key, &datatype, &value_num,
-                    &value_p));
-                var size = (int)(value_num * Methods.tiledb_datatype_size(datatype));
-                var fill_span = new ReadOnlySpan<byte>(value_p, size);
-                return fill_span.ToArray();
-            }
-            set
-            {
-                Add(key, value);
-            }
-        }
-
-        public ICollection<string> Keys
-        {
-            get
-            {
-                List<string> ret = new List<string>();
-                var ctx = _group.Context();
-                using var ctxHandle = ctx.Handle.Acquire();
-                using var groupHandle = _group.Handle.Acquire();
-                ulong num;
-                ctx.handle_error(Methods.tiledb_group_get_metadata_num(ctxHandle, groupHandle, &num));
-
-                for (ulong i = 0; i < num; ++i)
-                {
-                    var metadata = get_metadata_from_index(i);
-                    ret.Add(metadata.key);
-                }
-
-                return ret;
-            }
-
-        }
-
-        public ICollection<byte[]> Values
-        {
-            get
-            {
-                List<byte[]> ret = new List<byte[]>();
-                ulong num = MetadataNum();
-                for (ulong i = 0; i < num; ++i)
-                {
-                    var metadata = get_metadata_from_index(i);
-                    ret.Add(metadata.data);
-                }
-
-                return ret;
-            }
-        }
-
-        public int Count
-        {
-            get
-            {
-                ulong num = MetadataNum();
-                return (int)num;
-            }
-        }
-
-        public bool IsReadOnly
-        {
-            get
-            {
-                QueryType querytype = _group.QueryType();
-                return querytype == QueryType.Read;
-            }
-        }
-
-        public void Add(string key, byte[] value)
-        {
-            put_metadata(key, value, tiledb_datatype_t.TILEDB_UINT8);
-        }
-
-        public void Add(KeyValuePair<string, byte[]> item)
-        {
-            Add(item.Key, item.Value);
-        }
-
-        public void Clear()
-        {
-            throw new NotImplementedException();
-        }
-
-        public bool Contains(KeyValuePair<string, byte[]> item)
-        {
-            return ContainsKey(item.Key);
-        }
-
-        public bool ContainsKey(string key)
-        {
-            var (has_key, _) = HasMetadata(key);
-            return has_key;
-        }
-
-        public void CopyTo(KeyValuePair<string, byte[]>[] array, int arrayIndex)
-        {
-            throw new NotImplementedException();
-        }
-
-        public IEnumerator<KeyValuePair<string, byte[]>> GetEnumerator()
-        {
-            throw new NotImplementedException();
-        }
-
-        public bool Remove(string key)
-        {
-            DeleteMetadata(key);
-            return true;
-        }
-
-        public bool Remove(KeyValuePair<string, byte[]> item)
-        {
-            return Remove(item.Key);
-        }
-
-        public bool TryGetValue(string key, [MaybeNullWhen(false)] out byte[] value)
-        {
-            if (!ContainsKey(key))
-            {
-                value = null;
-                return false;
-            }
-            var metadata = get_metadata(key);
-            value = metadata.data;
-            return true;
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            throw new NotImplementedException();
-        }
-        #endregion
-
-        #region Private methods
-        private void put_metadata<T>(string key, T[] value, tiledb_datatype_t tiledb_datatype) where T : struct
-        {
-            ErrorHandling.CheckDataType<T>((DataType)tiledb_datatype);
-            if (string.IsNullOrEmpty(key) || value.Length == 0)
-            {
-                throw new ArgumentException("ArrayMetadata.put_metadata, null or empty key-value!");
-            }
-            var ctx = _group.Context();
-            using var ms_key = new MarshaledString(key);
-            using var ctxHandle = ctx.Handle.Acquire();
-            using var groupHandle = _group.Handle.Acquire();
-            fixed (T* dataPtr = &value[0])
-                ctx.handle_error(Methods.tiledb_group_put_metadata(ctxHandle, groupHandle, ms_key, tiledb_datatype, (uint)value.Length, dataPtr));
-        }
-
-        private (string key, byte[] data, tiledb_datatype_t tiledb_datatype, uint value_num) get_metadata(string key)
+    #region IDictionary interface
+    public byte[] this[string key]
+    {
+        get
         {
             var ctx = _group.Context();
             using var ctxHandle = ctx.Handle.Acquire();
@@ -351,31 +185,196 @@ namespace TileDB.CSharp
             void* value_p;
             using var ms_key = new MarshaledString(key);
             tiledb_datatype_t datatype;
+
+            int has_key = 0;
+            ctx.handle_error(Methods.tiledb_group_has_metadata_key(ctxHandle, groupHandle, ms_key, &datatype, &has_key));
+            if (has_key <= 0)
+            {
+                return new byte[0];
+            }
+
             uint value_num = 0;
             ctx.handle_error(Methods.tiledb_group_get_metadata(ctxHandle, groupHandle, ms_key, &datatype, &value_num,
                 &value_p));
             var size = (int)(value_num * Methods.tiledb_datatype_size(datatype));
             var fill_span = new ReadOnlySpan<byte>(value_p, size);
-            return (key, fill_span.ToArray(), datatype, value_num);
+            return fill_span.ToArray();
         }
-
-        private (string key, byte[] data, tiledb_datatype_t tiledb_datatype, uint value_num) get_metadata_from_index(ulong index)
+        set
         {
+            Add(key, value);
+        }
+    }
+
+    public ICollection<string> Keys
+    {
+        get
+        {
+            List<string> ret = new List<string>();
             var ctx = _group.Context();
             using var ctxHandle = ctx.Handle.Acquire();
             using var groupHandle = _group.Handle.Acquire();
-            void* value_p;
-            sbyte* keyPtr;
-            tiledb_datatype_t dataType;
-            uint valueNum = 0;
-            uint key_len;
-            ctx.handle_error(Methods.tiledb_group_get_metadata_from_index(ctxHandle, groupHandle, index, &keyPtr,
-                &key_len, &dataType, &valueNum, &value_p));
-            var size = (int)(valueNum * Methods.tiledb_datatype_size(dataType));
-            var fill_span = new ReadOnlySpan<byte>(value_p, size);
-            string key = MarshaledStringOut.GetStringFromNullTerminated(keyPtr);
-            return (key, fill_span.ToArray(), dataType, valueNum);
+            ulong num;
+            ctx.handle_error(Methods.tiledb_group_get_metadata_num(ctxHandle, groupHandle, &num));
+
+            for (ulong i = 0; i < num; ++i)
+            {
+                var metadata = get_metadata_from_index(i);
+                ret.Add(metadata.key);
+            }
+
+            return ret;
         }
-        #endregion
+
     }
+
+    public ICollection<byte[]> Values
+    {
+        get
+        {
+            List<byte[]> ret = new List<byte[]>();
+            ulong num = MetadataNum();
+            for (ulong i = 0; i < num; ++i)
+            {
+                var metadata = get_metadata_from_index(i);
+                ret.Add(metadata.data);
+            }
+
+            return ret;
+        }
+    }
+
+    public int Count
+    {
+        get
+        {
+            ulong num = MetadataNum();
+            return (int)num;
+        }
+    }
+
+    public bool IsReadOnly
+    {
+        get
+        {
+            QueryType querytype = _group.QueryType();
+            return querytype == QueryType.Read;
+        }
+    }
+
+    public void Add(string key, byte[] value)
+    {
+        put_metadata(key, value, tiledb_datatype_t.TILEDB_UINT8);
+    }
+
+    public void Add(KeyValuePair<string, byte[]> item)
+    {
+        Add(item.Key, item.Value);
+    }
+
+    public void Clear()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool Contains(KeyValuePair<string, byte[]> item)
+    {
+        return ContainsKey(item.Key);
+    }
+
+    public bool ContainsKey(string key)
+    {
+        var (has_key, _) = HasMetadata(key);
+        return has_key;
+    }
+
+    public void CopyTo(KeyValuePair<string, byte[]>[] array, int arrayIndex)
+    {
+        throw new NotImplementedException();
+    }
+
+    public IEnumerator<KeyValuePair<string, byte[]>> GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+
+    public bool Remove(string key)
+    {
+        DeleteMetadata(key);
+        return true;
+    }
+
+    public bool Remove(KeyValuePair<string, byte[]> item)
+    {
+        return Remove(item.Key);
+    }
+
+    public bool TryGetValue(string key, [MaybeNullWhen(false)] out byte[] value)
+    {
+        if (!ContainsKey(key))
+        {
+            value = null;
+            return false;
+        }
+        var metadata = get_metadata(key);
+        value = metadata.data;
+        return true;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        throw new NotImplementedException();
+    }
+    #endregion
+
+    #region Private methods
+    private void put_metadata<T>(string key, T[] value, tiledb_datatype_t tiledb_datatype) where T : struct
+    {
+        ErrorHandling.CheckDataType<T>((DataType)tiledb_datatype);
+        if (string.IsNullOrEmpty(key) || value.Length == 0)
+        {
+            throw new ArgumentException("ArrayMetadata.put_metadata, null or empty key-value!");
+        }
+        var ctx = _group.Context();
+        using var ms_key = new MarshaledString(key);
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var groupHandle = _group.Handle.Acquire();
+        fixed (T* dataPtr = &value[0])
+            ctx.handle_error(Methods.tiledb_group_put_metadata(ctxHandle, groupHandle, ms_key, tiledb_datatype, (uint)value.Length, dataPtr));
+    }
+
+    private (string key, byte[] data, tiledb_datatype_t tiledb_datatype, uint value_num) get_metadata(string key)
+    {
+        var ctx = _group.Context();
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var groupHandle = _group.Handle.Acquire();
+        void* value_p;
+        using var ms_key = new MarshaledString(key);
+        tiledb_datatype_t datatype;
+        uint value_num = 0;
+        ctx.handle_error(Methods.tiledb_group_get_metadata(ctxHandle, groupHandle, ms_key, &datatype, &value_num,
+            &value_p));
+        var size = (int)(value_num * Methods.tiledb_datatype_size(datatype));
+        var fill_span = new ReadOnlySpan<byte>(value_p, size);
+        return (key, fill_span.ToArray(), datatype, value_num);
+    }
+
+    private (string key, byte[] data, tiledb_datatype_t tiledb_datatype, uint value_num) get_metadata_from_index(ulong index)
+    {
+        var ctx = _group.Context();
+        using var ctxHandle = ctx.Handle.Acquire();
+        using var groupHandle = _group.Handle.Acquire();
+        void* value_p;
+        sbyte* keyPtr;
+        tiledb_datatype_t dataType;
+        uint valueNum = 0;
+        uint key_len;
+        ctx.handle_error(Methods.tiledb_group_get_metadata_from_index(ctxHandle, groupHandle, index, &keyPtr,
+            &key_len, &dataType, &valueNum, &value_p));
+        var size = (int)(valueNum * Methods.tiledb_datatype_size(dataType));
+        var fill_span = new ReadOnlySpan<byte>(value_p, size);
+        string key = MarshaledStringOut.GetStringFromNullTerminated(keyPtr);
+        return (key, fill_span.ToArray(), dataType, valueNum);
+    }
+    #endregion
 }

--- a/sources/TileDB.CSharp/GroupMetadata.cs
+++ b/sources/TileDB.CSharp/GroupMetadata.cs
@@ -40,7 +40,7 @@ namespace TileDB.CSharp
         /// <param name="v"></param>
         public void PutMetadata<T>(string key, T v) where T : struct
         {
-            T[] data = new T[1] { v };
+            T[] data = [v];
             PutMetadata(key, data);
         }
 

--- a/sources/TileDB.CSharp/InteropAugments.cs
+++ b/sources/TileDB.CSharp/InteropAugments.cs
@@ -3,23 +3,22 @@ using System.Diagnostics;
 
 // The Interop files are auto-generated so any additions to them will be made in this file to be preserved.
 
-namespace TileDB.Interop
+namespace TileDB.Interop;
+
+/// <summary>Defines the type of a member as it was used in the native signature.</summary>
+[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false, Inherited = true)]
+[Conditional("DEBUG")]
+internal sealed partial class NativeTypeNameAttribute : System.Attribute
 {
-    /// <summary>Defines the type of a member as it was used in the native signature.</summary>
-    [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.ReturnValue, AllowMultiple = false, Inherited = true)]
-    [Conditional("DEBUG")]
-    internal sealed partial class NativeTypeNameAttribute : System.Attribute
+    private readonly string _name;
+
+    /// <summary>Initializes a new instance of the <see cref="NativeTypeNameAttribute" /> class.</summary>
+    /// <param name="name">The name of the type that was used in the native signature.</param>
+    public NativeTypeNameAttribute(string name)
     {
-        private readonly string _name;
-
-        /// <summary>Initializes a new instance of the <see cref="NativeTypeNameAttribute" /> class.</summary>
-        /// <param name="name">The name of the type that was used in the native signature.</param>
-        public NativeTypeNameAttribute(string name)
-        {
-            _name = name;
-        }
-
-        /// <summary>Gets the name of the type that was used in the native signature.</summary>
-        public string Name => _name;
+        _name = name;
     }
+
+    /// <summary>Gets the name of the type that was used in the native signature.</summary>
+    public string Name => _name;
 }

--- a/sources/TileDB.CSharp/Marshalling/MarshaledContiguousStringCollection.cs
+++ b/sources/TileDB.CSharp/Marshalling/MarshaledContiguousStringCollection.cs
@@ -4,63 +4,62 @@ using System.Runtime.InteropServices;
 using System.Text;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling
+namespace TileDB.CSharp.Marshalling;
+
+internal unsafe ref struct MarshaledContiguousStringCollection
 {
-    internal unsafe ref struct MarshaledContiguousStringCollection
+    public byte* Data { get; private set; }
+
+    public ulong* Offsets { get; private set; }
+
+    public ulong DataCount { get; private set; }
+
+    public ulong OffsetsCount { get; private set; }
+
+    public MarshaledContiguousStringCollection(IReadOnlyCollection<string> strings, DataType dataType = DataType.StringAscii)
     {
-        public byte* Data { get; private set; }
-
-        public ulong* Offsets { get; private set; }
-
-        public ulong DataCount { get; private set; }
-
-        public ulong OffsetsCount { get; private set; }
-
-        public MarshaledContiguousStringCollection(IReadOnlyCollection<string> strings, DataType dataType = DataType.StringAscii)
+        Encoding encoding = MarshaledString.GetEncoding(dataType);
+        try
         {
-            Encoding encoding = MarshaledString.GetEncoding(dataType);
-            try
+            Offsets = (ulong*)Marshal.AllocHGlobal(strings.Count * sizeof(ulong));
+            OffsetsCount = (ulong)strings.Count * sizeof(ulong);
+            ulong currentOffset = 0;
+            DataCount = 0;
+            foreach (var str in strings)
             {
-                Offsets = (ulong*)Marshal.AllocHGlobal(strings.Count * sizeof(ulong));
-                OffsetsCount = (ulong)strings.Count * sizeof(ulong);
-                ulong currentOffset = 0;
-                DataCount = 0;
-                foreach (var str in strings)
-                {
-                    Offsets[currentOffset++] = DataCount;
-                    DataCount += (ulong)encoding.GetByteCount(str);
-                }
-
-                Data = (byte*)Marshal.AllocHGlobal((IntPtr)DataCount);
-                int i = 0;
-                foreach (var str in strings)
-                {
-                    currentOffset = Offsets[i];
-                    encoding.GetBytes(str, new Span<byte>(Data + currentOffset, checked((int)(DataCount - currentOffset))));
-                    i++;
-                }
+                Offsets[currentOffset++] = DataCount;
+                DataCount += (ulong)encoding.GetByteCount(str);
             }
-            catch
+
+            Data = (byte*)Marshal.AllocHGlobal((IntPtr)DataCount);
+            int i = 0;
+            foreach (var str in strings)
             {
-                Dispose();
-                throw;
+                currentOffset = Offsets[i];
+                encoding.GetBytes(str, new Span<byte>(Data + currentOffset, checked((int)(DataCount - currentOffset))));
+                i++;
             }
         }
-
-        public void Dispose()
+        catch
         {
-            if (Data is not null)
-            {
-                Marshal.FreeHGlobal((IntPtr)Data);
-                Data = null;
-                DataCount = 0;
-            }
-            if (Offsets is not null)
-            {
-                Marshal.FreeHGlobal((IntPtr)Offsets);
-                Offsets = null;
-                OffsetsCount = 0;
-            }
+            Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Data is not null)
+        {
+            Marshal.FreeHGlobal((IntPtr)Data);
+            Data = null;
+            DataCount = 0;
+        }
+        if (Offsets is not null)
+        {
+            Marshal.FreeHGlobal((IntPtr)Offsets);
+            Offsets = null;
+            OffsetsCount = 0;
         }
     }
 }

--- a/sources/TileDB.CSharp/Marshalling/MarshaledString.cs
+++ b/sources/TileDB.CSharp/Marshalling/MarshaledString.cs
@@ -7,74 +7,73 @@ using System.Runtime.InteropServices;
 using System.Text;
 using TileDB.CSharp;
 
-namespace TileDB.Interop
+namespace TileDB.Interop;
+
+[Obsolete(Obsoletions.TileDBInterop2Message, DiagnosticId = Obsoletions.TileDBInterop2DiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public unsafe struct MarshaledString : IDisposable
 {
-    [Obsolete(Obsoletions.TileDBInterop2Message, DiagnosticId = Obsoletions.TileDBInterop2DiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public unsafe struct MarshaledString : IDisposable
+    public MarshaledString(string input)
     {
-        public MarshaledString(string input)
+        (IntPtr ptr, Length) = AllocNullTerminated(input);
+        Value = (sbyte*)ptr;
+    }
+
+    internal static Encoding GetEncoding(DataType dataType)
+    {
+        switch (dataType)
         {
-            (IntPtr ptr, Length) = AllocNullTerminated(input);
-            Value = (sbyte*)ptr;
+            case DataType.StringAscii:
+                return Encoding.ASCII;
+            case DataType.StringUtf8:
+                return Encoding.UTF8;
+            case DataType.StringUtf16:
+                return Encoding.Unicode;
+            case DataType.StringUtf32:
+                return Encoding.UTF32;
+        }
+        ThrowHelpers.ThrowInvalidDataType(dataType);
+        return null;
+    }
+
+    internal static (IntPtr Pointer, int Length) AllocNullTerminated(string str)
+    {
+        if (str is null)
+        {
+            return ((IntPtr)0, 0);
         }
 
-        internal static Encoding GetEncoding(DataType dataType)
+        int length = Encoding.ASCII.GetByteCount(str);
+        var ptr = (sbyte*)Marshal.AllocHGlobal(length + 1);
+        int bytesWritten = Encoding.ASCII.GetBytes(str, new Span<byte>(ptr, length));
+        Debug.Assert(bytesWritten == length);
+        ptr[length] = 0;
+        return ((IntPtr)ptr, length);
+    }
+
+    internal static void FreeNullTerminated(IntPtr ptr) => Marshal.FreeHGlobal(ptr);
+
+    public ReadOnlySpan<byte> AsSpan() => new ReadOnlySpan<byte>(Value, Length);
+
+    public int Length { get; private set; }
+
+    public sbyte* Value { get; private set; }
+
+    public void Dispose()
+    {
+        if (Value != null)
         {
-            switch (dataType)
-            {
-                case DataType.StringAscii:
-                    return Encoding.ASCII;
-                case DataType.StringUtf8:
-                    return Encoding.UTF8;
-                case DataType.StringUtf16:
-                    return Encoding.Unicode;
-                case DataType.StringUtf32:
-                    return Encoding.UTF32;
-            }
-            ThrowHelpers.ThrowInvalidDataType(dataType);
-            return null;
+            Marshal.FreeHGlobal((IntPtr)Value);
+            Value = null;
+            Length = 0;
         }
+    }
 
-        internal static (IntPtr Pointer, int Length) AllocNullTerminated(string str)
-        {
-            if (str is null)
-            {
-                return ((IntPtr)0, 0);
-            }
+    public static implicit operator sbyte*(in MarshaledString value) => value.Value;
 
-            int length = Encoding.ASCII.GetByteCount(str);
-            var ptr = (sbyte*)Marshal.AllocHGlobal(length + 1);
-            int bytesWritten = Encoding.ASCII.GetBytes(str, new Span<byte>(ptr, length));
-            Debug.Assert(bytesWritten == length);
-            ptr[length] = 0;
-            return ((IntPtr)ptr, length);
-        }
-
-        internal static void FreeNullTerminated(IntPtr ptr) => Marshal.FreeHGlobal(ptr);
-
-        public ReadOnlySpan<byte> AsSpan() => new ReadOnlySpan<byte>(Value, Length);
-
-        public int Length { get; private set; }
-
-        public sbyte* Value { get; private set; }
-
-        public void Dispose()
-        {
-            if (Value != null)
-            {
-                Marshal.FreeHGlobal((IntPtr)Value);
-                Value = null;
-                Length = 0;
-            }
-        }
-
-        public static implicit operator sbyte*(in MarshaledString value) => value.Value;
-
-        public override string ToString()
-        {
-            var span = new ReadOnlySpan<byte>(Value, Length);
-            return MarshaledStringOut.GetString(span);
-        }
+    public override string ToString()
+    {
+        var span = new ReadOnlySpan<byte>(Value, Length);
+        return MarshaledStringOut.GetString(span);
     }
 }

--- a/sources/TileDB.CSharp/Marshalling/MarshaledStringCollection.cs
+++ b/sources/TileDB.CSharp/Marshalling/MarshaledStringCollection.cs
@@ -3,43 +3,42 @@ using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling
+namespace TileDB.CSharp.Marshalling;
+
+internal unsafe ref struct MarshaledStringCollection
 {
-    internal unsafe ref struct MarshaledStringCollection
+    public IntPtr* Strings { get; private set; }
+
+    public int Count { get; }
+
+    public MarshaledStringCollection(IReadOnlyList<string> strings)
     {
-        public IntPtr* Strings { get; private set; }
+        Count = strings.Count;
+        Strings = (IntPtr*)Marshal.AllocHGlobal(Count * sizeof(IntPtr));
 
-        public int Count { get; }
-
-        public MarshaledStringCollection(IReadOnlyList<string> strings)
+        try
         {
-            Count = strings.Count;
-            Strings = (IntPtr*)Marshal.AllocHGlobal(Count * sizeof(IntPtr));
-
-            try
-            {
-                for (int i = 0; i < Count; i++)
-                {
-                    Strings[i] = MarshaledString.AllocNullTerminated(strings[i]).Pointer;
-                }
-            }
-            catch
-            {
-                Dispose();
-                throw;
-            }
-        }
-
-        public void Dispose()
-        {
-            if (Strings is null) return;
-
             for (int i = 0; i < Count; i++)
             {
-                MarshaledString.FreeNullTerminated(Strings[i]);
+                Strings[i] = MarshaledString.AllocNullTerminated(strings[i]).Pointer;
             }
-            Marshal.FreeHGlobal((IntPtr)Strings);
-            Strings = null;
         }
+        catch
+        {
+            Dispose();
+            throw;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Strings is null) return;
+
+        for (int i = 0; i < Count; i++)
+        {
+            MarshaledString.FreeNullTerminated(Strings[i]);
+        }
+        Marshal.FreeHGlobal((IntPtr)Strings);
+        Strings = null;
     }
 }

--- a/sources/TileDB.CSharp/Marshalling/MarshaledStringOut.cs
+++ b/sources/TileDB.CSharp/Marshalling/MarshaledStringOut.cs
@@ -3,58 +3,57 @@ using System.ComponentModel;
 using System.Text;
 using TileDB.CSharp;
 
-namespace TileDB.Interop
+namespace TileDB.Interop;
+
+[Obsolete(Obsoletions.TileDBInterop2Message, DiagnosticId = Obsoletions.TileDBInterop2DiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public unsafe class LibC
 {
-    [Obsolete(Obsoletions.TileDBInterop2Message, DiagnosticId = Obsoletions.TileDBInterop2DiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public unsafe class LibC
+    // public struct handle_t {}
+    // [DllImport(LibDllImport.LibCPath)]
+    // public static extern void free(void* p);
+}
+
+[Obsolete(Obsoletions.TileDBInterop2Message, DiagnosticId = Obsoletions.TileDBInterop2DiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
+[EditorBrowsable(EditorBrowsableState.Never)]
+public unsafe class MarshaledStringOut
+{
+    public sbyte* Value;
+    public MarshaledStringOut()
     {
-        // public struct handle_t {}
-        // [DllImport(LibDllImport.LibCPath)]
-        // public static extern void free(void* p);
+        Value = null;
     }
 
-    [Obsolete(Obsoletions.TileDBInterop2Message, DiagnosticId = Obsoletions.TileDBInterop2DiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public unsafe class MarshaledStringOut
+    /// <summary>
+    /// Encodes a read-only span of bytes into a string, using the default encoding.
+    /// </summary>
+    internal static string GetString(ReadOnlySpan<byte> span) =>
+        Encoding.ASCII.GetString(span);
+
+    internal static string GetString(ReadOnlySpan<byte> span, DataType dataType) =>
+        dataType switch
+        {
+            DataType.StringAscii => Encoding.ASCII.GetString(span),
+            DataType.StringUtf8 => Encoding.UTF8.GetString(span),
+            DataType.StringUtf16 => Encoding.Unicode.GetString(span),
+            DataType.StringUtf32=> Encoding.UTF32.GetString(span),
+            _ => throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Unsupported string data type.")
+        };
+
+    /// <summary>
+    /// Encodes a null-terminated pointer of bytes into a string, using the default encoding.
+    /// </summary>
+    internal static unsafe string GetStringFromNullTerminated(sbyte* ptr)
     {
-        public sbyte* Value;
-        public MarshaledStringOut()
+        if (ptr == null)
         {
-            Value = null;
+            return string.Empty;
         }
 
-        /// <summary>
-        /// Encodes a read-only span of bytes into a string, using the default encoding.
-        /// </summary>
-        internal static string GetString(ReadOnlySpan<byte> span) =>
-            Encoding.ASCII.GetString(span);
-
-        internal static string GetString(ReadOnlySpan<byte> span, DataType dataType) =>
-            dataType switch
-            {
-                DataType.StringAscii => Encoding.ASCII.GetString(span),
-                DataType.StringUtf8 => Encoding.UTF8.GetString(span),
-                DataType.StringUtf16 => Encoding.Unicode.GetString(span),
-                DataType.StringUtf32=> Encoding.UTF32.GetString(span),
-                _ => throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Unsupported string data type.")
-            };
-
-        /// <summary>
-        /// Encodes a null-terminated pointer of bytes into a string, using the default encoding.
-        /// </summary>
-        internal static unsafe string GetStringFromNullTerminated(sbyte* ptr)
-        {
-            if (ptr == null)
-            {
-                return string.Empty;
-            }
-
-            var span = new ReadOnlySpan<byte>(ptr, int.MaxValue);
-            span = span[0..span.IndexOf((byte)0)];
-            return GetString(span);
-        }
-
-        public static implicit operator string(MarshaledStringOut s) => GetStringFromNullTerminated(s.Value);
+        var span = new ReadOnlySpan<byte>(ptr, int.MaxValue);
+        span = span[0..span.IndexOf((byte)0)];
+        return GetString(span);
     }
+
+    public static implicit operator string(MarshaledStringOut s) => GetStringFromNullTerminated(s.Value);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandleHolder.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandleHolder.cs
@@ -1,34 +1,33 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace TileDB.CSharp.Marshalling
+namespace TileDB.CSharp.Marshalling;
+
+internal struct SafeHandleHolder<TNativeObject> : IDisposable where TNativeObject : unmanaged
 {
-    internal struct SafeHandleHolder<TNativeObject> : IDisposable where TNativeObject : unmanaged
-    {
-        private readonly SafeHandle? _handle;
-        private bool _isHeld;
+    private readonly SafeHandle? _handle;
+    private bool _isHeld;
 
 #pragma warning disable S3869 // "SafeHandle.DangerousGetHandle" should not be called
-        public static unsafe implicit operator TNativeObject*(SafeHandleHolder<TNativeObject> holder) =>
-            (TNativeObject*)(holder._handle?.DangerousGetHandle() ?? (IntPtr)0);
+    public static unsafe implicit operator TNativeObject*(SafeHandleHolder<TNativeObject> holder) =>
+        (TNativeObject*)(holder._handle?.DangerousGetHandle() ?? (IntPtr)0);
 #pragma warning restore S3869 // "SafeHandle.DangerousGetHandle" should not be called
 
-        public SafeHandleHolder(SafeHandle handle)
+    public SafeHandleHolder(SafeHandle handle)
+    {
+        _handle = handle;
+        _isHeld = false;
+        _handle.DangerousAddRef(ref _isHeld);
+    }
+
+    public void Dispose()
+    {
+        if (!_isHeld)
         {
-            _handle = handle;
-            _isHeld = false;
-            _handle.DangerousAddRef(ref _isHeld);
+            return;
         }
 
-        public void Dispose()
-        {
-            if (!_isHeld)
-            {
-                return;
-            }
-
-            _isHeld = false;
-            _handle?.DangerousRelease();
-        }
+        _isHeld = false;
+        _handle?.DangerousRelease();
     }
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaEvolutionHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaEvolutionHandle.cs
@@ -2,54 +2,53 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class ArraySchemaEvolutionHandle : SafeHandle
 {
-    internal unsafe sealed class ArraySchemaEvolutionHandle : SafeHandle
+    public ArraySchemaEvolutionHandle() : base(IntPtr.Zero, true) { }
+
+    public ArraySchemaEvolutionHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static ArraySchemaEvolutionHandle Create(Context context)
     {
-        public ArraySchemaEvolutionHandle() : base(IntPtr.Zero, true) { }
-
-        public ArraySchemaEvolutionHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static ArraySchemaEvolutionHandle Create(Context context)
+        var handle = new ArraySchemaEvolutionHandle();
+        var successful = false;
+        tiledb_array_schema_evolution_t* evolution = null;
+        try
         {
-            var handle = new ArraySchemaEvolutionHandle();
-            var successful = false;
-            tiledb_array_schema_evolution_t* evolution = null;
-            try
+            using (var contextHandle = context.Handle.Acquire())
             {
-                using (var contextHandle = context.Handle.Acquire())
-                {
-                    context.handle_error(Methods.tiledb_array_schema_evolution_alloc(contextHandle, &evolution));
-                }
-                successful = true;
+                context.handle_error(Methods.tiledb_array_schema_evolution_alloc(contextHandle, &evolution));
             }
-            finally
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                if (successful)
-                {
-                    handle.InitHandle(evolution);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.InitHandle(evolution);
             }
-
-            return handle;
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_array_schema_evolution_free((tiledb_array_schema_evolution_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_array_schema_evolution_t* h) => SetHandle((IntPtr)h);
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_array_schema_evolution_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_array_schema_evolution_free((tiledb_array_schema_evolution_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_array_schema_evolution_t* h) => SetHandle((IntPtr)h);
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_array_schema_evolution_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ArraySchemaHandle.cs
@@ -2,54 +2,53 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class ArraySchemaHandle : SafeHandle
 {
-    internal unsafe sealed class ArraySchemaHandle : SafeHandle
+    public ArraySchemaHandle() : base(IntPtr.Zero, true) { }
+
+    public ArraySchemaHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static ArraySchemaHandle Create(Context context, tiledb_array_type_t arrayType)
     {
-        public ArraySchemaHandle() : base(IntPtr.Zero, true) { }
-
-        public ArraySchemaHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static ArraySchemaHandle Create(Context context, tiledb_array_type_t arrayType)
+        var handle = new ArraySchemaHandle();
+        var successful = false;
+        tiledb_array_schema_t* schema = null;
+        try
         {
-            var handle = new ArraySchemaHandle();
-            var successful = false;
-            tiledb_array_schema_t* schema = null;
-            try
+            using (var ctx = context.Handle.Acquire())
             {
-                using (var ctx = context.Handle.Acquire())
-                {
-                    context.handle_error(Methods.tiledb_array_schema_alloc(ctx, arrayType, &schema));
-                }
-                successful = true;
+                context.handle_error(Methods.tiledb_array_schema_alloc(ctx, arrayType, &schema));
             }
-            finally
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                if (successful)
-                {
-                    handle.InitHandle(schema);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.InitHandle(schema);
             }
-
-            return handle;
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_array_schema_free((tiledb_array_schema_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_array_schema_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_array_schema_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_array_schema_free((tiledb_array_schema_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_array_schema_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_array_schema_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/AttributeHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/AttributeHandle.cs
@@ -2,53 +2,52 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class AttributeHandle : SafeHandle
 {
-    internal unsafe sealed class AttributeHandle : SafeHandle
+    public AttributeHandle() : base(IntPtr.Zero, true) { }
+
+    public AttributeHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static AttributeHandle Create(Context context, string name, tiledb_datatype_t datatype)
     {
-        public AttributeHandle() : base(IntPtr.Zero, true) { }
-
-        public AttributeHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static AttributeHandle Create(Context context, string name, tiledb_datatype_t datatype)
+        var handle = new AttributeHandle();
+        var successful = false;
+        tiledb_attribute_t* attribute = null;
+        try
         {
-            var handle = new AttributeHandle();
-            var successful = false;
-            tiledb_attribute_t* attribute = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            using var ms_name = new MarshaledString(name);
+            context.handle_error(Methods.tiledb_attribute_alloc(contextHandle, ms_name, datatype, &attribute));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                using var ms_name = new MarshaledString(name);
-                context.handle_error(Methods.tiledb_attribute_alloc(contextHandle, ms_name, datatype, &attribute));
-                successful = true;
+                handle.InitHandle(attribute);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(attribute);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_attribute_free((tiledb_attribute_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_attribute_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_attribute_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_attribute_free((tiledb_attribute_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_attribute_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_attribute_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ChannelOperationHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ChannelOperationHandle.cs
@@ -2,34 +2,33 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class ChannelOperationHandle : SafeHandle
 {
-    internal unsafe sealed class ChannelOperationHandle : SafeHandle
+    // Keep the context handle around until this handle gets freed.
+    private SafeHandleHolder<tiledb_ctx_t> _ctx;
+
+    public ChannelOperationHandle() : base(IntPtr.Zero, true) { }
+
+    public ChannelOperationHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    protected override bool ReleaseHandle()
     {
-        // Keep the context handle around until this handle gets freed.
-        private SafeHandleHolder<tiledb_ctx_t> _ctx;
-
-        public ChannelOperationHandle() : base(IntPtr.Zero, true) { }
-
-        public ChannelOperationHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        protected override bool ReleaseHandle()
+        fixed (IntPtr* p = &handle)
         {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_aggregate_free(_ctx, (tiledb_channel_operation_t**)p);
-            }
-            _ctx.Dispose();
-            return true;
+            Methods.tiledb_aggregate_free(_ctx, (tiledb_channel_operation_t**)p);
         }
-
-        internal void InitHandle(Context ctx, tiledb_channel_operation_t* h)
-        {
-            _ctx = ctx.Handle.Acquire();
-            SetHandle((IntPtr)h);
-        }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_channel_operation_t> Acquire() => new(this);
+        _ctx.Dispose();
+        return true;
     }
+
+    internal void InitHandle(Context ctx, tiledb_channel_operation_t* h)
+    {
+        _ctx = ctx.Handle.Acquire();
+        SetHandle((IntPtr)h);
+    }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_channel_operation_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigHandle.cs
@@ -2,52 +2,51 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class ConfigHandle : SafeHandle
 {
-    internal unsafe sealed class ConfigHandle : SafeHandle
+    public ConfigHandle() : base(IntPtr.Zero, true) { }
+
+    public ConfigHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static ConfigHandle Create()
     {
-        public ConfigHandle() : base(IntPtr.Zero, true) { }
-
-        public ConfigHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static ConfigHandle Create()
+        var handle = new ConfigHandle();
+        var successful = false;
+        tiledb_config_t* config = null;
+        try
         {
-            var handle = new ConfigHandle();
-            var successful = false;
-            tiledb_config_t* config = null;
-            try
+            tiledb_error_t* error;
+            ErrorHandling.ThrowOnError(Methods.tiledb_config_alloc(&config, &error));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                tiledb_error_t* error;
-                ErrorHandling.ThrowOnError(Methods.tiledb_config_alloc(&config, &error));
-                successful = true;
+                handle.InitHandle(config);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(config);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_config_free((tiledb_config_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_config_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_config_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_config_free((tiledb_config_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_config_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_config_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigIteratorHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ConfigIteratorHandle.cs
@@ -2,54 +2,53 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class ConfigIteratorHandle : SafeHandle
 {
-    internal unsafe sealed class ConfigIteratorHandle : SafeHandle
+    public ConfigIteratorHandle() : base(IntPtr.Zero, true) { }
+
+    public ConfigIteratorHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static ConfigIteratorHandle Create(ConfigHandle hconfig, string prefix)
     {
-        public ConfigIteratorHandle() : base(IntPtr.Zero, true) { }
-
-        public ConfigIteratorHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static ConfigIteratorHandle Create(ConfigHandle hconfig, string prefix)
+        var handle = new ConfigIteratorHandle();
+        var successful = false;
+        tiledb_config_iter_t* config_iter = null;
+        try
         {
-            var handle = new ConfigIteratorHandle();
-            var successful = false;
-            tiledb_config_iter_t* config_iter = null;
-            try
+            using var config = hconfig.Acquire();
+            tiledb_error_t* error;
+            using var ms_prefix = new MarshaledString(prefix);
+            ErrorHandling.ThrowOnError(Methods.tiledb_config_iter_alloc(config, ms_prefix, &config_iter, &error));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var config = hconfig.Acquire();
-                tiledb_error_t* error;
-                using var ms_prefix = new MarshaledString(prefix);
-                ErrorHandling.ThrowOnError(Methods.tiledb_config_iter_alloc(config, ms_prefix, &config_iter, &error));
-                successful = true;
+                handle.InitHandle(config_iter);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(config_iter);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_config_iter_free((tiledb_config_iter_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_config_iter_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_config_iter_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_config_iter_free((tiledb_config_iter_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_config_iter_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_config_iter_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/ContextHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/ContextHandle.cs
@@ -2,52 +2,51 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class ContextHandle : SafeHandle
 {
-    internal unsafe sealed class ContextHandle : SafeHandle
+    public ContextHandle() : base(IntPtr.Zero, true) { }
+
+    public ContextHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static ContextHandle Create(ConfigHandle? configHandle = null)
     {
-        public ContextHandle() : base(IntPtr.Zero, true) { }
-
-        public ContextHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static ContextHandle Create(ConfigHandle? configHandle = null)
+        var handle = new ContextHandle();
+        var successful = false;
+        tiledb_ctx_t* context = null;
+        try
         {
-            var handle = new ContextHandle();
-            var successful = false;
-            tiledb_ctx_t* context = null;
-            try
+            using var configHandleHolder = configHandle?.Acquire() ?? default;
+            ErrorHandling.ThrowOnError(Methods.tiledb_ctx_alloc(configHandleHolder, &context));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var configHandleHolder = configHandle?.Acquire() ?? default;
-                ErrorHandling.ThrowOnError(Methods.tiledb_ctx_alloc(configHandleHolder, &context));
-                successful = true;
+                handle.InitHandle(context);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(context);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_ctx_free((tiledb_ctx_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_ctx_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_ctx_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_ctx_free((tiledb_ctx_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_ctx_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_ctx_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/DimensionHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/DimensionHandle.cs
@@ -2,53 +2,52 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class DimensionHandle : SafeHandle
 {
-    internal unsafe sealed class DimensionHandle : SafeHandle
+    public DimensionHandle() : base(IntPtr.Zero, true) { }
+
+    public DimensionHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static DimensionHandle Create(Context context, string name, tiledb_datatype_t datatype, void* dimDomain, void* tileExtent)
     {
-        public DimensionHandle() : base(IntPtr.Zero, true) { }
-
-        public DimensionHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static DimensionHandle Create(Context context, string name, tiledb_datatype_t datatype, void* dimDomain, void* tileExtent)
+        var handle = new DimensionHandle();
+        var successful = false;
+        tiledb_dimension_t* dimension = null;
+        try
         {
-            var handle = new DimensionHandle();
-            var successful = false;
-            tiledb_dimension_t* dimension = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            using var ms_name = new MarshaledString(name);
+            context.handle_error(Methods.tiledb_dimension_alloc(contextHandle, ms_name, datatype, dimDomain, tileExtent, &dimension));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                using var ms_name = new MarshaledString(name);
-                context.handle_error(Methods.tiledb_dimension_alloc(contextHandle, ms_name, datatype, dimDomain, tileExtent, &dimension));
-                successful = true;
+                handle.InitHandle(dimension);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(dimension);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_dimension_free((tiledb_dimension_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_dimension_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_dimension_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_dimension_free((tiledb_dimension_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_dimension_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_dimension_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/DomainHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/DomainHandle.cs
@@ -2,52 +2,51 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class DomainHandle : SafeHandle
 {
-    internal unsafe sealed class DomainHandle : SafeHandle
+    public DomainHandle() : base(IntPtr.Zero, true) { }
+
+    public DomainHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static DomainHandle Create(Context context)
     {
-        public DomainHandle() : base(IntPtr.Zero, true) { }
-
-        public DomainHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static DomainHandle Create(Context context)
+        var handle = new DomainHandle();
+        var successful = false;
+        tiledb_domain_t* domain = null;
+        try
         {
-            var handle = new DomainHandle();
-            var successful = false;
-            tiledb_domain_t* domain = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            context.handle_error(Methods.tiledb_domain_alloc(contextHandle, &domain));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                context.handle_error(Methods.tiledb_domain_alloc(contextHandle, &domain));
-                successful = true;
+                handle.InitHandle(domain);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(domain);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_domain_free((tiledb_domain_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_domain_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_domain_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_domain_free((tiledb_domain_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_domain_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_domain_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/EnumerationHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/EnumerationHandle.cs
@@ -2,82 +2,81 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class EnumerationHandle : SafeHandle
 {
-    internal unsafe sealed class EnumerationHandle : SafeHandle
+    public EnumerationHandle() : base(IntPtr.Zero, true) { }
+
+    public EnumerationHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static EnumerationHandle Create(Context context, string name, tiledb_datatype_t datatype, uint cellValNum, bool ordered, byte* data, ulong dataSize, ulong* offsets, ulong offsetsSize)
     {
-        public EnumerationHandle() : base(IntPtr.Zero, true) { }
-
-        public EnumerationHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static EnumerationHandle Create(Context context, string name, tiledb_datatype_t datatype, uint cellValNum, bool ordered, byte* data, ulong dataSize, ulong* offsets, ulong offsetsSize)
+        var handle = new EnumerationHandle();
+        var successful = false;
+        tiledb_enumeration_t* enumeration = null;
+        try
         {
-            var handle = new EnumerationHandle();
-            var successful = false;
-            tiledb_enumeration_t* enumeration = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            using var ms_name = new MarshaledString(name);
+            context.handle_error(Methods.tiledb_enumeration_alloc(contextHandle, ms_name, datatype, cellValNum,
+                ordered ? 1 : 0, data, dataSize, offsets, offsetsSize, &enumeration));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                using var ms_name = new MarshaledString(name);
-                context.handle_error(Methods.tiledb_enumeration_alloc(contextHandle, ms_name, datatype, cellValNum,
-                    ordered ? 1 : 0, data, dataSize, offsets, offsetsSize, &enumeration));
-                successful = true;
+                handle.InitHandle(enumeration);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(enumeration);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        public EnumerationHandle Extend(Context context, byte* data, ulong dataSize, ulong* offsets, ulong offsetsSize)
-        {
-            var handle = new EnumerationHandle();
-            var successful = false;
-            tiledb_enumeration_t* enumeration = null;
-            try
-            {
-                using var contextHandle = context.Handle.Acquire();
-                using var old_enumeration_handle = Acquire();
-                context.handle_error(Methods.tiledb_enumeration_extend(contextHandle, old_enumeration_handle, data,
-                    dataSize, offsets, offsetsSize, &enumeration));
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(enumeration);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return handle;
-        }
-
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_enumeration_free((tiledb_enumeration_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_enumeration_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_enumeration_t> Acquire() => new(this);
+        return handle;
     }
+
+    public EnumerationHandle Extend(Context context, byte* data, ulong dataSize, ulong* offsets, ulong offsetsSize)
+    {
+        var handle = new EnumerationHandle();
+        var successful = false;
+        tiledb_enumeration_t* enumeration = null;
+        try
+        {
+            using var contextHandle = context.Handle.Acquire();
+            using var old_enumeration_handle = Acquire();
+            context.handle_error(Methods.tiledb_enumeration_extend(contextHandle, old_enumeration_handle, data,
+                dataSize, offsets, offsetsSize, &enumeration));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(enumeration);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+
+        return handle;
+    }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_enumeration_free((tiledb_enumeration_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_enumeration_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_enumeration_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterHandle.cs
@@ -2,52 +2,51 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class FilterHandle : SafeHandle
 {
-    internal unsafe sealed class FilterHandle : SafeHandle
+    public FilterHandle() : base(IntPtr.Zero, true) { }
+
+    public FilterHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static FilterHandle Create(Context context, tiledb_filter_type_t filterType)
     {
-        public FilterHandle() : base(IntPtr.Zero, true) { }
-
-        public FilterHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static FilterHandle Create(Context context, tiledb_filter_type_t filterType)
+        var handle = new FilterHandle();
+        var successful = false;
+        tiledb_filter_t* filter = null;
+        try
         {
-            var handle = new FilterHandle();
-            var successful = false;
-            tiledb_filter_t* filter = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            context.handle_error(Methods.tiledb_filter_alloc(contextHandle, filterType, &filter));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                context.handle_error(Methods.tiledb_filter_alloc(contextHandle, filterType, &filter));
-                successful = true;
+                handle.InitHandle(filter);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(filter);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_filter_free((tiledb_filter_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_filter_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_filter_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_filter_free((tiledb_filter_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_filter_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_filter_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterListHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/FilterListHandle.cs
@@ -2,52 +2,51 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class FilterListHandle : SafeHandle
 {
-    internal unsafe sealed class FilterListHandle : SafeHandle
+    public FilterListHandle() : base(IntPtr.Zero, true) { }
+
+    public FilterListHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static FilterListHandle Create(Context context)
     {
-        public FilterListHandle() : base(IntPtr.Zero, true) { }
-
-        public FilterListHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static FilterListHandle Create(Context context)
+        var handle = new FilterListHandle();
+        var successful = false;
+        tiledb_filter_list_t* filterList = null;
+        try
         {
-            var handle = new FilterListHandle();
-            var successful = false;
-            tiledb_filter_list_t* filterList = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            context.handle_error(Methods.tiledb_filter_list_alloc(contextHandle, &filterList));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                context.handle_error(Methods.tiledb_filter_list_alloc(contextHandle, &filterList));
-                successful = true;
+                handle.InitHandle(filterList);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(filterList);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_filter_list_free((tiledb_filter_list_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_filter_list_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_filter_list_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_filter_list_free((tiledb_filter_list_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_filter_list_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_filter_list_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/FragmentInfoHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/FragmentInfoHandle.cs
@@ -2,54 +2,53 @@
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class FragmentInfoHandle : SafeHandle
 {
-    internal unsafe sealed class FragmentInfoHandle : SafeHandle
+    public FragmentInfoHandle() : base(IntPtr.Zero, true) { }
+
+    public FragmentInfoHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static FragmentInfoHandle Create(Context context, sbyte* array_uri)
     {
-        public FragmentInfoHandle() : base(IntPtr.Zero, true) { }
-
-        public FragmentInfoHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static FragmentInfoHandle Create(Context context, sbyte* array_uri)
+        var handle = new FragmentInfoHandle();
+        bool successful = false;
+        tiledb_fragment_info_t* fragmentInfo = null;
+        try
         {
-            var handle = new FragmentInfoHandle();
-            bool successful = false;
-            tiledb_fragment_info_t* fragmentInfo = null;
-            try
+            using (var ctx = context.Handle.Acquire())
             {
-                using (var ctx = context.Handle.Acquire())
-                {
-                    context.handle_error(Methods.tiledb_fragment_info_alloc(ctx, array_uri, &fragmentInfo));
-                }
-                successful = true;
+                context.handle_error(Methods.tiledb_fragment_info_alloc(ctx, array_uri, &fragmentInfo));
             }
-            finally
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                if (successful)
-                {
-                    handle.InitHandle(fragmentInfo);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.InitHandle(fragmentInfo);
             }
-
-            return handle;
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* h = &handle)
-            {
-                Methods.tiledb_fragment_info_free((tiledb_fragment_info_t**)h);
-            }
-            return true;
-        }
-
-        private void InitHandle(tiledb_fragment_info_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_fragment_info_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* h = &handle)
+        {
+            Methods.tiledb_fragment_info_free((tiledb_fragment_info_t**)h);
+        }
+        return true;
+    }
+
+    private void InitHandle(tiledb_fragment_info_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_fragment_info_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/GroupHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/GroupHandle.cs
@@ -2,52 +2,51 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class GroupHandle : SafeHandle
 {
-    internal unsafe sealed class GroupHandle : SafeHandle
+    public GroupHandle() : base(IntPtr.Zero, true) { }
+
+    public GroupHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static GroupHandle Create(Context context, sbyte* uri)
     {
-        public GroupHandle() : base(IntPtr.Zero, true) { }
-
-        public GroupHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static GroupHandle Create(Context context, sbyte* uri)
+        var handle = new GroupHandle();
+        var successful = false;
+        tiledb_group_t* group = null;
+        try
         {
-            var handle = new GroupHandle();
-            var successful = false;
-            tiledb_group_t* group = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            context.handle_error(Methods.tiledb_group_alloc(contextHandle, uri, &group));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                context.handle_error(Methods.tiledb_group_alloc(contextHandle, uri, &group));
-                successful = true;
+                handle.InitHandle(group);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(group);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_group_free((tiledb_group_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_group_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_group_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_group_free((tiledb_group_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_group_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_group_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryChannelHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryChannelHandle.cs
@@ -2,34 +2,33 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class QueryChannelHandle : SafeHandle
 {
-    internal unsafe sealed class QueryChannelHandle : SafeHandle
+    // Keep the context handle around until this handle gets freed.
+    private SafeHandleHolder<tiledb_ctx_t> _ctx;
+
+    public QueryChannelHandle() : base(IntPtr.Zero, true) { }
+
+    public QueryChannelHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    protected override bool ReleaseHandle()
     {
-        // Keep the context handle around until this handle gets freed.
-        private SafeHandleHolder<tiledb_ctx_t> _ctx;
-
-        public QueryChannelHandle() : base(IntPtr.Zero, true) { }
-
-        public QueryChannelHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        protected override bool ReleaseHandle()
+        fixed (IntPtr* p = &handle)
         {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_query_channel_free(_ctx, (tiledb_query_channel_t**)p);
-            }
-            _ctx.Dispose();
-            return true;
+            Methods.tiledb_query_channel_free(_ctx, (tiledb_query_channel_t**)p);
         }
-
-        internal void InitHandle(Context ctx, tiledb_query_channel_t* h)
-        {
-            _ctx = ctx.Handle.Acquire();
-            SetHandle((IntPtr)h);
-        }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_query_channel_t> Acquire() => new(this);
+        _ctx.Dispose();
+        return true;
     }
+
+    internal void InitHandle(Context ctx, tiledb_query_channel_t* h)
+    {
+        _ctx = ctx.Handle.Acquire();
+        SetHandle((IntPtr)h);
+    }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_query_channel_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryConditionHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryConditionHandle.cs
@@ -2,52 +2,51 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class QueryConditionHandle : SafeHandle
 {
-    internal unsafe sealed class QueryConditionHandle : SafeHandle
+    public QueryConditionHandle() : base(IntPtr.Zero, true) { }
+
+    public QueryConditionHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static QueryConditionHandle Create(Context context)
     {
-        public QueryConditionHandle() : base(IntPtr.Zero, true) { }
-
-        public QueryConditionHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static QueryConditionHandle Create(Context context)
+        var handle = new QueryConditionHandle();
+        var successful = false;
+        tiledb_query_condition_t* queryCondition = null;
+        try
         {
-            var handle = new QueryConditionHandle();
-            var successful = false;
-            tiledb_query_condition_t* queryCondition = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            context.handle_error(Methods.tiledb_query_condition_alloc(contextHandle, &queryCondition));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                context.handle_error(Methods.tiledb_query_condition_alloc(contextHandle, &queryCondition));
-                successful = true;
+                handle.InitHandle(queryCondition);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(queryCondition);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_query_condition_free((tiledb_query_condition_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_query_condition_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_query_condition_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_query_condition_free((tiledb_query_condition_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_query_condition_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_query_condition_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryFieldHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryFieldHandle.cs
@@ -2,34 +2,33 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class QueryFieldHandle : SafeHandle
 {
-    internal unsafe sealed class QueryFieldHandle : SafeHandle
+    // Keep the context handle around until this handle gets freed.
+    private SafeHandleHolder<tiledb_ctx_t> _ctx;
+
+    public QueryFieldHandle() : base(IntPtr.Zero, true) { }
+
+    public QueryFieldHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    protected override bool ReleaseHandle()
     {
-        // Keep the context handle around until this handle gets freed.
-        private SafeHandleHolder<tiledb_ctx_t> _ctx;
-
-        public QueryFieldHandle() : base(IntPtr.Zero, true) { }
-
-        public QueryFieldHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        protected override bool ReleaseHandle()
+        fixed (IntPtr* p = &handle)
         {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_query_field_free(_ctx, (tiledb_query_field_t**)p);
-            }
-            _ctx.Dispose();
-            return true;
+            Methods.tiledb_query_field_free(_ctx, (tiledb_query_field_t**)p);
         }
-
-        internal void InitHandle(Context ctx, tiledb_query_field_t* h)
-        {
-            _ctx = ctx.Handle.Acquire();
-            SetHandle((IntPtr)h);
-        }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_query_field_t> Acquire() => new(this);
+        _ctx.Dispose();
+        return true;
     }
+
+    internal void InitHandle(Context ctx, tiledb_query_field_t* h)
+    {
+        _ctx = ctx.Handle.Acquire();
+        SetHandle((IntPtr)h);
+    }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_query_field_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/QueryHandle.cs
@@ -2,53 +2,52 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class QueryHandle : SafeHandle
 {
-    internal unsafe sealed class QueryHandle : SafeHandle
+    public QueryHandle() : base(IntPtr.Zero, true) { }
+
+    public QueryHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static QueryHandle Create(Context context, ArrayHandle arrayHandle, tiledb_query_type_t queryType)
     {
-        public QueryHandle() : base(IntPtr.Zero, true) { }
-
-        public QueryHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static QueryHandle Create(Context context, ArrayHandle arrayHandle, tiledb_query_type_t queryType)
+        var handle = new QueryHandle();
+        var successful = false;
+        tiledb_query_t* query = null;
+        try
         {
-            var handle = new QueryHandle();
-            var successful = false;
-            tiledb_query_t* query = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            using var arrayHandleHolder = arrayHandle.Acquire();
+            context.handle_error(Methods.tiledb_query_alloc(contextHandle, arrayHandleHolder, queryType, &query));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                using var arrayHandleHolder = arrayHandle.Acquire();
-                context.handle_error(Methods.tiledb_query_alloc(contextHandle, arrayHandleHolder, queryType, &query));
-                successful = true;
+                handle.InitHandle(query);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(query);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_query_free((tiledb_query_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_query_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_query_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_query_free((tiledb_query_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_query_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_query_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSFileHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSFileHandle.cs
@@ -2,54 +2,53 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class VFSFileHandle : SafeHandle
 {
-    internal unsafe sealed class VFSFileHandle : SafeHandle
+    public VFSFileHandle() : base(IntPtr.Zero, true) { }
+
+    public VFSFileHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static VFSFileHandle Open(Context context, VFSHandle vfsHandle, string uri, tiledb_vfs_mode_t mode)
     {
-        public VFSFileHandle() : base(IntPtr.Zero, true) { }
-
-        public VFSFileHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static VFSFileHandle Open(Context context, VFSHandle vfsHandle, string uri, tiledb_vfs_mode_t mode)
+        var handle = new VFSFileHandle();
+        var successful = false;
+        tiledb_vfs_fh_t* vfsFh = null;
+        try
         {
-            var handle = new VFSFileHandle();
-            var successful = false;
-            tiledb_vfs_fh_t* vfsFh = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            using var vfsHandleHolder = vfsHandle.Acquire();
+            using var ms_uri = new MarshaledString(uri);
+            context.handle_error(Methods.tiledb_vfs_open(contextHandle, vfsHandleHolder, ms_uri, mode, &vfsFh));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                using var vfsHandleHolder = vfsHandle.Acquire();
-                using var ms_uri = new MarshaledString(uri);
-                context.handle_error(Methods.tiledb_vfs_open(contextHandle, vfsHandleHolder, ms_uri, mode, &vfsFh));
-                successful = true;
+                handle.InitHandle(vfsFh);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(vfsFh);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_vfs_fh_free((tiledb_vfs_fh_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_vfs_fh_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_vfs_fh_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_vfs_fh_free((tiledb_vfs_fh_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_vfs_fh_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_vfs_fh_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSHandle.cs
+++ b/sources/TileDB.CSharp/Marshalling/SafeHandles/VFSHandle.cs
@@ -2,53 +2,52 @@ using System;
 using System.Runtime.InteropServices;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling.SafeHandles
+namespace TileDB.CSharp.Marshalling.SafeHandles;
+
+internal unsafe sealed class VFSHandle : SafeHandle
 {
-    internal unsafe sealed class VFSHandle : SafeHandle
+    public VFSHandle() : base(IntPtr.Zero, true) { }
+
+    public VFSHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
+
+    public static VFSHandle Create(Context context, ConfigHandle? configHandle)
     {
-        public VFSHandle() : base(IntPtr.Zero, true) { }
-
-        public VFSHandle(IntPtr handle, bool ownsHandle) : base(IntPtr.Zero, ownsHandle) { SetHandle(handle); }
-
-        public static VFSHandle Create(Context context, ConfigHandle? configHandle)
+        var handle = new VFSHandle();
+        var successful = false;
+        tiledb_vfs_t* vfs = null;
+        try
         {
-            var handle = new VFSHandle();
-            var successful = false;
-            tiledb_vfs_t* vfs = null;
-            try
+            using var contextHandle = context.Handle.Acquire();
+            using var configHandleHolder = configHandle?.Acquire() ?? default;
+            context.handle_error(Methods.tiledb_vfs_alloc(contextHandle, configHandleHolder, &vfs));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var contextHandle = context.Handle.Acquire();
-                using var configHandleHolder = configHandle?.Acquire() ?? default;
-                context.handle_error(Methods.tiledb_vfs_alloc(contextHandle, configHandleHolder, &vfs));
-                successful = true;
+                handle.InitHandle(vfs);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(vfs);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return handle;
         }
 
-        protected override bool ReleaseHandle()
-        {
-            fixed (IntPtr* p = &handle)
-            {
-                Methods.tiledb_vfs_free((tiledb_vfs_t**)p);
-            }
-            return true;
-        }
-
-        internal void InitHandle(tiledb_vfs_t* h) { SetHandle((IntPtr)h); }
-        public override bool IsInvalid => handle == IntPtr.Zero;
-
-        public SafeHandleHolder<tiledb_vfs_t> Acquire() => new(this);
+        return handle;
     }
+
+    protected override bool ReleaseHandle()
+    {
+        fixed (IntPtr* p = &handle)
+        {
+            Methods.tiledb_vfs_free((tiledb_vfs_t**)p);
+        }
+        return true;
+    }
+
+    internal void InitHandle(tiledb_vfs_t* h) { SetHandle((IntPtr)h); }
+    public override bool IsInvalid => handle == IntPtr.Zero;
+
+    public SafeHandleHolder<tiledb_vfs_t> Acquire() => new(this);
 }

--- a/sources/TileDB.CSharp/Marshalling/ScratchBuffer.cs
+++ b/sources/TileDB.CSharp/Marshalling/ScratchBuffer.cs
@@ -4,87 +4,86 @@ using System.Runtime.InteropServices;
 
 #nullable enable
 
-namespace TileDB.CSharp.Marshalling
+namespace TileDB.CSharp.Marshalling;
+
+/// <summary>
+/// Manages temporary buffers with low GC pressure.
+/// </summary>
+/// <remarks>
+/// Objects of this type should not be passed around; instead pass their <see cref="Span"/> property.
+/// </remarks>
+/// <typeparam name="T">The type of items this scratch buffer stores.</typeparam>
+internal ref struct ScratchBuffer<T>
 {
+    public Span<T> Span { get; private set; }
+
+    private T[]? _arrayToReturn;
+
     /// <summary>
-    /// Manages temporary buffers with low GC pressure.
+    /// Creates a <see cref="ScratchBuffer{T}"/> of length at least <paramref name="minimumLength"/>.
     /// </summary>
+    /// <param name="minimumLength">The buffer's minimum length.</param>
+    /// <param name="preAllocatedSpan">A pre-allocated <see cref="Span{T}"/> that will
+    /// be preferred if it has at least <paramref name="minimumLength"/> elements.</param>
+    /// <param name="exactSize">Whether to make <see cref="Span"/> be
+    /// exactly of length <paramref name="minimumLength"/>. Defaults to <see langword="false"/>.</param>
     /// <remarks>
-    /// Objects of this type should not be passed around; instead pass their <see cref="Span"/> property.
+    /// <paramref name="preAllocatedSpan"/> could be allocated from the stack using
+    /// the <see langword="stackalloc"/> keyword. If it is too small, <see cref="Span"/>
+    /// will come from the array pool.
     /// </remarks>
-    /// <typeparam name="T">The type of items this scratch buffer stores.</typeparam>
-    internal ref struct ScratchBuffer<T>
+    /// <seealso cref="ScratchBuffer{T}(int, bool)"/>
+    public ScratchBuffer(int minimumLength, Span<T> preAllocatedSpan, bool exactSize = false)
     {
-        public Span<T> Span { get; private set; }
-
-        private T[]? _arrayToReturn;
-
-        /// <summary>
-        /// Creates a <see cref="ScratchBuffer{T}"/> of length at least <paramref name="minimumLength"/>.
-        /// </summary>
-        /// <param name="minimumLength">The buffer's minimum length.</param>
-        /// <param name="preAllocatedSpan">A pre-allocated <see cref="Span{T}"/> that will
-        /// be preferred if it has at least <paramref name="minimumLength"/> elements.</param>
-        /// <param name="exactSize">Whether to make <see cref="Span"/> be
-        /// exactly of length <paramref name="minimumLength"/>. Defaults to <see langword="false"/>.</param>
-        /// <remarks>
-        /// <paramref name="preAllocatedSpan"/> could be allocated from the stack using
-        /// the <see langword="stackalloc"/> keyword. If it is too small, <see cref="Span"/>
-        /// will come from the array pool.
-        /// </remarks>
-        /// <seealso cref="ScratchBuffer{T}(int, bool)"/>
-        public ScratchBuffer(int minimumLength, Span<T> preAllocatedSpan, bool exactSize = false)
+        if (preAllocatedSpan.Length >= minimumLength)
         {
-            if (preAllocatedSpan.Length >= minimumLength)
-            {
-                Span = preAllocatedSpan;
-                if (exactSize)
-                {
-                    Span = Span[..minimumLength];
-                }
-                _arrayToReturn = null;
-            }
-            else
-                this = new ScratchBuffer<T>(minimumLength);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="ScratchBuffer{T}"/> of length at least <paramref name="minimumLength"/>.
-        /// </summary>
-        /// <param name="minimumLength">The buffer's minimum length.</param>
-        /// <param name="exactSize">Whether to make <see cref="Span"/> be
-        /// exactly of length <paramref name="minimumLength"/>. Defaults to <see langword="false"/>.</param>
-        /// <remarks>The created instance's <see cref="Span"/>
-        /// will always come from the array pool.</remarks>
-        public ScratchBuffer(int minimumLength, bool exactSize = false)
-        {
-            Span = _arrayToReturn = ArrayPool<T>.Shared.Rent(minimumLength);
+            Span = preAllocatedSpan;
             if (exactSize)
             {
                 Span = Span[..minimumLength];
             }
-        }
-
-        /// <summary>
-        /// Allows directly using this <see cref="ScratchBuffer{T}"/> in a <see langword="fixed"/> statement.
-        /// </summary>
-        public ref T GetPinnableReference() => ref MemoryMarshal.GetReference(Span);
-
-        /// <summary>
-        /// Disposes the <see cref="ScratchBuffer{T}"/>.
-        /// </summary>
-        /// <remarks>
-        /// This function must be always called after using a <see cref="ScratchBuffer{T}"/>
-        /// to release any pooled arrays that might have been used. You can use <see langword="using"/>
-        /// keyword to do it more intuitively. After disposal, the spans returned by the <see cref="Span"/>
-        /// property must not be used, and accessing it will return an empty span.</remarks>
-        public void Dispose()
-        {
-            if (_arrayToReturn == null) return;
-
-            Span = default;
-            ArrayPool<T>.Shared.Return(_arrayToReturn);
             _arrayToReturn = null;
         }
+        else
+            this = new ScratchBuffer<T>(minimumLength);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="ScratchBuffer{T}"/> of length at least <paramref name="minimumLength"/>.
+    /// </summary>
+    /// <param name="minimumLength">The buffer's minimum length.</param>
+    /// <param name="exactSize">Whether to make <see cref="Span"/> be
+    /// exactly of length <paramref name="minimumLength"/>. Defaults to <see langword="false"/>.</param>
+    /// <remarks>The created instance's <see cref="Span"/>
+    /// will always come from the array pool.</remarks>
+    public ScratchBuffer(int minimumLength, bool exactSize = false)
+    {
+        Span = _arrayToReturn = ArrayPool<T>.Shared.Rent(minimumLength);
+        if (exactSize)
+        {
+            Span = Span[..minimumLength];
+        }
+    }
+
+    /// <summary>
+    /// Allows directly using this <see cref="ScratchBuffer{T}"/> in a <see langword="fixed"/> statement.
+    /// </summary>
+    public ref T GetPinnableReference() => ref MemoryMarshal.GetReference(Span);
+
+    /// <summary>
+    /// Disposes the <see cref="ScratchBuffer{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// This function must be always called after using a <see cref="ScratchBuffer{T}"/>
+    /// to release any pooled arrays that might have been used. You can use <see langword="using"/>
+    /// keyword to do it more intuitively. After disposal, the spans returned by the <see cref="Span"/>
+    /// property must not be used, and accessing it will return an empty span.</remarks>
+    public void Dispose()
+    {
+        if (_arrayToReturn == null) return;
+
+        Span = default;
+        ArrayPool<T>.Shared.Return(_arrayToReturn);
+        _arrayToReturn = null;
     }
 }

--- a/sources/TileDB.CSharp/Marshalling/SequentialPair.cs
+++ b/sources/TileDB.CSharp/Marshalling/SequentialPair.cs
@@ -1,24 +1,23 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace TileDB.CSharp.Marshalling
+namespace TileDB.CSharp.Marshalling;
+
+/// <summary>
+/// A struct containing two values of the same type that can be passed to native code.
+/// Has implicit conversion operators between <see cref="ValueTuple{T,T}"/>.
+/// </summary>
+/// <typeparam name="T">The type of the values</typeparam>
+/// <remarks>
+/// We can't use value tuples in interop because they are marked with auto layout.
+/// </remarks>
+[StructLayout(LayoutKind.Sequential)]
+internal struct SequentialPair<T>
 {
-    /// <summary>
-    /// A struct containing two values of the same type that can be passed to native code.
-    /// Has implicit conversion operators between <see cref="ValueTuple{T,T}"/>.
-    /// </summary>
-    /// <typeparam name="T">The type of the values</typeparam>
-    /// <remarks>
-    /// We can't use value tuples in interop because they are marked with auto layout.
-    /// </remarks>
-    [StructLayout(LayoutKind.Sequential)]
-    internal struct SequentialPair<T>
-    {
-        public T First;
-        public T Second;
+    public T First;
+    public T Second;
 
-        public static implicit operator (T First, T Second)(SequentialPair<T> x) => (x.First, x.Second);
+    public static implicit operator (T First, T Second)(SequentialPair<T> x) => (x.First, x.Second);
 
-        public static implicit operator SequentialPair<T>((T First, T Second) x) => new() { First = x.First, Second = x.Second };
-    }
+    public static implicit operator SequentialPair<T>((T First, T Second) x) => new() { First = x.First, Second = x.Second };
 }

--- a/sources/TileDB.CSharp/Marshalling/StringHandleHolder.cs
+++ b/sources/TileDB.CSharp/Marshalling/StringHandleHolder.cs
@@ -3,38 +3,37 @@ using System.Diagnostics;
 using System.Text;
 using TileDB.Interop;
 
-namespace TileDB.CSharp.Marshalling
+namespace TileDB.CSharp.Marshalling;
+
+internal unsafe struct StringHandleHolder : IDisposable
 {
-    internal unsafe struct StringHandleHolder : IDisposable
+    internal tiledb_string_t* _handle;
+
+    public void Dispose()
     {
-        internal tiledb_string_t* _handle;
-
-        public void Dispose()
+        if (_handle == null)
         {
-            if (_handle == null)
-            {
-                return;
-            }
-
-            fixed (tiledb_string_t** handlePtr = &_handle)
-            {
-                int result = Methods.tiledb_string_free(handlePtr);
-                Debug.Assert(result == (int)Status.TILEDB_OK);
-            }
+            return;
         }
 
-        public override string ToString()
+        fixed (tiledb_string_t** handlePtr = &_handle)
         {
-            if (_handle == null)
-            {
-                return string.Empty;
-            }
-
-            byte* data;
-            nuint length;
-            ErrorHandling.ThrowOnError(Methods.tiledb_string_view(_handle, (sbyte**)&data, &length));
-
-            return Encoding.UTF8.GetString(data, checked((int)length));
+            int result = Methods.tiledb_string_free(handlePtr);
+            Debug.Assert(result == (int)Status.TILEDB_OK);
         }
+    }
+
+    public override string ToString()
+    {
+        if (_handle == null)
+        {
+            return string.Empty;
+        }
+
+        byte* data;
+        nuint length;
+        ErrorHandling.ThrowOnError(Methods.tiledb_string_view(_handle, (sbyte**)&data, &length));
+
+        return Encoding.UTF8.GetString(data, checked((int)length));
     }
 }

--- a/sources/TileDB.CSharp/Obsoletions.cs
+++ b/sources/TileDB.CSharp/Obsoletions.cs
@@ -1,51 +1,50 @@
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+internal static class Obsoletions
 {
-    internal static class Obsoletions
-    {
 #pragma warning disable S1075 // URIs should not be hardcoded
-        public const string SharedUrlFormat = "https://tiledb-inc.github.io/TileDB-CSharp/obsoletions.html#{0}";
+    public const string SharedUrlFormat = "https://tiledb-inc.github.io/TileDB-CSharp/obsoletions.html#{0}";
 #pragma warning restore S1075 // URIs should not be hardcoded
 
-        public const string LegacyEnumNamesMessage = "Enum values that start with TILEDB_ are obsolete.";
-        public const string LegacyEnumNamesDiagId = "TILEDB0001";
+    public const string LegacyEnumNamesMessage = "Enum values that start with TILEDB_ are obsolete.";
+    public const string LegacyEnumNamesDiagId = "TILEDB0001";
 
-        public const string ObsoleteDataTypeMessage = "This data type is obsolete.";
-        public const string ObsoleteDataTypeDiagId = "TILEDB0002";
+    public const string ObsoleteDataTypeMessage = "This data type is obsolete.";
+    public const string ObsoleteDataTypeDiagId = "TILEDB0002";
 
-        public const string TileDBInteropMessage = "Members of the TileDB.Interop namespace should not be used by user code and will become internal in a future version.";
-        public const string TileDBInteropDiagId = "TILEDB0003";
+    public const string TileDBInteropMessage = "Members of the TileDB.Interop namespace should not be used by user code and will become internal in a future version.";
+    public const string TileDBInteropDiagId = "TILEDB0003";
 
-        public const string ContextErrorHappenedMessage = "The Context.ErrorHappened event is obsolete and will not be invoked.";
-        public const string ContextErrorHappenedDiagId = "TILEDB0004";
+    public const string ContextErrorHappenedMessage = "The Context.ErrorHappened event is obsolete and will not be invoked.";
+    public const string ContextErrorHappenedDiagId = "TILEDB0004";
 
-        public const string ErrorExceptionMessage = "The ErrorException type is obsolete and will not be thrown. Catch TileDBException instead.";
-        public const string ErrorExceptionDiagId = "TILEDB0005";
+    public const string ErrorExceptionMessage = "The ErrorException type is obsolete and will not be thrown. Catch TileDBException instead.";
+    public const string ErrorExceptionDiagId = "TILEDB0005";
 
-        public const string DimensionCreateMessage = "The overload of Dimension.Create that accepts an array is obsolete. Use the overload that explicitly accepts the lower and upper bounds instead.";
-        public const string DimensionCreateDiagId = "TILEDB0006";
+    public const string DimensionCreateMessage = "The overload of Dimension.Create that accepts an array is obsolete. Use the overload that explicitly accepts the lower and upper bounds instead.";
+    public const string DimensionCreateDiagId = "TILEDB0006";
 
-        public const string QueryConditionInitMessage = "The constructor and Init method of the QueryCondition classes is obsolete. Use the static Create methods instead.";
-        public const string QueryConditionInitDiagId = "TILEDB0007";
+    public const string QueryConditionInitMessage = "The constructor and Init method of the QueryCondition classes is obsolete. Use the static Create methods instead.";
+    public const string QueryConditionInitDiagId = "TILEDB0007";
 
-        public const string QueryConditionCombineMessage = "The QueryCondition.Combine method is obsolete. Use the '&', '|' and '!' operators instead.";
-        public const string QueryConditionCombineDiagId = "TILEDB0008";
+    public const string QueryConditionCombineMessage = "The QueryCondition.Combine method is obsolete. Use the '&', '|' and '!' operators instead.";
+    public const string QueryConditionCombineDiagId = "TILEDB0008";
 
-        public const string ConsolidateMetadataMessage = "The Array.ConsolidateMetadata and ArrayMetadata.ConsolidateMetadata methods are obsolete. Call Array.Consolidate with the config value 'sm.consolidation.mode' set to 'array_meta' instead.";
-        public const string ConsolidateMetadataDiagId = "TILEDB0009";
+    public const string ConsolidateMetadataMessage = "The Array.ConsolidateMetadata and ArrayMetadata.ConsolidateMetadata methods are obsolete. Call Array.Consolidate with the config value 'sm.consolidation.mode' set to 'array_meta' instead.";
+    public const string ConsolidateMetadataDiagId = "TILEDB0009";
 
-        public const string QuerySubmitAsyncMessage = "The Query.SubmitAsync method is obsolete due to reliability problems and will be removed in a future release";
-        public const string QuerySubmitAsyncDiagId = "TILEDB0010";
+    public const string QuerySubmitAsyncMessage = "The Query.SubmitAsync method is obsolete due to reliability problems and will be removed in a future release";
+    public const string QuerySubmitAsyncDiagId = "TILEDB0010";
 
-        public const string QuerySubarrayMessage = "Subarray-related methods of the Query class are obsolete and will become unavailable in a future version.";
-        public const string QuerySubarrayDiagId = "TILEDB0011";
+    public const string QuerySubarrayMessage = "Subarray-related methods of the Query class are obsolete and will become unavailable in a future version.";
+    public const string QuerySubarrayDiagId = "TILEDB0011";
 
-        public const string TileDBInterop2Message = "Members of the TileDB.Interop namespace should not be used by user code and will become internal in a future version.";
-        public const string TileDBInterop2DiagId = "TILEDB0012";
+    public const string TileDBInterop2Message = "Members of the TileDB.Interop namespace should not be used by user code and will become internal in a future version.";
+    public const string TileDBInterop2DiagId = "TILEDB0012";
 
-        public const string DataTypeTypeConversionsMessage = "The EnumUtils.TypeToDataType and EnumUtils.DataTypeToType methods are obsolete and will be removed in a future version.";
-        public const string DataTypeTypeConversionsDiagId = "TILEDB0013";
+    public const string DataTypeTypeConversionsMessage = "The EnumUtils.TypeToDataType and EnumUtils.DataTypeToType methods are obsolete and will be removed in a future version.";
+    public const string DataTypeTypeConversionsDiagId = "TILEDB0013";
 
-        public const string TileDBInterop3Message = "Members of the TileDB.Interop namespace should not be used by user code and will become internal in a future version.";
-        public const string TileDBInterop3DiagId = "TILEDB0014";
-    }
+    public const string TileDBInterop3Message = "Members of the TileDB.Interop namespace should not be used by user code and will become internal in a future version.";
+    public const string TileDBInterop3DiagId = "TILEDB0014";
 }

--- a/sources/TileDB.CSharp/Query.cs
+++ b/sources/TileDB.CSharp/Query.cs
@@ -10,1231 +10,1230 @@ using TileDB.Interop;
 using QueryHandle = TileDB.CSharp.Marshalling.SafeHandles.QueryHandle;
 using ConfigHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Contains estimates for the result's size.
+/// </summary>
+public class ResultSize
 {
     /// <summary>
-    /// Contains estimates for the result's size.
+    /// The data size in bytes.
     /// </summary>
-    public class ResultSize
+    public ulong DataBytesSize;
+
+    /// <summary>
+    /// The offsets size in bytes.
+    /// </summary>
+    public ulong? OffsetsBytesSize;
+
+    /// <summary>
+    /// The validities size in bytes.
+    /// </summary>
+    public ulong? ValidityBytesSize;
+
+    /// <summary>
+    /// Constructor.
+    /// </summary>
+    /// <param name="dataSize"></param>
+    /// <param name="offsetsSize"></param>
+    /// <param name="validitySize"></param>
+    public ResultSize(ulong dataSize, ulong? offsetsSize = null, ulong? validitySize = null)
     {
-        /// <summary>
-        /// The data size in bytes.
-        /// </summary>
-        public ulong DataBytesSize;
-
-        /// <summary>
-        /// The offsets size in bytes.
-        /// </summary>
-        public ulong? OffsetsBytesSize;
-
-        /// <summary>
-        /// The validities size in bytes.
-        /// </summary>
-        public ulong? ValidityBytesSize;
-
-        /// <summary>
-        /// Constructor.
-        /// </summary>
-        /// <param name="dataSize"></param>
-        /// <param name="offsetsSize"></param>
-        /// <param name="validitySize"></param>
-        public ResultSize(ulong dataSize, ulong? offsetsSize = null, ulong? validitySize = null)
-        {
-            DataBytesSize = dataSize;
-            OffsetsBytesSize = offsetsSize;
-            ValidityBytesSize = validitySize;
-        }
-
-        /// <summary>
-        /// Returns if the result is about a variable-length attribute or dimension.
-        /// </summary>
-        public bool IsVarSize() => OffsetsBytesSize.HasValue;
-
-        /// <summary>
-        /// Returns if the result is about a nullable attribute.
-        /// </summary>
-        public bool IsNullable() => ValidityBytesSize.HasValue;
-
-        /// <summary>
-        /// Gets the number of data elements.
-        /// </summary>
-        /// <param name="dataType">The data type of the attribute or dimension.</param>
-        public ulong DataSize(DataType dataType) =>
-            DataBytesSize / Methods.tiledb_datatype_size((tiledb_datatype_t)dataType);
-
-        /// <summary>
-        /// Gets the number of offsets.
-        /// </summary>
-        public ulong OffsetsSize() => OffsetsBytesSize is ulong size ? size / sizeof(ulong) : 0;
-
-        /// <summary>
-        /// Gets the number of validities.
-        /// </summary>
-        public ulong ValiditySize() => ValidityBytesSize.GetValueOrDefault();
+        DataBytesSize = dataSize;
+        OffsetsBytesSize = offsetsSize;
+        ValidityBytesSize = validitySize;
     }
 
     /// <summary>
-    /// Represents a TileDB query object.
+    /// Returns if the result is about a variable-length attribute or dimension.
     /// </summary>
-    public sealed unsafe class Query : IDisposable
+    public bool IsVarSize() => OffsetsBytesSize.HasValue;
+
+    /// <summary>
+    /// Returns if the result is about a nullable attribute.
+    /// </summary>
+    public bool IsNullable() => ValidityBytesSize.HasValue;
+
+    /// <summary>
+    /// Gets the number of data elements.
+    /// </summary>
+    /// <param name="dataType">The data type of the attribute or dimension.</param>
+    public ulong DataSize(DataType dataType) =>
+        DataBytesSize / Methods.tiledb_datatype_size((tiledb_datatype_t)dataType);
+
+    /// <summary>
+    /// Gets the number of offsets.
+    /// </summary>
+    public ulong OffsetsSize() => OffsetsBytesSize is ulong size ? size / sizeof(ulong) : 0;
+
+    /// <summary>
+    /// Gets the number of validities.
+    /// </summary>
+    public ulong ValiditySize() => ValidityBytesSize.GetValueOrDefault();
+}
+
+/// <summary>
+/// Represents a TileDB query object.
+/// </summary>
+public sealed unsafe class Query : IDisposable
+{
+    private readonly Array _array;
+    private readonly Context _ctx;
+    private readonly QueryHandle _handle;
+    private bool _disposed;
+
+    private readonly Dictionary<string, BufferHandle> _dataBufferHandles = new Dictionary<string, BufferHandle>();
+    private readonly Dictionary<string, BufferHandle> _offsetsBufferHandles = new Dictionary<string, BufferHandle>();
+    private readonly Dictionary<string, BufferHandle> _validityBufferHandles = new Dictionary<string, BufferHandle>();
+
+    /// <summary>
+    /// Creates a <see cref="Query"/>.
+    /// </summary>
+    /// <param name="ctx">The context associated with this query.</param>
+    /// <param name="array">The array on which the query will operate.</param>
+    /// <param name="queryType">The query's type.</param>
+    /// <remarks>
+    /// This overload is not recommended for use in new code.
+    /// You should use <see cref="Query(CSharp.Array, CSharp.QueryType)"/> instead.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public Query(Context ctx, Array array, QueryType queryType)
     {
-        private readonly Array _array;
-        private readonly Context _ctx;
-        private readonly QueryHandle _handle;
-        private bool _disposed;
+        _ctx = ctx;
+        _array = array;
+        _handle = QueryHandle.Create(ctx, array.Handle, (tiledb_query_type_t)queryType);
+    }
 
-        private readonly Dictionary<string, BufferHandle> _dataBufferHandles = new Dictionary<string, BufferHandle>();
-        private readonly Dictionary<string, BufferHandle> _offsetsBufferHandles = new Dictionary<string, BufferHandle>();
-        private readonly Dictionary<string, BufferHandle> _validityBufferHandles = new Dictionary<string, BufferHandle>();
+    /// <summary>
+    /// Creates a <see cref="Query"/> with an implicit <see cref="CSharp.QueryType"/>.
+    /// </summary>
+    /// <param name="ctx">The context associated with this query.</param>
+    /// <param name="array">The array on which the query will operate. Its <see cref="Array.QueryType"/> will be used for the query.</param>
+    /// <remarks>
+    /// This overload is not recommended for use in new code.
+    /// You should use <see cref="Query(CSharp.Array)"/> instead.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public Query(Context ctx, Array array) : this(ctx, array, array.QueryType()) { }
 
-        /// <summary>
-        /// Creates a <see cref="Query"/>.
-        /// </summary>
-        /// <param name="ctx">The context associated with this query.</param>
-        /// <param name="array">The array on which the query will operate.</param>
-        /// <param name="queryType">The query's type.</param>
-        /// <remarks>
-        /// This overload is not recommended for use in new code.
-        /// You should use <see cref="Query(CSharp.Array, CSharp.QueryType)"/> instead.
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public Query(Context ctx, Array array, QueryType queryType)
-        {
-            _ctx = ctx;
-            _array = array;
-            _handle = QueryHandle.Create(ctx, array.Handle, (tiledb_query_type_t)queryType);
-        }
+    /// <summary>
+    /// Creates a <see cref="Query"/>.
+    /// </summary>
+    /// <param name="array">The array on which the query will operate.</param>
+    /// <param name="queryType">The query's type.</param>
+    public Query(Array array, QueryType queryType) : this(array.Context(), array, queryType) { }
 
-        /// <summary>
-        /// Creates a <see cref="Query"/> with an implicit <see cref="CSharp.QueryType"/>.
-        /// </summary>
-        /// <param name="ctx">The context associated with this query.</param>
-        /// <param name="array">The array on which the query will operate. Its <see cref="Array.QueryType"/> will be used for the query.</param>
-        /// <remarks>
-        /// This overload is not recommended for use in new code.
-        /// You should use <see cref="Query(CSharp.Array)"/> instead.
-        /// </remarks>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public Query(Context ctx, Array array) : this(ctx, array, array.QueryType()) { }
+    /// <summary>
+    /// Creates a <see cref="Query"/> with an implicit <see cref="CSharp.QueryType"/>.
+    /// </summary>
+    /// <param name="array">The array on which the query will operate. Its <see cref="Array.QueryType"/> will be used for the query.</param>
+    public Query(Array array) : this(array.Context(), array) { }
 
-        /// <summary>
-        /// Creates a <see cref="Query"/>.
-        /// </summary>
-        /// <param name="array">The array on which the query will operate.</param>
-        /// <param name="queryType">The query's type.</param>
-        public Query(Array array, QueryType queryType) : this(array.Context(), array, queryType) { }
+    /// <summary>
+    /// Disposes this <see cref="Query"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _handle.Dispose();
+        FreeAllBufferHandles();
+        _disposed = true;
+    }
 
-        /// <summary>
-        /// Creates a <see cref="Query"/> with an implicit <see cref="CSharp.QueryType"/>.
-        /// </summary>
-        /// <param name="array">The array on which the query will operate. Its <see cref="Array.QueryType"/> will be used for the query.</param>
-        public Query(Array array) : this(array.Context(), array) { }
+    internal QueryHandle Handle => _handle;
 
-        /// <summary>
-        /// Disposes this <see cref="Query"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            if (_disposed) return;
-            _handle.Dispose();
-            FreeAllBufferHandles();
-            _disposed = true;
-        }
-
-        internal QueryHandle Handle => _handle;
-
-        /// <summary>
-        /// Gets a JSON string with statistics about the query.
-        /// </summary>
-        public string Stats()
-        {
-            sbyte* result = null;
-            try
-            {
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var handle = _handle.Acquire();
-                ErrorHandling.ThrowOnError(Methods.tiledb_query_get_stats(ctxHandle, handle, &result));
-
-                return MarshaledStringOut.GetStringFromNullTerminated(result);
-            }
-            finally
-            {
-                if (result is not null)
-                {
-                    ErrorHandling.ThrowOnError(Methods.tiledb_stats_free_str(&result));
-                }
-            }
-        }
-
-        /// <summary>
-        /// Set config.
-        /// </summary>
-        /// <param name="config"></param>
-        public void SetConfig(Config config)
+    /// <summary>
+    /// Gets a JSON string with statistics about the query.
+    /// </summary>
+    public string Stats()
+    {
+        sbyte* result = null;
+        try
         {
             using var ctxHandle = _ctx.Handle.Acquire();
             using var handle = _handle.Acquire();
-            using var configHandle = config.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_query_set_config(ctxHandle, handle, configHandle));
-        }
+            ErrorHandling.ThrowOnError(Methods.tiledb_query_get_stats(ctxHandle, handle, &result));
 
-        /// <summary>
-        /// Get config.
-        /// </summary>
-        /// <returns></returns>
-        public Config Config()
-        {
-            var handle = new ConfigHandle();
-            var successful = false;
-            tiledb_config_t* config = null;
-            try
-            {
-                using var ctxHandle = _ctx.Handle.Acquire();
-                using var queryHandle = _handle.Acquire();
-                _ctx.handle_error(Methods.tiledb_query_get_config(ctxHandle, queryHandle, &config));
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(config);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-            return new Config(handle);
-        }
-
-        /// <summary>
-        /// Indicates that the query will write to or read from a <see cref="Subarray"/>, and provides the appropriate information.
-        /// </summary>
-        /// <param name="subarray">The subarray to use.</param>
-        public void SetSubarray(Subarray subarray)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var subarrayHandle = subarray.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_query_set_subarray_t(ctxHandle, handle, subarrayHandle));
-        }
-
-        /// <summary>
-        /// Creates a <see cref="Subarray"/> corresponding to this query.
-        /// </summary>
-        public Subarray GetSubarray()
-        {
-            var handle = new SubarrayHandle();
-            var successful = false;
-            tiledb_subarray_t* subarray = null;
-            try
-            {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var queryHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_query_get_subarray_t(ctxHandle, queryHandle, &subarray));
-                }
-                successful = true;
-            }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(subarray);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return new Subarray(_ctx, _array, handle);
-        }
-
-        /// <summary>
-        /// Sets the data buffer for an attribute or dimension to an array.
-        /// </summary>
-        /// <typeparam name="T">The buffer's type.</typeparam>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">An array where the data will be read or written.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty or <typeparamref name="T"/>
-        /// does not match the excepted data type.</exception>
-        public void SetDataBuffer<T>(string name, T[] data) where T : struct
-        {
-            if (data is null)
-            {
-                ThrowHelpers.ThrowArgumentNullException(nameof(data));
-            }
-
-            SetDataBuffer(name, data.AsMemory());
-        }
-
-        /// <summary>
-        /// Sets the data buffer for an attribute or dimension to a <see cref="Memory{T}"/>.
-        /// </summary>
-        /// <typeparam name="T">The buffer's type.</typeparam>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">An <see cref="Memory{T}"/> where the data will be read or written.</param>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty or <typeparamref name="T"/>
-        /// does not match the excepted data type.</exception>
-        public void SetDataBuffer<T>(string name, Memory<T> data) where T : struct
-        {
-            CheckDataType<T>(name);
-
-            if (data.IsEmpty)
-            {
-                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(data));
-            }
-
-            UnsafeSetDataBuffer(name, data.Pin(), (ulong)data.Length * (ulong)sizeof(T), sizeof(T));
-        }
-
-        /// <summary>
-        /// Sets the data buffer for an attribute or dimension to an unmanaged memory buffer.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">A pointer to the memory buffer.</param>
-        /// <param name="size">The buffer's size <em>in <typeparamref name="T"/> values</em>.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="size"/> is zero or <typeparamref name="T"/>
-        /// does not match the excepted data type.</exception>
-        public void SetDataBuffer<T>(string name, T* data, ulong size) where T : struct
-        {
-            if (data is null)
-            {
-                ThrowHelpers.ThrowArgumentNullException(nameof(data));
-            }
-
-            if (size == 0)
-            {
-                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(size));
-            }
-
-            CheckDataType<T>(name);
-
-            UnsafeSetDataBuffer(name, new MemoryHandle(data), size * (ulong)sizeof(T), sizeof(T));
-        }
-
-        /// <summary>
-        /// Sets the data buffer for an attribute or dimension to a <see cref="ReadOnlyMemory{T}"/>.
-        /// Not supported for <see cref="QueryType.Read"/> queries.
-        /// </summary>
-        /// <typeparam name="T">The buffer's type.</typeparam>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> from where the data will be written.</param>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty or <typeparamref name="T"/>
-        /// does not match the excepted data type.</exception>
-        /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
-        public void SetDataReadOnlyBuffer<T>(string name, ReadOnlyMemory<T> data) where T : struct
-        {
-            if (QueryType() == CSharp.QueryType.Read)
-            {
-                ThrowHelpers.ThrowOperationNotAllowedOnReadQueries();
-            }
-
-            SetDataBuffer(name, MemoryMarshal.AsMemory(data));
-        }
-
-        /// <summary>
-        /// Sets the data buffer for an attribute or dimension to an
-        /// unmanaged memory buffer without performing type validation.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">A pointer to the memory buffer.</param>
-        /// <param name="byteSize">The buffer's size <em>in bytes</em>.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="byteSize"/> is zero.</exception>
-        public void UnsafeSetDataBuffer(string name, void* data, ulong byteSize)
-        {
-            if (data is null)
-            {
-                ThrowHelpers.ThrowArgumentNullException(nameof(data));
-            }
-
-            if (byteSize == 0)
-            {
-                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(byteSize));
-            }
-
-            UnsafeSetDataBuffer(name, new MemoryHandle(data), byteSize, 0);
-        }
-
-        /// <summary>
-        /// Sets the data buffer for an attribute or dimension to a
-        /// byte buffer without performing type validation.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">A <see cref="Memory{T}"/> of bytes pointing to the buffer.</param>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
-        public void UnsafeSetDataBuffer(string name, Memory<byte> data)
-        {
-            if (data.IsEmpty)
-            {
-                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(data));
-            }
-
-            UnsafeSetDataBuffer(name, data.Pin(), (ulong)data.Length, 0);
-        }
-
-        /// <summary>
-        /// Sets the data buffer for an attribute or dimension
-        /// to a pinned memory buffer pointed by a <see cref="MemoryHandle"/>.
-        /// This method does not perform type validation.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="memoryHandle">A <see cref="MemoryHandle"/> pointing to the buffer.</param>
-        /// <param name="byteSize">The buffer's size <em>in bytes</em>.</param>
-        /// <exception cref="ArgumentException"><paramref name="byteSize"/> is zero.</exception>
-        /// <remarks>
-        /// <para>After calling this method, user code must not use <paramref name="memoryHandle"/>;
-        /// its ownership is transferred to this <see cref="Query"/> object.</para>
-        /// <para><paramref name="memoryHandle"/> will be disposed when one of the following happens:
-        /// <list type="bullet">
-        /// <item>The <see cref="Dispose"/> method is called.</item>
-        /// <item>The buffer for <paramref name="name"/> is reassigned through subsequent calls to this method.</item>
-        /// <item>This method call throws an exception.</item>
-        /// </list></para>
-        /// </remarks>
-        public void UnsafeSetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize)
-        {
-            if (byteSize == 0)
-            {
-                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(byteSize));
-            }
-
-            UnsafeSetDataBuffer(name, memoryHandle, byteSize, 0);
-        }
-
-        private void UnsafeSetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize, int elementSize)
-        {
-            BufferHandle? handle = null;
-            bool successful = false;
-            try
-            {
-                handle = new BufferHandle(ref memoryHandle, byteSize, elementSize);
-
-                SetDataBufferCore(name, handle.DataPointer, handle.SizePointer);
-
-                AddOrReplaceBufferHandle(_dataBufferHandles, name, handle);
-                successful = true;
-            }
-            finally
-            {
-                if (!successful)
-                {
-                    memoryHandle.Dispose();
-                    handle?.Dispose();
-                }
-            }
-        }
-
-        /// <summary>
-        /// Sets the data buffer for an attribute or dimension to a
-        /// read-only byte buffer without performing type validation.
-        /// Not supported for <see cref="QueryType.Read"/> queries.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> of bytes pointing to the buffer.</param>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
-        /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
-        public void UnsafeSetDataReadOnlyBuffer(string name, ReadOnlyMemory<byte> data)
-        {
-            if (QueryType() == CSharp.QueryType.Read)
-            {
-                ThrowHelpers.ThrowOperationNotAllowedOnReadQueries();
-            }
-
-            UnsafeSetDataBuffer(name, MemoryMarshal.AsMemory(data));
-        }
-
-        private void SetDataBufferCore(string name, void* data, ulong* size)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(name);
-            _ctx.handle_error(Methods.tiledb_query_set_data_buffer(ctxHandle, handle, ms_name, data, size));
-        }
-
-        /// <summary>
-        /// Sets the offsets buffer for a variable-sized attribute or dimension to an array.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">An array where the offsets will be read or written.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
-        public void SetOffsetsBuffer(string name, ulong[] data)
-        {
-            if (data is null)
-            {
-                ThrowHelpers.ThrowArgumentNullException(nameof(data));
-            }
-
-            SetOffsetsBuffer(name, data.AsMemory());
-        }
-
-        /// <summary>
-        /// Sets the offsets buffer for a variable-sized attribute or dimension to a <see cref="Memory{T}"/>.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">A <see cref="Memory{T}"/> where the offsets will be read or written.</param>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
-        public void SetOffsetsBuffer(string name, Memory<ulong> data)
-        {
-            if (data.IsEmpty)
-            {
-                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(data));
-            }
-
-            UnsafeSetOffsetsBuffer(name, data.Pin(), (ulong)data.Length);
-        }
-
-        /// <summary>
-        /// Sets the offsets buffer for a variable-sized attribute or dimension to an unmanaged memory buffer.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">A pointer to the memory buffer.</param>
-        /// <param name="size">The buffer's size <em>in 64-bit integers</em>.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="size"/> is zero.</exception>
-        public void SetOffsetsBuffer(string name, ulong* data, ulong size)
-        {
-            if (data is null)
-            {
-                ThrowHelpers.ThrowArgumentNullException(nameof(data));
-            }
-
-            if (size == 0)
-            {
-                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(size));
-            }
-
-            UnsafeSetOffsetsBuffer(name, new MemoryHandle(data), size);
-        }
-
-        /// <summary>
-        /// Sets the offsets buffer for a variable-sized attribute or dimension
-        /// to a pinned memory buffer pointed by a <see cref="MemoryHandle"/>.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="memoryHandle">A <see cref="MemoryHandle"/> pointing to the buffer.</param>
-        /// <param name="size">The buffer's size <em>in 64-bit integers</em>.</param>
-        /// <exception cref="ArgumentException"><paramref name="size"/> is zero.</exception>
-        /// <remarks>
-        /// <para>After calling this method, user code must not use <paramref name="memoryHandle"/>;
-        /// its ownership is transferred to this <see cref="Query"/> object.</para>
-        /// <para><paramref name="memoryHandle"/> will be disposed when one of the following happens:
-        /// <list type="bullet">
-        /// <item>The <see cref="Dispose"/> method is called.</item>
-        /// <item>The buffer for <paramref name="name"/> is reassigned through subsequent calls to this method.</item>
-        /// <item>This method call throws an exception.</item>
-        /// </list></para>
-        /// </remarks>
-        private void UnsafeSetOffsetsBuffer(string name, MemoryHandle memoryHandle, ulong size)
-        {
-            BufferHandle? handle = null;
-            bool successful = false;
-            try
-            {
-                handle = new BufferHandle(ref memoryHandle, size * sizeof(ulong), sizeof(ulong));
-
-                SetOffsetsBufferCore(name, (ulong*)handle.DataPointer, handle.SizePointer);
-
-                AddOrReplaceBufferHandle(_offsetsBufferHandles, name, handle);
-                successful = true;
-            }
-            finally
-            {
-                if (!successful)
-                {
-                    memoryHandle.Dispose();
-                    handle?.Dispose();
-                }
-            }
-        }
-
-        private void SetOffsetsBufferCore(string name, ulong* data, ulong* size)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(name);
-            _ctx.handle_error(Methods.tiledb_query_set_offsets_buffer(ctxHandle, handle, ms_name, data, size));
-        }
-
-        /// <summary>
-        /// Sets the offsets buffer for a variable-sized attribute or dimension to a <see cref="ReadOnlyMemory{T}"/>.
-        /// Not supported for <see cref="QueryType.Read"/> queries.
-        /// </summary>
-        /// <param name="name">The name of the attribute or the dimension.</param>
-        /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> from where the offsets will be written.</param>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
-        /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
-        public void SetOffsetsReadOnlyBuffer(string name, ReadOnlyMemory<ulong> data)
-        {
-            if (QueryType() != CSharp.QueryType.Read)
-            {
-                ThrowHelpers.ThrowOperationNotAllowedOnReadQueries();
-            }
-
-            SetOffsetsBuffer(name, MemoryMarshal.AsMemory(data));
-        }
-
-        /// <summary>
-        /// Sets the validity buffer for a nullable attribute to an array.
-        /// </summary>
-        /// <param name="name">The name of the attribute.</param>
-        /// <param name="data">An array where the validities will be read or written.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
-        /// <remarks>
-        /// Each value corresponds to whether an element exists (1) or not (0).
-        /// </remarks>
-        public void SetValidityBuffer(string name, byte[] data)
-        {
-            if (data is null)
-            {
-                ThrowHelpers.ThrowArgumentNullException(nameof(data));
-            }
-
-            SetValidityBuffer(name, data.AsMemory());
-        }
-
-        /// <summary>
-        /// Sets the validity buffer for a nullable attribute to a <see cref="Memory{T}"/>.
-        /// </summary>
-        /// <param name="name">The name of the attribute.</param>
-        /// <param name="data">A <see cref="Memory{T}"/> where the validities will be read or written.</param>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
-        /// <remarks>
-        /// Each value corresponds to whether an element exists (1) or not (0).
-        /// </remarks>
-        public void SetValidityBuffer(string name, Memory<byte> data)
-        {
-            if (data.IsEmpty)
-            {
-                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(data));
-            }
-
-            UnsafeSetValidityBuffer(name, data.Pin(), (ulong)data.Length);
-        }
-
-        /// <summary>
-        /// Sets the validity buffer for a nullable attribute to an unmanaged memory buffer.
-        /// </summary>
-        /// <param name="name">The name of the attribute.</param>
-        /// <param name="data">A pointer to the memory buffer.</param>
-        /// <param name="size">The buffer's size.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
-        /// <exception cref="ArgumentException"><paramref name="size"/> is zero.</exception>
-        /// <remarks>
-        /// Each value corresponds to whether an element exists (1) or not (0).
-        /// </remarks>
-        public void SetValidityBuffer(string name, byte* data, ulong size)
-        {
-            if (data is null)
-            {
-                ThrowHelpers.ThrowArgumentNullException(nameof(data));
-            }
-
-            if (size == 0)
-            {
-                ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(size));
-            }
-
-            UnsafeSetValidityBuffer(name, new MemoryHandle(data), size);
-        }
-
-        /// <summary>
-        /// Sets the validity buffer for a nullable attribute to a <see cref="ReadOnlyMemory{T}"/>.
-        /// Not supported for <see cref="QueryType.Read"/> queries.
-        /// </summary>
-        /// <param name="name">The name of the attribute.</param>
-        /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> from where the validities will be written.</param>
-        /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
-        /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
-        /// <remarks>
-        /// Each value corresponds to whether an element exists (1) or not (0).
-        /// </remarks>
-        public void SetValidityReadOnlyBuffer(string name, ReadOnlyMemory<byte> data)
-        {
-            if (QueryType() == CSharp.QueryType.Read)
-            {
-                ThrowHelpers.ThrowOperationNotAllowedOnReadQueries();
-            }
-
-            SetValidityBuffer(name, MemoryMarshal.AsMemory(data));
-        }
-
-        /// <summary>
-        /// Sets the validity buffer for a nullable attribute
-        /// to a pinned memory buffer pointed by a <see cref="MemoryHandle"/>.
-        /// </summary>
-        /// <param name="name">The name of the attribute.</param>
-        /// <param name="memoryHandle">A <see cref="MemoryHandle"/> pointing to the buffer.</param>
-        /// <param name="size">The buffer's size.</param>
-        /// <exception cref="ArgumentException"><paramref name="size"/> is zero.</exception>
-        /// <remarks>
-        /// <para>Each value corresponds to whether an element exists (1) or not (0).</para>
-        /// <para>After calling this method, user code must not use <paramref name="memoryHandle"/>;
-        /// its ownership is transferred to this <see cref="Query"/> object.</para>
-        /// <para><paramref name="memoryHandle"/> will be disposed when one of the following happens:
-        /// <list type="bullet">
-        /// <item>The <see cref="Dispose"/> method is called.</item>
-        /// <item>The buffer for <paramref name="name"/> is reassigned through subsequent calls to this method.</item>
-        /// <item>This method call throws an exception.</item>
-        /// </list></para>
-        /// </remarks>
-        private void UnsafeSetValidityBuffer(string name, MemoryHandle memoryHandle, ulong size)
-        {
-            BufferHandle? handle = null;
-            bool successful = false;
-            try
-            {
-                handle = new BufferHandle(ref memoryHandle, size * sizeof(byte), sizeof(byte));
-
-                SetValidityBufferCore(name, (byte*)handle.DataPointer, handle.SizePointer);
-
-                AddOrReplaceBufferHandle(_validityBufferHandles, name, handle);
-                successful = true;
-            }
-            finally
-            {
-                if (!successful)
-                {
-                    memoryHandle.Dispose();
-                    handle?.Dispose();
-                }
-            }
-        }
-
-        private void SetValidityBufferCore(string name, byte* data, ulong* size)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(name);
-            _ctx.handle_error(Methods.tiledb_query_set_validity_buffer(ctxHandle, handle, ms_name, data, size));
-        }
-
-        /// <summary>
-        /// Sets the layout of the cells to be written or read.
-        /// </summary>
-        /// <param name="layouttype"></param>
-        public void SetLayout(LayoutType layouttype)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_query_set_layout(ctxHandle, handle, (tiledb_layout_t)layouttype));
-        }
-
-        /// <summary>
-        /// Sets the layout of the cells to be written or read.
-        /// </summary>
-        /// <returns></returns>
-        public LayoutType QueryLayout()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_layout_t layout;
-            _ctx.handle_error(Methods.tiledb_query_get_layout(ctxHandle, handle, &layout));
-            return (LayoutType)layout;
-        }
-
-        /// <summary>
-        /// Sets the query condition to be applied on a read.
-        /// </summary>
-        /// <param name="condition"></param>
-        public void SetCondition(QueryCondition condition)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var conditionHandle = condition.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_query_set_condition(ctxHandle, handle, conditionHandle));
-        }
-
-        /// <summary>
-        /// Flushes all internal state of a query object and finalizes the query, only applicable to global layout writes.
-        /// </summary>
-        public void FinalizeQuery()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_query_finalize(ctxHandle, handle));
-        }
-
-        /// <summary>
-        /// Submits the query. Call will block until query is complete.
-        /// </summary>
-        /// <returns></returns>
-        public QueryStatus Submit()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_query_submit(ctxHandle, handle));
-            return QueryStatus.Completed;
-        }
-
-        /// <summary>
-        /// Submits and finalizes the query.
-        /// </summary>
-        /// <seealso cref="Submit"/>
-        /// <seealso cref="FinalizeQuery"/>
-        public void SubmitAndFinalize()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_query_submit_and_finalize(ctxHandle, handle));
-        }
-
-        /// <summary>
-        /// Returns `true` if the query has results. Applicable only to read; false for write queries.
-        /// </summary>
-        /// <returns></returns>
-        public bool HasResults()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            int ret;
-            _ctx.handle_error(Methods.tiledb_query_has_results(ctxHandle, handle, &ret));
-            return ret > 0;
-        }
-
-        /// <summary>
-        /// Returns a <see cref="QueryStatusDetails"/> value describing this <see cref="Query"/>.
-        /// </summary>
-        public QueryStatusDetails GetStatusDetails()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            QueryStatusDetails statusDetails;
-            _ctx.handle_error(Methods.tiledb_query_get_status_details(ctxHandle, handle, &statusDetails._details));
-            return statusDetails;
-        }
-
-        /// <summary>
-        /// Returns the query status.
-        /// </summary>
-        /// <returns></returns>
-        public QueryStatus Status()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_query_status_t query_status;
-            _ctx.handle_error(Methods.tiledb_query_get_status(ctxHandle, handle, &query_status));
-            return (QueryStatus)query_status;
-        }
-
-        /// <summary>
-        /// Returns the query type (read or write).
-        /// </summary>
-        /// <returns></returns>
-        public QueryType QueryType()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            tiledb_query_type_t query_type;
-            _ctx.handle_error(Methods.tiledb_query_get_type(ctxHandle, handle, &query_type));
-            return (QueryType)query_type;
-        }
-
-        /// <summary>
-        /// Returns the array of the query.
-        /// </summary>
-        /// <returns></returns>
-        public Array Array()
-        {
-            return _array;
-        }
-
-        private ulong GetEstimatedResultSize(string name)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(name);
-            ulong size;
-            _ctx.handle_error(Methods.tiledb_query_get_est_result_size(ctxHandle, handle, ms_name, &size));
-            return size;
-        }
-
-        private (ulong OffsetSize, ulong DataSize) GetEstimatedResultSizeVar(string name)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(name);
-            ulong size_off;
-            ulong size_val;
-            _ctx.handle_error(Methods.tiledb_query_get_est_result_size_var(ctxHandle, handle, ms_name, &size_off, &size_val));
-
-            return (size_off, size_val);
-        }
-
-        private (ulong DataSize, ulong ValiditySize) GetEstimatedResultSizeNullable(string name)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(name);
-            ulong size_val;
-            ulong size_validity;
-            _ctx.handle_error(Methods.tiledb_query_get_est_result_size_nullable(ctxHandle, handle, ms_name, &size_val, &size_validity));
-            return (size_val, size_validity);
-        }
-
-        private (ulong OffsetsSize, ulong DataSize, ulong ValiditySize) GetEstimatedResultSizeVarNullable(string name)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(name);
-            ulong size_off;
-            ulong size_val;
-            ulong size_validity;
-
-            _ctx.handle_error(Methods.tiledb_query_get_est_result_size_var_nullable(ctxHandle, handle, ms_name, &size_off, &size_val, &size_validity));
-
-            return (size_off, size_val, size_validity);
-        }
-
-        /// <summary>
-        /// Estimates the result size for an attribute or dimension.
-        /// </summary>
-        /// <param name="name">The name of the attribute or dimension.</param>
-        public ResultSize EstResultSize(string name)
-        {
-            bool isVar, isNullable;
-            using (var schema = _array.Schema())
-            {
-                isVar = schema.IsVarSize(name);
-                isNullable = schema.IsNullable(name);
-            }
-            switch (isVar, isNullable)
-            {
-                case (true, true):
-                    (var offsetsSize, var dataSize, var validitySize) = GetEstimatedResultSizeVarNullable(name);
-                    return new ResultSize(offsetsSize, dataSize, validitySize);
-                case (true, false):
-                    (offsetsSize, dataSize) = GetEstimatedResultSizeVar(name);
-                    return new ResultSize(dataSize, offsetsSize);
-                case (false, true):
-                    (dataSize, validitySize) = GetEstimatedResultSizeNullable(name);
-                    return new ResultSize(dataSize, null, validitySize);
-                case (false, false):
-                    dataSize = GetEstimatedResultSize(name);
-                    return new ResultSize(dataSize);
-            }
-        }
-
-        /// <summary>
-        /// Returns the number of written fragments. Applicable only to WRITE queries.
-        /// </summary>
-        /// <returns></returns>
-        public uint FragmentNum()
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            uint num;
-            _ctx.handle_error(Methods.tiledb_query_get_fragment_num(ctxHandle, handle, &num));
-            return num;
-        }
-
-        /// <summary>
-        /// Returns the URI of the written fragment with the input index. Applicable only to WRITE queries.
-        /// </summary>
-        /// <param name="idx"></param>
-        /// <returns></returns>
-        public string FragmentUri(ulong idx)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            sbyte* result;
-            _ctx.handle_error(Methods.tiledb_query_get_fragment_uri(ctxHandle, handle, idx, &result));
             return MarshaledStringOut.GetStringFromNullTerminated(result);
         }
+        finally
+        {
+            if (result is not null)
+            {
+                ErrorHandling.ThrowOnError(Methods.tiledb_stats_free_str(&result));
+            }
+        }
+    }
 
-        /// <summary>
-        /// Retrieves the timestamp range of the written fragment with the input index. Applicable only to WRITE queries.
-        /// </summary>
-        /// <param name="idx"></param>
-        /// <returns></returns>
-        public Tuple<ulong, ulong> FragmentTimestampRange(ulong idx)
+    /// <summary>
+    /// Set config.
+    /// </summary>
+    /// <param name="config"></param>
+    public void SetConfig(Config config)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var configHandle = config.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_query_set_config(ctxHandle, handle, configHandle));
+    }
+
+    /// <summary>
+    /// Get config.
+    /// </summary>
+    /// <returns></returns>
+    public Config Config()
+    {
+        var handle = new ConfigHandle();
+        var successful = false;
+        tiledb_config_t* config = null;
+        try
         {
             using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong t1;
-            ulong t2;
-            _ctx.handle_error(Methods.tiledb_query_get_fragment_timestamp_range(ctxHandle, handle, idx, &t1, &t2));
-            return new Tuple<ulong, ulong>(t1, t2);
+            using var queryHandle = _handle.Acquire();
+            _ctx.handle_error(Methods.tiledb_query_get_config(ctxHandle, queryHandle, &config));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(config);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+        return new Config(handle);
+    }
+
+    /// <summary>
+    /// Indicates that the query will write to or read from a <see cref="Subarray"/>, and provides the appropriate information.
+    /// </summary>
+    /// <param name="subarray">The subarray to use.</param>
+    public void SetSubarray(Subarray subarray)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var subarrayHandle = subarray.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_query_set_subarray_t(ctxHandle, handle, subarrayHandle));
+    }
+
+    /// <summary>
+    /// Creates a <see cref="Subarray"/> corresponding to this query.
+    /// </summary>
+    public Subarray GetSubarray()
+    {
+        var handle = new SubarrayHandle();
+        var successful = false;
+        tiledb_subarray_t* subarray = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var queryHandle = _handle.Acquire())
+            {
+                _ctx.handle_error(Methods.tiledb_query_get_subarray_t(ctxHandle, queryHandle, &subarray));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(subarray);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
         }
 
-        /// <summary>
-        /// Returns the query's default <see cref="QueryChannel"/>.
-        /// </summary>
-        public QueryChannel GetDefaultChannel()
+        return new Subarray(_ctx, _array, handle);
+    }
+
+    /// <summary>
+    /// Sets the data buffer for an attribute or dimension to an array.
+    /// </summary>
+    /// <typeparam name="T">The buffer's type.</typeparam>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">An array where the data will be read or written.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty or <typeparamref name="T"/>
+    /// does not match the excepted data type.</exception>
+    public void SetDataBuffer<T>(string name, T[] data) where T : struct
+    {
+        if (data is null)
         {
-            var handle = new QueryChannelHandle();
-            var successful = false;
-            tiledb_query_channel_t* channel = null;
+            ThrowHelpers.ThrowArgumentNullException(nameof(data));
+        }
+
+        SetDataBuffer(name, data.AsMemory());
+    }
+
+    /// <summary>
+    /// Sets the data buffer for an attribute or dimension to a <see cref="Memory{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The buffer's type.</typeparam>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">An <see cref="Memory{T}"/> where the data will be read or written.</param>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty or <typeparamref name="T"/>
+    /// does not match the excepted data type.</exception>
+    public void SetDataBuffer<T>(string name, Memory<T> data) where T : struct
+    {
+        CheckDataType<T>(name);
+
+        if (data.IsEmpty)
+        {
+            ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(data));
+        }
+
+        UnsafeSetDataBuffer(name, data.Pin(), (ulong)data.Length * (ulong)sizeof(T), sizeof(T));
+    }
+
+    /// <summary>
+    /// Sets the data buffer for an attribute or dimension to an unmanaged memory buffer.
+    /// </summary>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">A pointer to the memory buffer.</param>
+    /// <param name="size">The buffer's size <em>in <typeparamref name="T"/> values</em>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="size"/> is zero or <typeparamref name="T"/>
+    /// does not match the excepted data type.</exception>
+    public void SetDataBuffer<T>(string name, T* data, ulong size) where T : struct
+    {
+        if (data is null)
+        {
+            ThrowHelpers.ThrowArgumentNullException(nameof(data));
+        }
+
+        if (size == 0)
+        {
+            ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(size));
+        }
+
+        CheckDataType<T>(name);
+
+        UnsafeSetDataBuffer(name, new MemoryHandle(data), size * (ulong)sizeof(T), sizeof(T));
+    }
+
+    /// <summary>
+    /// Sets the data buffer for an attribute or dimension to a <see cref="ReadOnlyMemory{T}"/>.
+    /// Not supported for <see cref="QueryType.Read"/> queries.
+    /// </summary>
+    /// <typeparam name="T">The buffer's type.</typeparam>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> from where the data will be written.</param>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty or <typeparamref name="T"/>
+    /// does not match the excepted data type.</exception>
+    /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
+    public void SetDataReadOnlyBuffer<T>(string name, ReadOnlyMemory<T> data) where T : struct
+    {
+        if (QueryType() == CSharp.QueryType.Read)
+        {
+            ThrowHelpers.ThrowOperationNotAllowedOnReadQueries();
+        }
+
+        SetDataBuffer(name, MemoryMarshal.AsMemory(data));
+    }
+
+    /// <summary>
+    /// Sets the data buffer for an attribute or dimension to an
+    /// unmanaged memory buffer without performing type validation.
+    /// </summary>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">A pointer to the memory buffer.</param>
+    /// <param name="byteSize">The buffer's size <em>in bytes</em>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="byteSize"/> is zero.</exception>
+    public void UnsafeSetDataBuffer(string name, void* data, ulong byteSize)
+    {
+        if (data is null)
+        {
+            ThrowHelpers.ThrowArgumentNullException(nameof(data));
+        }
+
+        if (byteSize == 0)
+        {
+            ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(byteSize));
+        }
+
+        UnsafeSetDataBuffer(name, new MemoryHandle(data), byteSize, 0);
+    }
+
+    /// <summary>
+    /// Sets the data buffer for an attribute or dimension to a
+    /// byte buffer without performing type validation.
+    /// </summary>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">A <see cref="Memory{T}"/> of bytes pointing to the buffer.</param>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+    public void UnsafeSetDataBuffer(string name, Memory<byte> data)
+    {
+        if (data.IsEmpty)
+        {
+            ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(data));
+        }
+
+        UnsafeSetDataBuffer(name, data.Pin(), (ulong)data.Length, 0);
+    }
+
+    /// <summary>
+    /// Sets the data buffer for an attribute or dimension
+    /// to a pinned memory buffer pointed by a <see cref="MemoryHandle"/>.
+    /// This method does not perform type validation.
+    /// </summary>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="memoryHandle">A <see cref="MemoryHandle"/> pointing to the buffer.</param>
+    /// <param name="byteSize">The buffer's size <em>in bytes</em>.</param>
+    /// <exception cref="ArgumentException"><paramref name="byteSize"/> is zero.</exception>
+    /// <remarks>
+    /// <para>After calling this method, user code must not use <paramref name="memoryHandle"/>;
+    /// its ownership is transferred to this <see cref="Query"/> object.</para>
+    /// <para><paramref name="memoryHandle"/> will be disposed when one of the following happens:
+    /// <list type="bullet">
+    /// <item>The <see cref="Dispose"/> method is called.</item>
+    /// <item>The buffer for <paramref name="name"/> is reassigned through subsequent calls to this method.</item>
+    /// <item>This method call throws an exception.</item>
+    /// </list></para>
+    /// </remarks>
+    public void UnsafeSetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize)
+    {
+        if (byteSize == 0)
+        {
+            ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(byteSize));
+        }
+
+        UnsafeSetDataBuffer(name, memoryHandle, byteSize, 0);
+    }
+
+    private void UnsafeSetDataBuffer(string name, MemoryHandle memoryHandle, ulong byteSize, int elementSize)
+    {
+        BufferHandle? handle = null;
+        bool successful = false;
+        try
+        {
+            handle = new BufferHandle(ref memoryHandle, byteSize, elementSize);
+
+            SetDataBufferCore(name, handle.DataPointer, handle.SizePointer);
+
+            AddOrReplaceBufferHandle(_dataBufferHandles, name, handle);
+            successful = true;
+        }
+        finally
+        {
+            if (!successful)
+            {
+                memoryHandle.Dispose();
+                handle?.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sets the data buffer for an attribute or dimension to a
+    /// read-only byte buffer without performing type validation.
+    /// Not supported for <see cref="QueryType.Read"/> queries.
+    /// </summary>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> of bytes pointing to the buffer.</param>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+    /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
+    public void UnsafeSetDataReadOnlyBuffer(string name, ReadOnlyMemory<byte> data)
+    {
+        if (QueryType() == CSharp.QueryType.Read)
+        {
+            ThrowHelpers.ThrowOperationNotAllowedOnReadQueries();
+        }
+
+        UnsafeSetDataBuffer(name, MemoryMarshal.AsMemory(data));
+    }
+
+    private void SetDataBufferCore(string name, void* data, ulong* size)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(name);
+        _ctx.handle_error(Methods.tiledb_query_set_data_buffer(ctxHandle, handle, ms_name, data, size));
+    }
+
+    /// <summary>
+    /// Sets the offsets buffer for a variable-sized attribute or dimension to an array.
+    /// </summary>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">An array where the offsets will be read or written.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+    public void SetOffsetsBuffer(string name, ulong[] data)
+    {
+        if (data is null)
+        {
+            ThrowHelpers.ThrowArgumentNullException(nameof(data));
+        }
+
+        SetOffsetsBuffer(name, data.AsMemory());
+    }
+
+    /// <summary>
+    /// Sets the offsets buffer for a variable-sized attribute or dimension to a <see cref="Memory{T}"/>.
+    /// </summary>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">A <see cref="Memory{T}"/> where the offsets will be read or written.</param>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+    public void SetOffsetsBuffer(string name, Memory<ulong> data)
+    {
+        if (data.IsEmpty)
+        {
+            ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(data));
+        }
+
+        UnsafeSetOffsetsBuffer(name, data.Pin(), (ulong)data.Length);
+    }
+
+    /// <summary>
+    /// Sets the offsets buffer for a variable-sized attribute or dimension to an unmanaged memory buffer.
+    /// </summary>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">A pointer to the memory buffer.</param>
+    /// <param name="size">The buffer's size <em>in 64-bit integers</em>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="size"/> is zero.</exception>
+    public void SetOffsetsBuffer(string name, ulong* data, ulong size)
+    {
+        if (data is null)
+        {
+            ThrowHelpers.ThrowArgumentNullException(nameof(data));
+        }
+
+        if (size == 0)
+        {
+            ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(size));
+        }
+
+        UnsafeSetOffsetsBuffer(name, new MemoryHandle(data), size);
+    }
+
+    /// <summary>
+    /// Sets the offsets buffer for a variable-sized attribute or dimension
+    /// to a pinned memory buffer pointed by a <see cref="MemoryHandle"/>.
+    /// </summary>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="memoryHandle">A <see cref="MemoryHandle"/> pointing to the buffer.</param>
+    /// <param name="size">The buffer's size <em>in 64-bit integers</em>.</param>
+    /// <exception cref="ArgumentException"><paramref name="size"/> is zero.</exception>
+    /// <remarks>
+    /// <para>After calling this method, user code must not use <paramref name="memoryHandle"/>;
+    /// its ownership is transferred to this <see cref="Query"/> object.</para>
+    /// <para><paramref name="memoryHandle"/> will be disposed when one of the following happens:
+    /// <list type="bullet">
+    /// <item>The <see cref="Dispose"/> method is called.</item>
+    /// <item>The buffer for <paramref name="name"/> is reassigned through subsequent calls to this method.</item>
+    /// <item>This method call throws an exception.</item>
+    /// </list></para>
+    /// </remarks>
+    private void UnsafeSetOffsetsBuffer(string name, MemoryHandle memoryHandle, ulong size)
+    {
+        BufferHandle? handle = null;
+        bool successful = false;
+        try
+        {
+            handle = new BufferHandle(ref memoryHandle, size * sizeof(ulong), sizeof(ulong));
+
+            SetOffsetsBufferCore(name, (ulong*)handle.DataPointer, handle.SizePointer);
+
+            AddOrReplaceBufferHandle(_offsetsBufferHandles, name, handle);
+            successful = true;
+        }
+        finally
+        {
+            if (!successful)
+            {
+                memoryHandle.Dispose();
+                handle?.Dispose();
+            }
+        }
+    }
+
+    private void SetOffsetsBufferCore(string name, ulong* data, ulong* size)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(name);
+        _ctx.handle_error(Methods.tiledb_query_set_offsets_buffer(ctxHandle, handle, ms_name, data, size));
+    }
+
+    /// <summary>
+    /// Sets the offsets buffer for a variable-sized attribute or dimension to a <see cref="ReadOnlyMemory{T}"/>.
+    /// Not supported for <see cref="QueryType.Read"/> queries.
+    /// </summary>
+    /// <param name="name">The name of the attribute or the dimension.</param>
+    /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> from where the offsets will be written.</param>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+    /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
+    public void SetOffsetsReadOnlyBuffer(string name, ReadOnlyMemory<ulong> data)
+    {
+        if (QueryType() != CSharp.QueryType.Read)
+        {
+            ThrowHelpers.ThrowOperationNotAllowedOnReadQueries();
+        }
+
+        SetOffsetsBuffer(name, MemoryMarshal.AsMemory(data));
+    }
+
+    /// <summary>
+    /// Sets the validity buffer for a nullable attribute to an array.
+    /// </summary>
+    /// <param name="name">The name of the attribute.</param>
+    /// <param name="data">An array where the validities will be read or written.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+    /// <remarks>
+    /// Each value corresponds to whether an element exists (1) or not (0).
+    /// </remarks>
+    public void SetValidityBuffer(string name, byte[] data)
+    {
+        if (data is null)
+        {
+            ThrowHelpers.ThrowArgumentNullException(nameof(data));
+        }
+
+        SetValidityBuffer(name, data.AsMemory());
+    }
+
+    /// <summary>
+    /// Sets the validity buffer for a nullable attribute to a <see cref="Memory{T}"/>.
+    /// </summary>
+    /// <param name="name">The name of the attribute.</param>
+    /// <param name="data">A <see cref="Memory{T}"/> where the validities will be read or written.</param>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+    /// <remarks>
+    /// Each value corresponds to whether an element exists (1) or not (0).
+    /// </remarks>
+    public void SetValidityBuffer(string name, Memory<byte> data)
+    {
+        if (data.IsEmpty)
+        {
+            ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(data));
+        }
+
+        UnsafeSetValidityBuffer(name, data.Pin(), (ulong)data.Length);
+    }
+
+    /// <summary>
+    /// Sets the validity buffer for a nullable attribute to an unmanaged memory buffer.
+    /// </summary>
+    /// <param name="name">The name of the attribute.</param>
+    /// <param name="data">A pointer to the memory buffer.</param>
+    /// <param name="size">The buffer's size.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="data"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="size"/> is zero.</exception>
+    /// <remarks>
+    /// Each value corresponds to whether an element exists (1) or not (0).
+    /// </remarks>
+    public void SetValidityBuffer(string name, byte* data, ulong size)
+    {
+        if (data is null)
+        {
+            ThrowHelpers.ThrowArgumentNullException(nameof(data));
+        }
+
+        if (size == 0)
+        {
+            ThrowHelpers.ThrowBufferCannotBeEmpty(nameof(size));
+        }
+
+        UnsafeSetValidityBuffer(name, new MemoryHandle(data), size);
+    }
+
+    /// <summary>
+    /// Sets the validity buffer for a nullable attribute to a <see cref="ReadOnlyMemory{T}"/>.
+    /// Not supported for <see cref="QueryType.Read"/> queries.
+    /// </summary>
+    /// <param name="name">The name of the attribute.</param>
+    /// <param name="data">A <see cref="ReadOnlyMemory{T}"/> from where the validities will be written.</param>
+    /// <exception cref="ArgumentException"><paramref name="data"/> is empty.</exception>
+    /// <exception cref="NotSupportedException">The query's type is <see cref="QueryType.Read"/></exception>
+    /// <remarks>
+    /// Each value corresponds to whether an element exists (1) or not (0).
+    /// </remarks>
+    public void SetValidityReadOnlyBuffer(string name, ReadOnlyMemory<byte> data)
+    {
+        if (QueryType() == CSharp.QueryType.Read)
+        {
+            ThrowHelpers.ThrowOperationNotAllowedOnReadQueries();
+        }
+
+        SetValidityBuffer(name, MemoryMarshal.AsMemory(data));
+    }
+
+    /// <summary>
+    /// Sets the validity buffer for a nullable attribute
+    /// to a pinned memory buffer pointed by a <see cref="MemoryHandle"/>.
+    /// </summary>
+    /// <param name="name">The name of the attribute.</param>
+    /// <param name="memoryHandle">A <see cref="MemoryHandle"/> pointing to the buffer.</param>
+    /// <param name="size">The buffer's size.</param>
+    /// <exception cref="ArgumentException"><paramref name="size"/> is zero.</exception>
+    /// <remarks>
+    /// <para>Each value corresponds to whether an element exists (1) or not (0).</para>
+    /// <para>After calling this method, user code must not use <paramref name="memoryHandle"/>;
+    /// its ownership is transferred to this <see cref="Query"/> object.</para>
+    /// <para><paramref name="memoryHandle"/> will be disposed when one of the following happens:
+    /// <list type="bullet">
+    /// <item>The <see cref="Dispose"/> method is called.</item>
+    /// <item>The buffer for <paramref name="name"/> is reassigned through subsequent calls to this method.</item>
+    /// <item>This method call throws an exception.</item>
+    /// </list></para>
+    /// </remarks>
+    private void UnsafeSetValidityBuffer(string name, MemoryHandle memoryHandle, ulong size)
+    {
+        BufferHandle? handle = null;
+        bool successful = false;
+        try
+        {
+            handle = new BufferHandle(ref memoryHandle, size * sizeof(byte), sizeof(byte));
+
+            SetValidityBufferCore(name, (byte*)handle.DataPointer, handle.SizePointer);
+
+            AddOrReplaceBufferHandle(_validityBufferHandles, name, handle);
+            successful = true;
+        }
+        finally
+        {
+            if (!successful)
+            {
+                memoryHandle.Dispose();
+                handle?.Dispose();
+            }
+        }
+    }
+
+    private void SetValidityBufferCore(string name, byte* data, ulong* size)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(name);
+        _ctx.handle_error(Methods.tiledb_query_set_validity_buffer(ctxHandle, handle, ms_name, data, size));
+    }
+
+    /// <summary>
+    /// Sets the layout of the cells to be written or read.
+    /// </summary>
+    /// <param name="layouttype"></param>
+    public void SetLayout(LayoutType layouttype)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_query_set_layout(ctxHandle, handle, (tiledb_layout_t)layouttype));
+    }
+
+    /// <summary>
+    /// Sets the layout of the cells to be written or read.
+    /// </summary>
+    /// <returns></returns>
+    public LayoutType QueryLayout()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        tiledb_layout_t layout;
+        _ctx.handle_error(Methods.tiledb_query_get_layout(ctxHandle, handle, &layout));
+        return (LayoutType)layout;
+    }
+
+    /// <summary>
+    /// Sets the query condition to be applied on a read.
+    /// </summary>
+    /// <param name="condition"></param>
+    public void SetCondition(QueryCondition condition)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var conditionHandle = condition.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_query_set_condition(ctxHandle, handle, conditionHandle));
+    }
+
+    /// <summary>
+    /// Flushes all internal state of a query object and finalizes the query, only applicable to global layout writes.
+    /// </summary>
+    public void FinalizeQuery()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_query_finalize(ctxHandle, handle));
+    }
+
+    /// <summary>
+    /// Submits the query. Call will block until query is complete.
+    /// </summary>
+    /// <returns></returns>
+    public QueryStatus Submit()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_query_submit(ctxHandle, handle));
+        return QueryStatus.Completed;
+    }
+
+    /// <summary>
+    /// Submits and finalizes the query.
+    /// </summary>
+    /// <seealso cref="Submit"/>
+    /// <seealso cref="FinalizeQuery"/>
+    public void SubmitAndFinalize()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_query_submit_and_finalize(ctxHandle, handle));
+    }
+
+    /// <summary>
+    /// Returns `true` if the query has results. Applicable only to read; false for write queries.
+    /// </summary>
+    /// <returns></returns>
+    public bool HasResults()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        int ret;
+        _ctx.handle_error(Methods.tiledb_query_has_results(ctxHandle, handle, &ret));
+        return ret > 0;
+    }
+
+    /// <summary>
+    /// Returns a <see cref="QueryStatusDetails"/> value describing this <see cref="Query"/>.
+    /// </summary>
+    public QueryStatusDetails GetStatusDetails()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        QueryStatusDetails statusDetails;
+        _ctx.handle_error(Methods.tiledb_query_get_status_details(ctxHandle, handle, &statusDetails._details));
+        return statusDetails;
+    }
+
+    /// <summary>
+    /// Returns the query status.
+    /// </summary>
+    /// <returns></returns>
+    public QueryStatus Status()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        tiledb_query_status_t query_status;
+        _ctx.handle_error(Methods.tiledb_query_get_status(ctxHandle, handle, &query_status));
+        return (QueryStatus)query_status;
+    }
+
+    /// <summary>
+    /// Returns the query type (read or write).
+    /// </summary>
+    /// <returns></returns>
+    public QueryType QueryType()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        tiledb_query_type_t query_type;
+        _ctx.handle_error(Methods.tiledb_query_get_type(ctxHandle, handle, &query_type));
+        return (QueryType)query_type;
+    }
+
+    /// <summary>
+    /// Returns the array of the query.
+    /// </summary>
+    /// <returns></returns>
+    public Array Array()
+    {
+        return _array;
+    }
+
+    private ulong GetEstimatedResultSize(string name)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(name);
+        ulong size;
+        _ctx.handle_error(Methods.tiledb_query_get_est_result_size(ctxHandle, handle, ms_name, &size));
+        return size;
+    }
+
+    private (ulong OffsetSize, ulong DataSize) GetEstimatedResultSizeVar(string name)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(name);
+        ulong size_off;
+        ulong size_val;
+        _ctx.handle_error(Methods.tiledb_query_get_est_result_size_var(ctxHandle, handle, ms_name, &size_off, &size_val));
+
+        return (size_off, size_val);
+    }
+
+    private (ulong DataSize, ulong ValiditySize) GetEstimatedResultSizeNullable(string name)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(name);
+        ulong size_val;
+        ulong size_validity;
+        _ctx.handle_error(Methods.tiledb_query_get_est_result_size_nullable(ctxHandle, handle, ms_name, &size_val, &size_validity));
+        return (size_val, size_validity);
+    }
+
+    private (ulong OffsetsSize, ulong DataSize, ulong ValiditySize) GetEstimatedResultSizeVarNullable(string name)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(name);
+        ulong size_off;
+        ulong size_val;
+        ulong size_validity;
+
+        _ctx.handle_error(Methods.tiledb_query_get_est_result_size_var_nullable(ctxHandle, handle, ms_name, &size_off, &size_val, &size_validity));
+
+        return (size_off, size_val, size_validity);
+    }
+
+    /// <summary>
+    /// Estimates the result size for an attribute or dimension.
+    /// </summary>
+    /// <param name="name">The name of the attribute or dimension.</param>
+    public ResultSize EstResultSize(string name)
+    {
+        bool isVar, isNullable;
+        using (var schema = _array.Schema())
+        {
+            isVar = schema.IsVarSize(name);
+            isNullable = schema.IsNullable(name);
+        }
+        switch (isVar, isNullable)
+        {
+            case (true, true):
+                (var offsetsSize, var dataSize, var validitySize) = GetEstimatedResultSizeVarNullable(name);
+                return new ResultSize(offsetsSize, dataSize, validitySize);
+            case (true, false):
+                (offsetsSize, dataSize) = GetEstimatedResultSizeVar(name);
+                return new ResultSize(dataSize, offsetsSize);
+            case (false, true):
+                (dataSize, validitySize) = GetEstimatedResultSizeNullable(name);
+                return new ResultSize(dataSize, null, validitySize);
+            case (false, false):
+                dataSize = GetEstimatedResultSize(name);
+                return new ResultSize(dataSize);
+        }
+    }
+
+    /// <summary>
+    /// Returns the number of written fragments. Applicable only to WRITE queries.
+    /// </summary>
+    /// <returns></returns>
+    public uint FragmentNum()
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        uint num;
+        _ctx.handle_error(Methods.tiledb_query_get_fragment_num(ctxHandle, handle, &num));
+        return num;
+    }
+
+    /// <summary>
+    /// Returns the URI of the written fragment with the input index. Applicable only to WRITE queries.
+    /// </summary>
+    /// <param name="idx"></param>
+    /// <returns></returns>
+    public string FragmentUri(ulong idx)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        sbyte* result;
+        _ctx.handle_error(Methods.tiledb_query_get_fragment_uri(ctxHandle, handle, idx, &result));
+        return MarshaledStringOut.GetStringFromNullTerminated(result);
+    }
+
+    /// <summary>
+    /// Retrieves the timestamp range of the written fragment with the input index. Applicable only to WRITE queries.
+    /// </summary>
+    /// <param name="idx"></param>
+    /// <returns></returns>
+    public Tuple<ulong, ulong> FragmentTimestampRange(ulong idx)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong t1;
+        ulong t2;
+        _ctx.handle_error(Methods.tiledb_query_get_fragment_timestamp_range(ctxHandle, handle, idx, &t1, &t2));
+        return new Tuple<ulong, ulong>(t1, t2);
+    }
+
+    /// <summary>
+    /// Returns the query's default <see cref="QueryChannel"/>.
+    /// </summary>
+    public QueryChannel GetDefaultChannel()
+    {
+        var handle = new QueryChannelHandle();
+        var successful = false;
+        tiledb_query_channel_t* channel = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var queryHandle = _handle.Acquire())
+            {
+                _ctx.handle_error(Methods.tiledb_query_get_default_channel(ctxHandle, queryHandle, &channel));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(_ctx, channel);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+
+        return new QueryChannel(_ctx, this, handle);
+    }
+
+    /// <summary>
+    /// Gets information about a field in a query.
+    /// </summary>
+    /// <param name="name">The field's name.</param>
+    public QueryField GetField(string name)
+    {
+        var handle = new QueryFieldHandle();
+        var successful = false;
+        tiledb_query_field_t* field = null;
+        try
+        {
+            using (var ctxHandle = _ctx.Handle.Acquire())
+            using (var queryHandle = _handle.Acquire())
+            using (var ms_name = new MarshaledString(name))
+            {
+                _ctx.handle_error(Methods.tiledb_query_get_field(ctxHandle, queryHandle, ms_name, &field));
+            }
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
+            {
+                handle.InitHandle(_ctx, field);
+            }
+            else
+            {
+                handle.SetHandleAsInvalid();
+            }
+        }
+
+        return new QueryField(_ctx, this, handle, name);
+    }
+
+    private void CheckDataType<T>(string name)
+    {
+        using var @field = GetField(name);
+        ErrorHandling.CheckDataType<T>(@field.DataType);
+    }
+
+    private static DataType GetDataType(string name, ArraySchema schema, Domain domain)
+    {
+        if (schema.HasAttribute(name))
+        {
+            using var attribute = schema.Attribute(name);
+            return attribute.Type();
+        }
+        else if (domain.HasDimension(name))
+        {
+            using var dimension = domain.Dimension(name);
+            return dimension.Type();
+        }
+
+        if (name == "__coords")
+        {
+            return domain.Type();
+        }
+
+        throw new ArgumentException("No datatype for " + name);
+    }
+
+    /// <summary>
+    /// Returns the number of elements read into result buffers from a read query.
+    /// <list type="table">
+    /// <item>
+    /// <term>Dictionary key</term>
+    /// <description>Name of buffer used in call to <see cref="SetDataBuffer{T}(string, T[])"/>,
+    /// <see cref="SetOffsetsBuffer(string, ulong[])"/>, or <see cref="SetValidityBuffer(string, byte[])"/>.</description>
+    /// </item>
+    /// <item>
+    /// <term>Tuple <see cref="Tuple{T1, T2, T3}.Item1"/></term>
+    /// <description>Number of elements read by the query</description>
+    /// </item>
+    /// <item>
+    /// <term>Tuple <see cref="Tuple{T1, T2, T3}.Item2"/></term>
+    /// <description>Number of offset elements read by the query
+    /// or <see langword="null"/> if the buffer is not variable-sized.</description>
+    /// </item>
+    /// <item>
+    /// <term>Tuple <see cref="Tuple{T1, T2, T3}.Item3"/></term>
+    /// <description>Number of validity bytes read by the query
+    /// or <see langword="null"/> if the buffer is not nullable.</description>
+    /// </item>
+    /// </list>
+    /// </summary>
+    /// <returns>Dictionary mapping buffer name to number of results</returns>
+    /// <remarks>
+    /// This method exhibits poor performance characteristics. Consider using
+    /// <see cref="GetResultDataElements"/>, <see cref="GetResultDataBytes"/>,
+    /// <see cref="GetResultOffsets"/> and <see cref="GetResultValidities"/> instead.
+    /// </remarks>
+    public Dictionary<string, Tuple<ulong, ulong?, ulong?>> ResultBufferElements()
+    {
+        using var schema = _array.Schema();
+        using var domain = schema.Domain();
+        var buffers = new Dictionary<string, Tuple<ulong, ulong?, ulong?>>();
+        foreach ((string key, BufferHandle dataHandle) in _dataBufferHandles)
+        {
+            ulong? offsetNum = null;
+            ulong? validityNum = null;
+
+            ulong typeSize = EnumUtil.DataTypeSize(GetDataType(key, schema, domain));
+            ulong dataNum = dataHandle.SizeInBytes / typeSize;
+
+            if (_offsetsBufferHandles.TryGetValue(key, out BufferHandle? offsetHandle))
+            {
+                offsetNum = offsetHandle.SizeInBytes / sizeof(ulong);
+            }
+            if (_validityBufferHandles.TryGetValue(key, out BufferHandle? validityHandle))
+            {
+                validityNum = validityHandle.SizeInBytes;
+            }
+
+            buffers.Add(key, new(dataNum, offsetNum, validityNum));
+        }
+
+        return buffers;
+    }
+
+    /// <summary>
+    /// Returns the number of elements read into the data buffer of an attribute or dimension.
+    /// </summary>
+    /// <param name="name">The name of the attribute or dimension.</param>
+    /// <exception cref="KeyNotFoundException">No data buffer has
+    /// been registered with <paramref name="name"/>.</exception>
+    /// <exception cref="InvalidOperationException">The data buffer had been
+    /// set with an overload of <c>UnsafeSetDataBuffer</c>.</exception>
+    public ulong GetResultDataElements(string name) => _dataBufferHandles[name].SizeInElements;
+
+    /// <summary>
+    /// Returns the number of bytes read into the data buffer of an attribute or dimension.
+    /// </summary>
+    /// <param name="name">The name of the attribute or dimension.</param>
+    /// <returns>
+    /// The number of elements read, or the number of bytes read if the data buffer had been
+    /// assigned with an overload of the <c>Query.UnsafeSetDataBuffer</c> method.
+    /// </returns>
+    /// <exception cref="KeyNotFoundException">No data buffer has
+    /// been registered with <paramref name="name"/>.</exception>
+    public ulong GetResultDataBytes(string name) => _dataBufferHandles[name].SizeInBytes;
+
+    /// <summary>
+    /// Returns the number of offsets read into the offsets buffer of a variable-sized attribute or dimension.
+    /// </summary>
+    /// <param name="name">The name of the attribute or dimension.</param>
+    /// <exception cref="KeyNotFoundException">No offsets buffer has
+    /// been registered with <paramref name="name"/>.</exception>
+    public ulong GetResultOffsets(string name) => _offsetsBufferHandles[name].SizeInElements;
+
+    /// <summary>
+    /// Returns the number of validity bytes read into the validity buffer of a nullable attribute.
+    /// </summary>
+    /// <param name="name">The name of the attribute or dimension.</param>
+    /// <exception cref="KeyNotFoundException">No validity buffer has
+    /// been registered with <paramref name="name"/>.</exception>
+    public ulong GetResultValidities(string name) => _validityBufferHandles[name].SizeInElements;
+
+    /// <summary>
+    /// Free all handles.
+    /// </summary>
+    private void FreeAllBufferHandles()
+    {
+        DisposeValuesAndClear(_dataBufferHandles);
+        DisposeValuesAndClear(_offsetsBufferHandles);
+        DisposeValuesAndClear(_validityBufferHandles);
+
+        static void DisposeValuesAndClear(Dictionary<string, BufferHandle> handles)
+        {
+            foreach (var bh in handles)
+            {
+                bh.Value.Dispose();
+            }
+            handles.Clear();
+        }
+    }
+
+    private static void AddOrReplaceBufferHandle(Dictionary<string, BufferHandle> dict, string name, BufferHandle handle)
+    {
+        if (dict.TryGetValue(name, out var existingHandle))
+        {
+            existingHandle.Dispose();
+        }
+        dict[name] = handle;
+    }
+
+    private sealed class BufferHandle : IDisposable
+    {
+        private readonly int _elementSize;
+
+        private MemoryHandle DataHandle;
+
+        public ulong* SizePointer { get; private set; }
+
+        public void* DataPointer => DataHandle.Pointer;
+
+        public ulong SizeInBytes => *SizePointer;
+
+        public ulong SizeInElements
+        {
+            get
+            {
+                if (_elementSize == 0)
+                {
+                    ThrowHelpers.ThrowBufferUnsafelySet();
+                }
+                return *SizePointer / (ulong)_elementSize;
+            }
+        }
+
+        public BufferHandle(ref MemoryHandle handle, ulong size, int elementSize)
+        {
+            DataHandle = handle;
+            handle = default;
+            _elementSize = elementSize;
+            bool successful = false;
             try
             {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var queryHandle = _handle.Acquire())
-                {
-                    _ctx.handle_error(Methods.tiledb_query_get_default_channel(ctxHandle, queryHandle, &channel));
-                }
+                SizePointer = (ulong*)Marshal.AllocHGlobal(sizeof(ulong));
                 successful = true;
             }
             finally
             {
-                if (successful)
+                if (!successful)
                 {
-                    handle.InitHandle(_ctx, channel);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
+                    DataHandle.Dispose();
                 }
             }
-
-            return new QueryChannel(_ctx, this, handle);
+            *SizePointer = size;
         }
 
-        /// <summary>
-        /// Gets information about a field in a query.
-        /// </summary>
-        /// <param name="name">The field's name.</param>
-        public QueryField GetField(string name)
+        public void Dispose()
         {
-            var handle = new QueryFieldHandle();
-            var successful = false;
-            tiledb_query_field_t* field = null;
-            try
+            DataHandle.Dispose();
+            if (SizePointer != null)
             {
-                using (var ctxHandle = _ctx.Handle.Acquire())
-                using (var queryHandle = _handle.Acquire())
-                using (var ms_name = new MarshaledString(name))
-                {
-                    _ctx.handle_error(Methods.tiledb_query_get_field(ctxHandle, queryHandle, ms_name, &field));
-                }
-                successful = true;
+                Marshal.FreeHGlobal((IntPtr)SizePointer);
             }
-            finally
-            {
-                if (successful)
-                {
-                    handle.InitHandle(_ctx, field);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
-            }
-
-            return new QueryField(_ctx, this, handle, name);
-        }
-
-        private void CheckDataType<T>(string name)
-        {
-            using var @field = GetField(name);
-            ErrorHandling.CheckDataType<T>(@field.DataType);
-        }
-
-        private static DataType GetDataType(string name, ArraySchema schema, Domain domain)
-        {
-            if (schema.HasAttribute(name))
-            {
-                using var attribute = schema.Attribute(name);
-                return attribute.Type();
-            }
-            else if (domain.HasDimension(name))
-            {
-                using var dimension = domain.Dimension(name);
-                return dimension.Type();
-            }
-
-            if (name == "__coords")
-            {
-                return domain.Type();
-            }
-
-            throw new ArgumentException("No datatype for " + name);
-        }
-
-        /// <summary>
-        /// Returns the number of elements read into result buffers from a read query.
-        /// <list type="table">
-        /// <item>
-        /// <term>Dictionary key</term>
-        /// <description>Name of buffer used in call to <see cref="SetDataBuffer{T}(string, T[])"/>,
-        /// <see cref="SetOffsetsBuffer(string, ulong[])"/>, or <see cref="SetValidityBuffer(string, byte[])"/>.</description>
-        /// </item>
-        /// <item>
-        /// <term>Tuple <see cref="Tuple{T1, T2, T3}.Item1"/></term>
-        /// <description>Number of elements read by the query</description>
-        /// </item>
-        /// <item>
-        /// <term>Tuple <see cref="Tuple{T1, T2, T3}.Item2"/></term>
-        /// <description>Number of offset elements read by the query
-        /// or <see langword="null"/> if the buffer is not variable-sized.</description>
-        /// </item>
-        /// <item>
-        /// <term>Tuple <see cref="Tuple{T1, T2, T3}.Item3"/></term>
-        /// <description>Number of validity bytes read by the query
-        /// or <see langword="null"/> if the buffer is not nullable.</description>
-        /// </item>
-        /// </list>
-        /// </summary>
-        /// <returns>Dictionary mapping buffer name to number of results</returns>
-        /// <remarks>
-        /// This method exhibits poor performance characteristics. Consider using
-        /// <see cref="GetResultDataElements"/>, <see cref="GetResultDataBytes"/>,
-        /// <see cref="GetResultOffsets"/> and <see cref="GetResultValidities"/> instead.
-        /// </remarks>
-        public Dictionary<string, Tuple<ulong, ulong?, ulong?>> ResultBufferElements()
-        {
-            using var schema = _array.Schema();
-            using var domain = schema.Domain();
-            var buffers = new Dictionary<string, Tuple<ulong, ulong?, ulong?>>();
-            foreach ((string key, BufferHandle dataHandle) in _dataBufferHandles)
-            {
-                ulong? offsetNum = null;
-                ulong? validityNum = null;
-
-                ulong typeSize = EnumUtil.DataTypeSize(GetDataType(key, schema, domain));
-                ulong dataNum = dataHandle.SizeInBytes / typeSize;
-
-                if (_offsetsBufferHandles.TryGetValue(key, out BufferHandle? offsetHandle))
-                {
-                    offsetNum = offsetHandle.SizeInBytes / sizeof(ulong);
-                }
-                if (_validityBufferHandles.TryGetValue(key, out BufferHandle? validityHandle))
-                {
-                    validityNum = validityHandle.SizeInBytes;
-                }
-
-                buffers.Add(key, new(dataNum, offsetNum, validityNum));
-            }
-
-            return buffers;
-        }
-
-        /// <summary>
-        /// Returns the number of elements read into the data buffer of an attribute or dimension.
-        /// </summary>
-        /// <param name="name">The name of the attribute or dimension.</param>
-        /// <exception cref="KeyNotFoundException">No data buffer has
-        /// been registered with <paramref name="name"/>.</exception>
-        /// <exception cref="InvalidOperationException">The data buffer had been
-        /// set with an overload of <c>UnsafeSetDataBuffer</c>.</exception>
-        public ulong GetResultDataElements(string name) => _dataBufferHandles[name].SizeInElements;
-
-        /// <summary>
-        /// Returns the number of bytes read into the data buffer of an attribute or dimension.
-        /// </summary>
-        /// <param name="name">The name of the attribute or dimension.</param>
-        /// <returns>
-        /// The number of elements read, or the number of bytes read if the data buffer had been
-        /// assigned with an overload of the <c>Query.UnsafeSetDataBuffer</c> method.
-        /// </returns>
-        /// <exception cref="KeyNotFoundException">No data buffer has
-        /// been registered with <paramref name="name"/>.</exception>
-        public ulong GetResultDataBytes(string name) => _dataBufferHandles[name].SizeInBytes;
-
-        /// <summary>
-        /// Returns the number of offsets read into the offsets buffer of a variable-sized attribute or dimension.
-        /// </summary>
-        /// <param name="name">The name of the attribute or dimension.</param>
-        /// <exception cref="KeyNotFoundException">No offsets buffer has
-        /// been registered with <paramref name="name"/>.</exception>
-        public ulong GetResultOffsets(string name) => _offsetsBufferHandles[name].SizeInElements;
-
-        /// <summary>
-        /// Returns the number of validity bytes read into the validity buffer of a nullable attribute.
-        /// </summary>
-        /// <param name="name">The name of the attribute or dimension.</param>
-        /// <exception cref="KeyNotFoundException">No validity buffer has
-        /// been registered with <paramref name="name"/>.</exception>
-        public ulong GetResultValidities(string name) => _validityBufferHandles[name].SizeInElements;
-
-        /// <summary>
-        /// Free all handles.
-        /// </summary>
-        private void FreeAllBufferHandles()
-        {
-            DisposeValuesAndClear(_dataBufferHandles);
-            DisposeValuesAndClear(_offsetsBufferHandles);
-            DisposeValuesAndClear(_validityBufferHandles);
-
-            static void DisposeValuesAndClear(Dictionary<string, BufferHandle> handles)
-            {
-                foreach (var bh in handles)
-                {
-                    bh.Value.Dispose();
-                }
-                handles.Clear();
-            }
-        }
-
-        private static void AddOrReplaceBufferHandle(Dictionary<string, BufferHandle> dict, string name, BufferHandle handle)
-        {
-            if (dict.TryGetValue(name, out var existingHandle))
-            {
-                existingHandle.Dispose();
-            }
-            dict[name] = handle;
-        }
-
-        private sealed class BufferHandle : IDisposable
-        {
-            private readonly int _elementSize;
-
-            private MemoryHandle DataHandle;
-
-            public ulong* SizePointer { get; private set; }
-
-            public void* DataPointer => DataHandle.Pointer;
-
-            public ulong SizeInBytes => *SizePointer;
-
-            public ulong SizeInElements
-            {
-                get
-                {
-                    if (_elementSize == 0)
-                    {
-                        ThrowHelpers.ThrowBufferUnsafelySet();
-                    }
-                    return *SizePointer / (ulong)_elementSize;
-                }
-            }
-
-            public BufferHandle(ref MemoryHandle handle, ulong size, int elementSize)
-            {
-                DataHandle = handle;
-                handle = default;
-                _elementSize = elementSize;
-                bool successful = false;
-                try
-                {
-                    SizePointer = (ulong*)Marshal.AllocHGlobal(sizeof(ulong));
-                    successful = true;
-                }
-                finally
-                {
-                    if (!successful)
-                    {
-                        DataHandle.Dispose();
-                    }
-                }
-                *SizePointer = size;
-            }
-
-            public void Dispose()
-            {
-                DataHandle.Dispose();
-                if (SizePointer != null)
-                {
-                    Marshal.FreeHGlobal((IntPtr)SizePointer);
-                }
-                SizePointer = null;
-            }
+            SizePointer = null;
         }
     }
 }

--- a/sources/TileDB.CSharp/QueryCondition.cs
+++ b/sources/TileDB.CSharp/QueryCondition.cs
@@ -3,262 +3,261 @@ using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 using QueryConditionHandle = TileDB.CSharp.Marshalling.SafeHandles.QueryConditionHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB query condition object.
+/// </summary>
+public sealed unsafe class QueryCondition : IDisposable
 {
+    private readonly QueryConditionHandle _handle;
+    private readonly Context _ctx;
+
     /// <summary>
-    /// Represents a TileDB query condition object.
+    /// Creates a <see cref="QueryCondition"/>.
     /// </summary>
-    public sealed unsafe class QueryCondition : IDisposable
+    /// <param name="ctx">The <see cref="Context"/> associated with this query condition.</param>
+    /// <remarks>
+    /// The query condition must be initialized by calling
+    /// <see cref="Init(string, string, QueryConditionOperatorType)"/>
+    /// or <see cref="Init{T}(string, T, QueryConditionOperatorType)"/>.
+    /// </remarks>
+    private QueryCondition(Context ctx)
     {
-        private readonly QueryConditionHandle _handle;
-        private readonly Context _ctx;
+        _ctx = ctx;
+        _handle = QueryConditionHandle.Create(_ctx);
+    }
 
-        /// <summary>
-        /// Creates a <see cref="QueryCondition"/>.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with this query condition.</param>
-        /// <remarks>
-        /// The query condition must be initialized by calling
-        /// <see cref="Init(string, string, QueryConditionOperatorType)"/>
-        /// or <see cref="Init{T}(string, T, QueryConditionOperatorType)"/>.
-        /// </remarks>
-        private QueryCondition(Context ctx)
+    private QueryCondition(Context ctx, QueryConditionHandle handle)
+    {
+        _ctx = ctx;
+        _handle = handle;
+    }
+
+    /// <summary>
+    /// Disposes this <see cref="QueryCondition"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
+
+    internal QueryConditionHandle Handle => _handle;
+
+    /// <summary>
+    /// Initializes this <see cref="QueryCondition"/> with a value of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+    /// <param name="condition_value">The value to compare the attribute with.</param>
+    /// <param name="optype">The type of the relationship between the attribute with
+    /// the name <paramref name="attribute_name"/> and <paramref name="condition_value"/>.</param>
+    /// <remarks>
+    /// Query conditions created with <see cref="Create(Context, string, string, QueryConditionOperatorType)"/>
+    /// must not call this method.
+    /// </remarks>
+    private void Init<T>(string attribute_name, T condition_value, QueryConditionOperatorType optype) where T : struct
+    {
+        ErrorHandling.ThrowIfManagedType<T>();
+        Init(attribute_name, &condition_value, (ulong)sizeof(T), optype);
+    }
+
+    /// <summary>
+    /// Initializes this <see cref="QueryCondition"/> with a string.
+    /// </summary>
+    /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+    /// <param name="condition_value">The string to compare the attribute with.</param>
+    /// <param name="optype">The type of the relationship between the attribute with
+    /// the name <paramref name="attribute_name"/> and <paramref name="condition_value"/>.</param>
+    /// <remarks>
+    /// Query conditions created with <see cref="Create(Context, string, string, QueryConditionOperatorType)"/>
+    /// must not call this method.
+    /// </remarks>
+    private void Init(string attribute_name, string condition_value, QueryConditionOperatorType optype)
+    {
+        using var ms_condition_value = new MarshaledString(condition_value);
+        Init(attribute_name, ms_condition_value, (ulong)ms_condition_value.Length, optype);
+    }
+
+    private void Init(string attribute_name, void* condition_value, ulong condition_value_size, QueryConditionOperatorType optype)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_attribute_name = new MarshaledString(attribute_name);
+        _ctx.handle_error(Methods.tiledb_query_condition_init(ctxHandle, handle, ms_attribute_name, condition_value, condition_value_size, (tiledb_query_condition_op_t)optype));
+    }
+
+    private void SetUseEnumeration(bool value)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_query_condition_set_use_enumeration(ctxHandle, handle, value ? 1 : 0));
+    }
+
+    private static QueryCondition Combine(QueryCondition lhs, QueryCondition? rhs, QueryConditionCombinationOperatorType combination_optype)
+    {
+        var ctx = lhs._ctx;
+        if (rhs is { _ctx: Context rhsCtx } && ctx != rhsCtx)
         {
-            _ctx = ctx;
-            _handle = QueryConditionHandle.Create(_ctx);
+            ThrowHelpers.ThrowQueryConditionDifferentContexts();
         }
 
-        private QueryCondition(Context ctx, QueryConditionHandle handle)
+        var handle = new QueryConditionHandle();
+        var successful = false;
+        tiledb_query_condition_t* condition_p = null;
+        try
         {
-            _ctx = ctx;
-            _handle = handle;
-        }
-
-        /// <summary>
-        /// Disposes this <see cref="QueryCondition"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            _handle.Dispose();
-        }
-
-        internal QueryConditionHandle Handle => _handle;
-
-        /// <summary>
-        /// Initializes this <see cref="QueryCondition"/> with a value of type <typeparamref name="T"/>.
-        /// </summary>
-        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
-        /// <param name="condition_value">The value to compare the attribute with.</param>
-        /// <param name="optype">The type of the relationship between the attribute with
-        /// the name <paramref name="attribute_name"/> and <paramref name="condition_value"/>.</param>
-        /// <remarks>
-        /// Query conditions created with <see cref="Create(Context, string, string, QueryConditionOperatorType)"/>
-        /// must not call this method.
-        /// </remarks>
-        private void Init<T>(string attribute_name, T condition_value, QueryConditionOperatorType optype) where T : struct
-        {
-            ErrorHandling.ThrowIfManagedType<T>();
-            Init(attribute_name, &condition_value, (ulong)sizeof(T), optype);
-        }
-
-        /// <summary>
-        /// Initializes this <see cref="QueryCondition"/> with a string.
-        /// </summary>
-        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
-        /// <param name="condition_value">The string to compare the attribute with.</param>
-        /// <param name="optype">The type of the relationship between the attribute with
-        /// the name <paramref name="attribute_name"/> and <paramref name="condition_value"/>.</param>
-        /// <remarks>
-        /// Query conditions created with <see cref="Create(Context, string, string, QueryConditionOperatorType)"/>
-        /// must not call this method.
-        /// </remarks>
-        private void Init(string attribute_name, string condition_value, QueryConditionOperatorType optype)
-        {
-            using var ms_condition_value = new MarshaledString(condition_value);
-            Init(attribute_name, ms_condition_value, (ulong)ms_condition_value.Length, optype);
-        }
-
-        private void Init(string attribute_name, void* condition_value, ulong condition_value_size, QueryConditionOperatorType optype)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_attribute_name = new MarshaledString(attribute_name);
-            _ctx.handle_error(Methods.tiledb_query_condition_init(ctxHandle, handle, ms_attribute_name, condition_value, condition_value_size, (tiledb_query_condition_op_t)optype));
-        }
-
-        private void SetUseEnumeration(bool value)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_query_condition_set_use_enumeration(ctxHandle, handle, value ? 1 : 0));
-        }
-
-        private static QueryCondition Combine(QueryCondition lhs, QueryCondition? rhs, QueryConditionCombinationOperatorType combination_optype)
-        {
-            var ctx = lhs._ctx;
-            if (rhs is { _ctx: Context rhsCtx } && ctx != rhsCtx)
+            using (var ctxHandle = ctx.Handle.Acquire())
+            using (var lhsHandle = lhs.Handle.Acquire())
+            using (var rhsHandle = rhs?.Handle?.Acquire() ?? default)
             {
-                ThrowHelpers.ThrowQueryConditionDifferentContexts();
+                ctx.handle_error(Methods.tiledb_query_condition_combine(ctxHandle, lhsHandle, rhsHandle,
+                    (tiledb_query_condition_combination_op_t)combination_optype, &condition_p));
             }
-
-            var handle = new QueryConditionHandle();
-            var successful = false;
-            tiledb_query_condition_t* condition_p = null;
-            try
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using (var ctxHandle = ctx.Handle.Acquire())
-                using (var lhsHandle = lhs.Handle.Acquire())
-                using (var rhsHandle = rhs?.Handle?.Acquire() ?? default)
-                {
-                    ctx.handle_error(Methods.tiledb_query_condition_combine(ctxHandle, lhsHandle, rhsHandle,
-                        (tiledb_query_condition_combination_op_t)combination_optype, &condition_p));
-                }
-                successful = true;
+                handle.InitHandle(condition_p);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(condition_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return new QueryCondition(ctx, handle);
         }
 
-        /// <summary>
-        /// Creates a new <see cref="QueryCondition"/> with a string.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
-        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
-        /// <param name="value">The value to compare the attribute with.</param>
-        /// <param name="optype">The type of the relationship between the attribute with
-        /// the name <paramref name="attribute_name"/> and <paramref name="value"/>.</param>
-        public static QueryCondition Create(Context ctx, string attribute_name, string value, QueryConditionOperatorType optype)
-        {
-            var ret = new QueryCondition(ctx);
-            ret.Init(attribute_name, value, optype);
-            return ret;
-        }
+        return new QueryCondition(ctx, handle);
+    }
 
-        /// <summary>
-        /// Creates a new query condition with datatype <typeparamref name="T"/>.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
-        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
-        /// <param name="value">The value to compare the attribute with.</param>
-        /// <param name="optype">The type of the relationship between the attribute with
-        /// the name <paramref name="attribute_name"/> and <paramref name="value"/>.</param>
-        public static QueryCondition Create<T>(Context ctx, string attribute_name, T value, QueryConditionOperatorType optype) where T : struct
-        {
-            return Create(ctx, attribute_name, value, optype, true);
-        }
+    /// <summary>
+    /// Creates a new <see cref="QueryCondition"/> with a string.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
+    /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+    /// <param name="value">The value to compare the attribute with.</param>
+    /// <param name="optype">The type of the relationship between the attribute with
+    /// the name <paramref name="attribute_name"/> and <paramref name="value"/>.</param>
+    public static QueryCondition Create(Context ctx, string attribute_name, string value, QueryConditionOperatorType optype)
+    {
+        var ret = new QueryCondition(ctx);
+        ret.Init(attribute_name, value, optype);
+        return ret;
+    }
 
-        /// <summary>
-        /// Creates a new query condition with datatype <typeparamref name="T"/>.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
-        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
-        /// <param name="value">The value to compare the attribute with.</param>
-        /// <param name="optype">The type of the relationship between the attribute with
-        /// the name <paramref name="attribute_name"/> and <paramref name="value"/>.</param>
-        /// <param name="useEnumeration">Whether to match the query condition on the
-        /// enumerated value instead of the underlying value. Optional, defaults to
-        /// <see langword="true"/>.</param>
-        public static QueryCondition Create<T>(Context ctx, string attribute_name, T value, QueryConditionOperatorType optype, bool useEnumeration = true) where T : struct
+    /// <summary>
+    /// Creates a new query condition with datatype <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
+    /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+    /// <param name="value">The value to compare the attribute with.</param>
+    /// <param name="optype">The type of the relationship between the attribute with
+    /// the name <paramref name="attribute_name"/> and <paramref name="value"/>.</param>
+    public static QueryCondition Create<T>(Context ctx, string attribute_name, T value, QueryConditionOperatorType optype) where T : struct
+    {
+        return Create(ctx, attribute_name, value, optype, true);
+    }
+
+    /// <summary>
+    /// Creates a new query condition with datatype <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
+    /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+    /// <param name="value">The value to compare the attribute with.</param>
+    /// <param name="optype">The type of the relationship between the attribute with
+    /// the name <paramref name="attribute_name"/> and <paramref name="value"/>.</param>
+    /// <param name="useEnumeration">Whether to match the query condition on the
+    /// enumerated value instead of the underlying value. Optional, defaults to
+    /// <see langword="true"/>.</param>
+    public static QueryCondition Create<T>(Context ctx, string attribute_name, T value, QueryConditionOperatorType optype, bool useEnumeration = true) where T : struct
+    {
+        var ret = new QueryCondition(ctx);
+        ret.Init(attribute_name, value, optype);
+        if (!useEnumeration)
         {
-            var ret = new QueryCondition(ctx);
-            ret.Init(attribute_name, value, optype);
-            if (!useEnumeration)
+            ret.SetUseEnumeration(false);
+        }
+        return ret;
+    }
+
+    /// <summary>
+    /// Creates a new query condition that is satisfied where the given attribute is null.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
+    /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+    public static QueryCondition CreateIsNull(Context ctx, string attribute_name)
+    {
+        var ret = new QueryCondition(ctx);
+        ret.Init(attribute_name, null, 0, QueryConditionOperatorType.Equal);
+        return ret;
+    }
+
+    /// <summary>
+    /// Creates a new query condition that is satisfied where the given attribute is not null.
+    /// </summary>
+    /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
+    /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
+    public static QueryCondition CreateIsNotNull(Context ctx, string attribute_name)
+    {
+        var ret = new QueryCondition(ctx);
+        ret.Init(attribute_name, null, 0, QueryConditionOperatorType.NotEqual);
+        return ret;
+    }
+
+    /// <summary>
+    /// Creates the conjunction of two <see cref="QueryCondition"/>s.
+    /// </summary>
+    /// <param name="lhs">The first query condition.</param>
+    /// <param name="rhs">The second query condition.</param>
+    /// <returns>A query condition that will be satisfied if both
+    /// <paramref name="lhs"/> and <paramref name="rhs"/> are satisfied.</returns>
+    public static QueryCondition operator &(QueryCondition lhs, QueryCondition rhs) =>
+        Combine(lhs, rhs, QueryConditionCombinationOperatorType.And);
+
+    /// <summary>
+    /// Creates the disjunction of two <see cref="QueryCondition"/>s.
+    /// </summary>
+    /// <param name="lhs">The first query condition.</param>
+    /// <param name="rhs">The second query condition.</param>
+    /// <returns>A query condition that will be satisfied if at least one of
+    /// <paramref name="lhs"/> or <paramref name="rhs"/> are satisfied.</returns>
+    public static QueryCondition operator |(QueryCondition lhs, QueryCondition rhs) =>
+        Combine(lhs, rhs, QueryConditionCombinationOperatorType.Or);
+
+    /// <summary>
+    /// Creates the negation of a <see cref="QueryCondition"/>.
+    /// </summary>
+    /// <param name="condition">The query condition to negate.</param>
+    /// <returns>A query condition that will be satisfied if
+    /// <paramref name="condition"/> is not satisfied.</returns>
+    public static QueryCondition operator !(QueryCondition condition)
+    {
+        var ctx = condition._ctx;
+
+        var handle = new QueryConditionHandle();
+        var successful = false;
+        tiledb_query_condition_t* condition_p = null;
+        try
+        {
+            using (var ctxHandle = ctx.Handle.Acquire())
+            using (var conditionHandle = condition.Handle.Acquire())
             {
-                ret.SetUseEnumeration(false);
+                ctx.handle_error(Methods.tiledb_query_condition_negate(ctxHandle, conditionHandle, &condition_p));
             }
-            return ret;
+            successful = true;
         }
-
-        /// <summary>
-        /// Creates a new query condition that is satisfied where the given attribute is null.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
-        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
-        public static QueryCondition CreateIsNull(Context ctx, string attribute_name)
+        finally
         {
-            var ret = new QueryCondition(ctx);
-            ret.Init(attribute_name, null, 0, QueryConditionOperatorType.Equal);
-            return ret;
-        }
-
-        /// <summary>
-        /// Creates a new query condition that is satisfied where the given attribute is not null.
-        /// </summary>
-        /// <param name="ctx">The <see cref="Context"/> associated with the query condition.</param>
-        /// <param name="attribute_name">The name of the attribute the query condition refers to.</param>
-        public static QueryCondition CreateIsNotNull(Context ctx, string attribute_name)
-        {
-            var ret = new QueryCondition(ctx);
-            ret.Init(attribute_name, null, 0, QueryConditionOperatorType.NotEqual);
-            return ret;
-        }
-
-        /// <summary>
-        /// Creates the conjunction of two <see cref="QueryCondition"/>s.
-        /// </summary>
-        /// <param name="lhs">The first query condition.</param>
-        /// <param name="rhs">The second query condition.</param>
-        /// <returns>A query condition that will be satisfied if both
-        /// <paramref name="lhs"/> and <paramref name="rhs"/> are satisfied.</returns>
-        public static QueryCondition operator &(QueryCondition lhs, QueryCondition rhs) =>
-            Combine(lhs, rhs, QueryConditionCombinationOperatorType.And);
-
-        /// <summary>
-        /// Creates the disjunction of two <see cref="QueryCondition"/>s.
-        /// </summary>
-        /// <param name="lhs">The first query condition.</param>
-        /// <param name="rhs">The second query condition.</param>
-        /// <returns>A query condition that will be satisfied if at least one of
-        /// <paramref name="lhs"/> or <paramref name="rhs"/> are satisfied.</returns>
-        public static QueryCondition operator |(QueryCondition lhs, QueryCondition rhs) =>
-            Combine(lhs, rhs, QueryConditionCombinationOperatorType.Or);
-
-        /// <summary>
-        /// Creates the negation of a <see cref="QueryCondition"/>.
-        /// </summary>
-        /// <param name="condition">The query condition to negate.</param>
-        /// <returns>A query condition that will be satisfied if
-        /// <paramref name="condition"/> is not satisfied.</returns>
-        public static QueryCondition operator !(QueryCondition condition)
-        {
-            var ctx = condition._ctx;
-
-            var handle = new QueryConditionHandle();
-            var successful = false;
-            tiledb_query_condition_t* condition_p = null;
-            try
+            if (successful)
             {
-                using (var ctxHandle = ctx.Handle.Acquire())
-                using (var conditionHandle = condition.Handle.Acquire())
-                {
-                    ctx.handle_error(Methods.tiledb_query_condition_negate(ctxHandle, conditionHandle, &condition_p));
-                }
-                successful = true;
+                handle.InitHandle(condition_p);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(condition_p);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-
-            return new QueryCondition(ctx, handle);
         }
+
+        return new QueryCondition(ctx, handle);
     }
 }

--- a/sources/TileDB.CSharp/QueryStatusDetails.cs
+++ b/sources/TileDB.CSharp/QueryStatusDetails.cs
@@ -1,21 +1,20 @@
 ﻿using TileDB.Interop;
 
-namespace TileDB.CSharp
-{
-    /// <summary>
-    /// Specifies additional details about the status of a <see cref="Query"/>.
-    /// </summary>
-    public struct QueryStatusDetails
-    {
-        internal tiledb_query_status_details_t _details;
+namespace TileDB.CSharp;
 
-        /// <summary>
-        /// The reason the <see cref="Query"/> cannot continue.
-        /// </summary>
-        public QueryStatusDetailsReason Reason
-        {
-            readonly get => (QueryStatusDetailsReason)_details.incomplete_reason;
-            set => _details.incomplete_reason = (tiledb_query_status_details_reason_t)value;
-        }
+/// <summary>
+/// Specifies additional details about the status of a <see cref="Query"/>.
+/// </summary>
+public struct QueryStatusDetails
+{
+    internal tiledb_query_status_details_t _details;
+
+    /// <summary>
+    /// The reason the <see cref="Query"/> cannot continue.
+    /// </summary>
+    public QueryStatusDetailsReason Reason
+    {
+        readonly get => (QueryStatusDetailsReason)_details.incomplete_reason;
+        set => _details.incomplete_reason = (tiledb_query_status_details_reason_t)value;
     }
 }

--- a/sources/TileDB.CSharp/Stats.cs
+++ b/sources/TileDB.CSharp/Stats.cs
@@ -1,94 +1,93 @@
 using System;
 using TileDB.Interop;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Contains methods related to collecting statistics of TileDB Embedded.
+/// </summary>
+public static unsafe class Stats
 {
     /// <summary>
-    /// Contains methods related to collecting statistics of TileDB Embedded.
+    /// Enables statistic gathering
     /// </summary>
-    public static unsafe class Stats
+    public static void Enable() => ErrorHandling.ThrowOnError(Methods.tiledb_stats_enable());
+
+    /// <summary>
+    /// Disables statistic gathering
+    /// </summary>
+    public static void Disable() => ErrorHandling.ThrowOnError(Methods.tiledb_stats_disable());
+
+    /// <summary>
+    /// Resets all previously gathered statistics.
+    /// </summary>
+    public static void Reset() => ErrorHandling.ThrowOnError(Methods.tiledb_stats_reset());
+
+    /// <summary>
+    /// Writes statistics to standard output.
+    /// </summary>
+    public static void Dump() => Console.WriteLine(Get());
+
+    /// <summary>
+    /// Writes TileDB statistics to a file.
+    /// </summary>
+    /// <param name="filePath">Path to file to dump statistics</param>
+    public static void Dump(string filePath) => System.IO.File.WriteAllText(filePath, Get());
+
+    /// <summary>
+    /// Gets a JSON string with statistics about TileDB Embedded.
+    /// </summary>
+    public static string Get()
     {
-        /// <summary>
-        /// Enables statistic gathering
-        /// </summary>
-        public static void Enable() => ErrorHandling.ThrowOnError(Methods.tiledb_stats_enable());
-
-        /// <summary>
-        /// Disables statistic gathering
-        /// </summary>
-        public static void Disable() => ErrorHandling.ThrowOnError(Methods.tiledb_stats_disable());
-
-        /// <summary>
-        /// Resets all previously gathered statistics.
-        /// </summary>
-        public static void Reset() => ErrorHandling.ThrowOnError(Methods.tiledb_stats_reset());
-
-        /// <summary>
-        /// Writes statistics to standard output.
-        /// </summary>
-        public static void Dump() => Console.WriteLine(Get());
-
-        /// <summary>
-        /// Writes TileDB statistics to a file.
-        /// </summary>
-        /// <param name="filePath">Path to file to dump statistics</param>
-        public static void Dump(string filePath) => System.IO.File.WriteAllText(filePath, Get());
-
-        /// <summary>
-        /// Gets a JSON string with statistics about TileDB Embedded.
-        /// </summary>
-        public static string Get()
+        sbyte* result = null;
+        try
         {
-            sbyte* result = null;
-            try
+            ErrorHandling.ThrowOnError(Methods.tiledb_stats_dump_str(&result));
+            return MarshaledStringOut.GetStringFromNullTerminated(result);
+        }
+        finally
+        {
+            if (result is not null)
             {
-                ErrorHandling.ThrowOnError(Methods.tiledb_stats_dump_str(&result));
-                return MarshaledStringOut.GetStringFromNullTerminated(result);
-            }
-            finally
-            {
-                if (result is not null)
-                {
-                    ErrorHandling.ThrowOnError(Methods.tiledb_stats_free_str(&result));
-                }
+                ErrorHandling.ThrowOnError(Methods.tiledb_stats_free_str(&result));
             }
         }
+    }
 
-        /// <summary>
-        /// Gets a JSON string with raw statistics about TileDB Embedded.
-        /// </summary>
-        public static string GetRaw()
+    /// <summary>
+    /// Gets a JSON string with raw statistics about TileDB Embedded.
+    /// </summary>
+    public static string GetRaw()
+    {
+        sbyte* result = null;
+        try
         {
-            sbyte* result = null;
-            try
+            ErrorHandling.ThrowOnError(Methods.tiledb_stats_raw_dump_str(&result));
+            return MarshaledStringOut.GetStringFromNullTerminated(result);
+        }
+        finally
+        {
+            if (result is not null)
             {
-                ErrorHandling.ThrowOnError(Methods.tiledb_stats_raw_dump_str(&result));
-                return MarshaledStringOut.GetStringFromNullTerminated(result);
-            }
-            finally
-            {
-                if (result is not null)
-                {
-                    ErrorHandling.ThrowOnError(Methods.tiledb_stats_free_str(&result));
-                }
+                ErrorHandling.ThrowOnError(Methods.tiledb_stats_free_str(&result));
             }
         }
+    }
 
-        /// <summary>
-        /// Enables heap profiling of TileDB Embedded.
-        /// </summary>
-        /// <param name="fileNamePrefix">The file name prefix of the dumps. If it is
-        /// <see langword="null"/> or empty, dumps will be written to stdout.</param>
-        /// <param name="dumpIntervalMilliseconds">If non-zero, this spawns a dedicated
-        /// thread to dump on this time interval.</param>
-        /// <param name="dumpIntervalBytes">If non-zero, a dump will occur when the total
-        /// number of lifetime allocated bytes is increased by more than this amount.</param>
-        /// <param name="dumpThresholdBytes">If non-zero, labeled allocations with a number
-        /// of bytes lower than this threshold will not be reported in the dump.</param>
-        public static void EnableHeapProfiler(string? fileNamePrefix, ulong dumpIntervalMilliseconds, ulong dumpIntervalBytes, ulong dumpThresholdBytes)
-        {
-            using var ms_fileNamePrefix = new MarshaledString(fileNamePrefix ?? "");
-            ErrorHandling.ThrowOnError(Methods.tiledb_heap_profiler_enable(ms_fileNamePrefix, dumpIntervalMilliseconds, dumpIntervalBytes, dumpThresholdBytes));
-        }
+    /// <summary>
+    /// Enables heap profiling of TileDB Embedded.
+    /// </summary>
+    /// <param name="fileNamePrefix">The file name prefix of the dumps. If it is
+    /// <see langword="null"/> or empty, dumps will be written to stdout.</param>
+    /// <param name="dumpIntervalMilliseconds">If non-zero, this spawns a dedicated
+    /// thread to dump on this time interval.</param>
+    /// <param name="dumpIntervalBytes">If non-zero, a dump will occur when the total
+    /// number of lifetime allocated bytes is increased by more than this amount.</param>
+    /// <param name="dumpThresholdBytes">If non-zero, labeled allocations with a number
+    /// of bytes lower than this threshold will not be reported in the dump.</param>
+    public static void EnableHeapProfiler(string? fileNamePrefix, ulong dumpIntervalMilliseconds, ulong dumpIntervalBytes, ulong dumpThresholdBytes)
+    {
+        using var ms_fileNamePrefix = new MarshaledString(fileNamePrefix ?? "");
+        ErrorHandling.ThrowOnError(Methods.tiledb_heap_profiler_enable(ms_fileNamePrefix, dumpIntervalMilliseconds, dumpIntervalBytes, dumpThresholdBytes));
     }
 }

--- a/sources/TileDB.CSharp/Subarray.cs
+++ b/sources/TileDB.CSharp/Subarray.cs
@@ -5,374 +5,373 @@ using TileDB.CSharp.Marshalling;
 using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB subarray object.
+/// </summary>
+public sealed unsafe class Subarray : IDisposable
 {
+    private readonly Array _array;
+    private readonly Context _ctx;
+    private readonly SubarrayHandle _handle;
+
+    internal SubarrayHandle Handle => _handle;
+
     /// <summary>
-    /// Represents a TileDB subarray object.
+    /// Creates a <see cref="Subarray"/>.
     /// </summary>
-    public sealed unsafe class Subarray : IDisposable
+    /// <param name="array">The <see cref="Array"/> the subarray is associated with.</param>
+    public Subarray(Array array)
     {
-        private readonly Array _array;
-        private readonly Context _ctx;
-        private readonly SubarrayHandle _handle;
+        _array = array;
+        _ctx = array.Context();
+        _handle = SubarrayHandle.Create(_ctx, array.Handle);
+    }
 
-        internal SubarrayHandle Handle => _handle;
+    /// <summary>
+    /// Creates a <see cref="Subarray"/> with the ability to toggle range coalescing.
+    /// </summary>
+    /// <param name="array">The <see cref="Array"/> the subarray is associated with.</param>
+    /// <param name="coalesceRanges">Whether to coalesce adjacent ranges as they are added.
+    /// Optional, defaults to <see langword="true"/>.</param>
+    public Subarray(Array array, bool coalesceRanges) : this(array)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_subarray_set_coalesce_ranges(ctxHandle, handle, coalesceRanges ? 1 : 0));
+    }
 
-        /// <summary>
-        /// Creates a <see cref="Subarray"/>.
-        /// </summary>
-        /// <param name="array">The <see cref="Array"/> the subarray is associated with.</param>
-        public Subarray(Array array)
+    internal Subarray(Context ctx, Array array, SubarrayHandle handle)
+    {
+        _ctx = ctx;
+        _array = array;
+        _handle = handle;
+    }
+
+    /// <summary>
+    /// Disposes this <see cref="Subarray"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        _handle.Dispose();
+    }
+
+    /// <summary>
+    /// Sets a <see cref="Config"/> to this <see cref="Subarray"/>
+    /// </summary>
+    /// <param name="config">The config to set.</param>
+    /// <remarks>
+    /// The following options from <paramref name="config"/> will be considered:
+    /// <list type="bullet">
+    /// <item><c>sm.memory_budget</c></item>
+    /// <item><c>sm.memory_budget_var</c></item>
+    /// <item><c>sm.sub_partitioner_memory_budget</c></item>
+    /// <item><c>sm.var_offsets.mode</c></item>
+    /// <item><c>sm.var_offsets.extra_element</c></item>
+    /// <item><c>sm.var_offsets.bitsize</c></item>
+    /// <item><c>sm.check_coord_dups</c></item>
+    /// <item><c>sm.check_coord_oob</c></item>
+    /// <item><c>sm.check_global_order</c></item>
+    /// <item><c>sm.dedup_coords</c></item>
+    /// </list>
+    /// </remarks>
+    public void SetConfig(Config config)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var configHandle = config.Handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_subarray_set_config(ctxHandle, handle, configHandle));
+    }
+
+    private (DataType DataType, uint NumberOfDimensions) GetDomainInfo()
+    {
+        using var schema = _array.Schema();
+        using var domain = schema.Domain();
+        return (domain.Type(), domain.NDim());
+    }
+
+    /// <summary>
+    /// Sets a subarray, defined in the order dimensions were added.
+    /// </summary>
+    /// <typeparam name="T">The type of the dimensions.</typeparam>
+    /// <param name="data">An array of <c>[start,stop]</c> values per dimension.</param>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> does not match the dimension's type.</exception>
+    /// <exception cref="ArgumentException"><paramref name="data"/> does not contain exactly twice as many items as the number of dimensions.</exception>
+    /// <seealso cref="SetSubarray{T}(ReadOnlySpan{T})"/>
+    public void SetSubarray<T>(params T[] data) where T : struct
+    {
+        ErrorHandling.ThrowIfNull(data);
+        SetSubarray<T>(data.AsSpan());
+    }
+
+    /// <summary>
+    /// Sets a subarray, defined in the order dimensions were added.
+    /// </summary>
+    /// <typeparam name="T">The type of the dimensions.</typeparam>
+    /// <param name="data">A read-only span of <c>[start,stop]</c> values per dimension.</param>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
+    /// <exception cref="InvalidOperationException"><typeparamref name="T"/> does not match the dimension's type.</exception>
+    /// <exception cref="ArgumentException"><paramref name="data"/> does not contain exactly twice as many items as the number of dimensions.</exception>
+    /// <seealso cref="SetSubarray{T}(T[])"/>
+    public void SetSubarray<T>(ReadOnlySpan<T> data) where T : struct
+    {
+        ErrorHandling.ThrowIfManagedType<T>();
+        (var domainType, var nDim) = GetDomainInfo();
+
+        ErrorHandling.CheckDataType<T>(domainType);
+        if (data.Length != nDim * 2)
         {
-            _array = array;
-            _ctx = array.Context();
-            _handle = SubarrayHandle.Create(_ctx, array.Handle);
+            ThrowHelpers.ThrowSubarrayLengthMismatch(nameof(data));
         }
 
-        /// <summary>
-        /// Creates a <see cref="Subarray"/> with the ability to toggle range coalescing.
-        /// </summary>
-        /// <param name="array">The <see cref="Array"/> the subarray is associated with.</param>
-        /// <param name="coalesceRanges">Whether to coalesce adjacent ranges as they are added.
-        /// Optional, defaults to <see langword="true"/>.</param>
-        public Subarray(Array array, bool coalesceRanges) : this(array)
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        fixed (T* dataPtr = &MemoryMarshal.GetReference(data))
         {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_subarray_set_coalesce_ranges(ctxHandle, handle, coalesceRanges ? 1 : 0));
+            _ctx.handle_error(Methods.tiledb_subarray_set_subarray(ctxHandle, handle, dataPtr));
+        }
+    }
+
+    private void ValidateType<T>(string name) where T : struct
+    {
+        ErrorHandling.ThrowIfManagedType<T>();
+        using var schema = _array.Schema();
+        using var domain = schema.Domain();
+        using var dimension = domain.Dimension(name);
+        ErrorHandling.CheckDataType<T>(dimension.Type());
+    }
+
+    private void ValidateType<T>(uint index) where T : struct
+    {
+        ErrorHandling.ThrowIfManagedType<T>();
+        using var schema = _array.Schema();
+        using var domain = schema.Domain();
+        using var dimension = domain.Dimension(index);
+        ErrorHandling.CheckDataType<T>(dimension.Type());
+    }
+
+    /// <summary>
+    /// Adds a 1D range along a subarray dimension index, in the form (start, end).
+    /// </summary>
+    /// <typeparam name="T">The dimension's type.</typeparam>
+    /// <param name="dimensionIndex">The dimension's index.</param>
+    /// <param name="start">The start of the dimension's range.</param>
+    /// <param name="end">The end of the dimension's range.</param>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
+    public void AddRange<T>(uint dimensionIndex, T start, T end) where T : struct
+    {
+        ValidateType<T>(dimensionIndex);
+        AddRange(dimensionIndex, &start, &end, null);
+    }
+
+    /// <summary>
+    /// Adds a 1D range along a subarray dimension name, specified by its name, in the form (start, end).
+    /// </summary>
+    /// <typeparam name="T">The dimension's type.</typeparam>
+    /// <param name="dimensionName">The dimension's name.</param>
+    /// <param name="start">The start of the dimension's range.</param>
+    /// <param name="end">The end of the dimension's range.</param>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
+    public void AddRange<T>(string dimensionName, T start, T end) where T : struct
+    {
+        ValidateType<T>(dimensionName);
+        AddRange(dimensionName, &start, &end, null);
+    }
+
+    // TODO: Make it public once the Core supports strides.
+    /// <summary>
+    /// Adds a 1D range along a subarray dimension index, in the form (start, end, stride).
+    /// </summary>
+    /// <typeparam name="T">The dimension's type.</typeparam>
+    /// <param name="dimensionIndex">The dimension's index.</param>
+    /// <param name="start">The start of the dimension's range.</param>
+    /// <param name="end">The end of the dimension's range.</param>
+    /// <param name="stride">The stride between dimension range values</param>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
+    private void AddRange<T>(uint dimensionIndex, T start, T end, T stride) where T : struct
+    {
+        ValidateType<T>(dimensionIndex);
+        AddRange(dimensionIndex, &start, &end, &stride);
+    }
+
+    // TODO: Make it public once the Core supports strides.
+    /// <summary>
+    /// Adds a 1D range along a subarray dimension name, specified by its name, in the form(start, end, stride).
+    /// </summary>
+    /// <typeparam name="T">The dimension's type.</typeparam>
+    /// <param name="dimensionName">The dimension's name.</param>
+    /// <param name="start">The start of the dimension's range.</param>
+    /// <param name="end">The end of the dimension's range.</param>
+    /// <param name="stride">The stride between dimension range values</param>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
+    private void AddRange<T>(string dimensionName, T start, T end, T stride) where T : struct
+    {
+        ValidateType<T>(dimensionName);
+        AddRange(dimensionName, &start, &end, &stride);
+    }
+
+    private void AddRange(uint dimensionIndex, void* start, void* end, void* stride)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _ctx.handle_error(Methods.tiledb_subarray_add_range(ctxHandle, handle, dimensionIndex, start, end, stride));
+    }
+
+    private void AddRange(string dimensionName, void* start, void* end, void* stride)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(dimensionName);
+        _ctx.handle_error(Methods.tiledb_subarray_add_range_by_name(ctxHandle, handle, ms_name, start, end, stride));
+    }
+
+    /// <summary>
+    /// Adds a 1D string range along a subarray dimension index, in the form (start, end).
+    /// </summary>
+    /// <param name="dimensionIndex">The dimension's index.</param>
+    /// <param name="start">The start of the dimension's range.</param>
+    /// <param name="end">The end of the dimension's range.</param>
+    public void AddRange(uint dimensionIndex, string start, string end)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_start = new MarshaledString(start);
+        using var ms_end = new MarshaledString(end);
+        _ctx.handle_error(Methods.tiledb_subarray_add_range_var(ctxHandle, handle, dimensionIndex, ms_start, (ulong)ms_start.Length, ms_end, (ulong)ms_end.Length));
+    }
+
+    /// <summary>
+    /// Adds a 1D string range along a subarray dimension name, in the form (start, end).
+    /// </summary>
+    /// <param name="dimensionName">The dimension's name.</param>
+    /// <param name="start">The start of the dimension's range.</param>
+    /// <param name="end">The end of the dimension's range.</param>
+    public void AddRange(string dimensionName, string start, string end)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_name = new MarshaledString(dimensionName);
+        using var ms_start = new MarshaledString(start);
+        using var ms_end = new MarshaledString(end);
+        _ctx.handle_error(Methods.tiledb_subarray_add_range_var_by_name(ctxHandle, handle, ms_name, ms_start, (ulong)ms_start.Length, ms_end, (ulong)ms_end.Length));
+    }
+
+    /// <summary>
+    /// Gets the number of ranges for a given dimension index.
+    /// </summary>
+    /// <param name="dimensionIndex">The dimension's index.</param>
+    public ulong GetRangeCount(uint dimensionIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong result;
+        _ctx.handle_error(Methods.tiledb_subarray_get_range_num(ctxHandle, handle, dimensionIndex, &result));
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the number of ranges for a given dimension name.
+    /// </summary>
+    /// <param name="dimensionName">The dimension's name.</param>
+    public ulong GetRangeCount(string dimensionName)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_dimensionName = new MarshaledString(dimensionName);
+        ulong result;
+        _ctx.handle_error(Methods.tiledb_subarray_get_range_num_from_name(ctxHandle, handle, ms_dimensionName, &result));
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the range for a given dimension index and range index.
+    /// </summary>
+    /// <typeparam name="T">The dimension's type.</typeparam>
+    /// <param name="dimensionIndex">The dimension's index.</param>
+    /// <param name="rangeIndex">The range's index.</param>
+    /// <returns>The dimension's start and end values.</returns>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
+    public (T Start, T End) GetRange<T>(uint dimensionIndex, uint rangeIndex) where T : struct
+    {
+        ValidateType<T>(dimensionIndex);
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        void* startPtr, endPtr, stridePtr_unused;
+        _ctx.handle_error(Methods.tiledb_subarray_get_range(ctxHandle, handle, dimensionIndex, rangeIndex, &startPtr, &endPtr, &stridePtr_unused));
+        return (Unsafe.ReadUnaligned<T>(startPtr), Unsafe.ReadUnaligned<T>(endPtr));
+    }
+
+    /// <summary>
+    /// Gets the range for a given dimension name and range index.
+    /// </summary>
+    /// <typeparam name="T">The dimension's type.</typeparam>
+    /// <param name="dimensionName">The dimension's name.</param>
+    /// <param name="rangeIndex">The range's index.</param>
+    /// <returns>The dimension's start and end values.</returns>
+    /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
+    public (T Start, T End) GetRange<T>(string dimensionName, uint rangeIndex) where T : struct
+    {
+        ValidateType<T>(dimensionName);
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_dimensionName = new MarshaledString(dimensionName);
+        void* startPtr, endPtr, stridePtr_unused;
+        _ctx.handle_error(Methods.tiledb_subarray_get_range_from_name(ctxHandle, handle, ms_dimensionName, rangeIndex, &startPtr, &endPtr, &stridePtr_unused));
+        return (Unsafe.ReadUnaligned<T>(startPtr), Unsafe.ReadUnaligned<T>(endPtr));
+    }
+
+    /// <summary>
+    /// Gets the string range for a given dimension index and range index.
+    /// </summary>
+    /// <param name="dimensionIndex">The dimension's index.</param>
+    /// <param name="rangeIndex">The range's index.</param>
+    /// <returns>The dimension's start and end values.</returns>
+    public (string Start, string End) GetStringRange(uint dimensionIndex, uint rangeIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        ulong start_size;
+        ulong end_size;
+        _ctx.handle_error(Methods.tiledb_subarray_get_range_var_size(ctxHandle, handle, dimensionIndex, rangeIndex, &start_size, &end_size));
+
+        using var startBuffer = new ScratchBuffer<byte>(checked((int)start_size), stackalloc byte[128]);
+        using var endBuffer = new ScratchBuffer<byte>(checked((int)end_size), stackalloc byte[128]);
+        fixed (byte* startPtr = startBuffer, endPtr = endBuffer)
+        {
+            _ctx.handle_error(Methods.tiledb_subarray_get_range_var(ctxHandle, handle, dimensionIndex, rangeIndex, startPtr, endPtr));
         }
 
-        internal Subarray(Context ctx, Array array, SubarrayHandle handle)
+        var startStr = MarshaledStringOut.GetString(startBuffer.Span);
+        var endStr = MarshaledStringOut.GetString(endBuffer.Span);
+        return (startStr, endStr);
+    }
+
+    /// <summary>
+    /// Gets the string range for a given dimension name and range index.
+    /// </summary>
+    /// <param name="dimensionName">The dimension's name.</param>
+    /// <param name="rangeIndex">The range's index.</param>
+    /// <returns>The dimension's start and end values.</returns>
+    public (string Start, string End) GetStringRange(string dimensionName, uint rangeIndex)
+    {
+        using var ctxHandle = _ctx.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        using var ms_dimensionName = new MarshaledString(dimensionName);
+        ulong start_size;
+        ulong end_size;
+        _ctx.handle_error(Methods.tiledb_subarray_get_range_var_size_from_name(ctxHandle, handle, ms_dimensionName, rangeIndex, &start_size, &end_size));
+
+        using var startBuffer = new ScratchBuffer<byte>(checked((int)start_size), stackalloc byte[128]);
+        using var endBuffer = new ScratchBuffer<byte>(checked((int)end_size), stackalloc byte[128]);
+        fixed (byte* startPtr = startBuffer, endPtr = endBuffer)
         {
-            _ctx = ctx;
-            _array = array;
-            _handle = handle;
+            _ctx.handle_error(Methods.tiledb_subarray_get_range_var_from_name(ctxHandle, handle, ms_dimensionName, rangeIndex, startPtr, endPtr));
         }
 
-        /// <summary>
-        /// Disposes this <see cref="Subarray"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            _handle.Dispose();
-        }
-
-        /// <summary>
-        /// Sets a <see cref="Config"/> to this <see cref="Subarray"/>
-        /// </summary>
-        /// <param name="config">The config to set.</param>
-        /// <remarks>
-        /// The following options from <paramref name="config"/> will be considered:
-        /// <list type="bullet">
-        /// <item><c>sm.memory_budget</c></item>
-        /// <item><c>sm.memory_budget_var</c></item>
-        /// <item><c>sm.sub_partitioner_memory_budget</c></item>
-        /// <item><c>sm.var_offsets.mode</c></item>
-        /// <item><c>sm.var_offsets.extra_element</c></item>
-        /// <item><c>sm.var_offsets.bitsize</c></item>
-        /// <item><c>sm.check_coord_dups</c></item>
-        /// <item><c>sm.check_coord_oob</c></item>
-        /// <item><c>sm.check_global_order</c></item>
-        /// <item><c>sm.dedup_coords</c></item>
-        /// </list>
-        /// </remarks>
-        public void SetConfig(Config config)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var configHandle = config.Handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_subarray_set_config(ctxHandle, handle, configHandle));
-        }
-
-        private (DataType DataType, uint NumberOfDimensions) GetDomainInfo()
-        {
-            using var schema = _array.Schema();
-            using var domain = schema.Domain();
-            return (domain.Type(), domain.NDim());
-        }
-
-        /// <summary>
-        /// Sets a subarray, defined in the order dimensions were added.
-        /// </summary>
-        /// <typeparam name="T">The type of the dimensions.</typeparam>
-        /// <param name="data">An array of <c>[start,stop]</c> values per dimension.</param>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
-        /// <exception cref="InvalidOperationException"><typeparamref name="T"/> does not match the dimension's type.</exception>
-        /// <exception cref="ArgumentException"><paramref name="data"/> does not contain exactly twice as many items as the number of dimensions.</exception>
-        /// <seealso cref="SetSubarray{T}(ReadOnlySpan{T})"/>
-        public void SetSubarray<T>(params T[] data) where T : struct
-        {
-            ErrorHandling.ThrowIfNull(data);
-            SetSubarray<T>(data.AsSpan());
-        }
-
-        /// <summary>
-        /// Sets a subarray, defined in the order dimensions were added.
-        /// </summary>
-        /// <typeparam name="T">The type of the dimensions.</typeparam>
-        /// <param name="data">A read-only span of <c>[start,stop]</c> values per dimension.</param>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
-        /// <exception cref="InvalidOperationException"><typeparamref name="T"/> does not match the dimension's type.</exception>
-        /// <exception cref="ArgumentException"><paramref name="data"/> does not contain exactly twice as many items as the number of dimensions.</exception>
-        /// <seealso cref="SetSubarray{T}(T[])"/>
-        public void SetSubarray<T>(ReadOnlySpan<T> data) where T : struct
-        {
-            ErrorHandling.ThrowIfManagedType<T>();
-            (var domainType, var nDim) = GetDomainInfo();
-
-            ErrorHandling.CheckDataType<T>(domainType);
-            if (data.Length != nDim * 2)
-            {
-                ThrowHelpers.ThrowSubarrayLengthMismatch(nameof(data));
-            }
-
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            fixed (T* dataPtr = &MemoryMarshal.GetReference(data))
-            {
-                _ctx.handle_error(Methods.tiledb_subarray_set_subarray(ctxHandle, handle, dataPtr));
-            }
-        }
-
-        private void ValidateType<T>(string name) where T : struct
-        {
-            ErrorHandling.ThrowIfManagedType<T>();
-            using var schema = _array.Schema();
-            using var domain = schema.Domain();
-            using var dimension = domain.Dimension(name);
-            ErrorHandling.CheckDataType<T>(dimension.Type());
-        }
-
-        private void ValidateType<T>(uint index) where T : struct
-        {
-            ErrorHandling.ThrowIfManagedType<T>();
-            using var schema = _array.Schema();
-            using var domain = schema.Domain();
-            using var dimension = domain.Dimension(index);
-            ErrorHandling.CheckDataType<T>(dimension.Type());
-        }
-
-        /// <summary>
-        /// Adds a 1D range along a subarray dimension index, in the form (start, end).
-        /// </summary>
-        /// <typeparam name="T">The dimension's type.</typeparam>
-        /// <param name="dimensionIndex">The dimension's index.</param>
-        /// <param name="start">The start of the dimension's range.</param>
-        /// <param name="end">The end of the dimension's range.</param>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
-        public void AddRange<T>(uint dimensionIndex, T start, T end) where T : struct
-        {
-            ValidateType<T>(dimensionIndex);
-            AddRange(dimensionIndex, &start, &end, null);
-        }
-
-        /// <summary>
-        /// Adds a 1D range along a subarray dimension name, specified by its name, in the form (start, end).
-        /// </summary>
-        /// <typeparam name="T">The dimension's type.</typeparam>
-        /// <param name="dimensionName">The dimension's name.</param>
-        /// <param name="start">The start of the dimension's range.</param>
-        /// <param name="end">The end of the dimension's range.</param>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
-        public void AddRange<T>(string dimensionName, T start, T end) where T : struct
-        {
-            ValidateType<T>(dimensionName);
-            AddRange(dimensionName, &start, &end, null);
-        }
-
-        // TODO: Make it public once the Core supports strides.
-        /// <summary>
-        /// Adds a 1D range along a subarray dimension index, in the form (start, end, stride).
-        /// </summary>
-        /// <typeparam name="T">The dimension's type.</typeparam>
-        /// <param name="dimensionIndex">The dimension's index.</param>
-        /// <param name="start">The start of the dimension's range.</param>
-        /// <param name="end">The end of the dimension's range.</param>
-        /// <param name="stride">The stride between dimension range values</param>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
-        private void AddRange<T>(uint dimensionIndex, T start, T end, T stride) where T : struct
-        {
-            ValidateType<T>(dimensionIndex);
-            AddRange(dimensionIndex, &start, &end, &stride);
-        }
-
-        // TODO: Make it public once the Core supports strides.
-        /// <summary>
-        /// Adds a 1D range along a subarray dimension name, specified by its name, in the form(start, end, stride).
-        /// </summary>
-        /// <typeparam name="T">The dimension's type.</typeparam>
-        /// <param name="dimensionName">The dimension's name.</param>
-        /// <param name="start">The start of the dimension's range.</param>
-        /// <param name="end">The end of the dimension's range.</param>
-        /// <param name="stride">The stride between dimension range values</param>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
-        private void AddRange<T>(string dimensionName, T start, T end, T stride) where T : struct
-        {
-            ValidateType<T>(dimensionName);
-            AddRange(dimensionName, &start, &end, &stride);
-        }
-
-        private void AddRange(uint dimensionIndex, void* start, void* end, void* stride)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _ctx.handle_error(Methods.tiledb_subarray_add_range(ctxHandle, handle, dimensionIndex, start, end, stride));
-        }
-
-        private void AddRange(string dimensionName, void* start, void* end, void* stride)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(dimensionName);
-            _ctx.handle_error(Methods.tiledb_subarray_add_range_by_name(ctxHandle, handle, ms_name, start, end, stride));
-        }
-
-        /// <summary>
-        /// Adds a 1D string range along a subarray dimension index, in the form (start, end).
-        /// </summary>
-        /// <param name="dimensionIndex">The dimension's index.</param>
-        /// <param name="start">The start of the dimension's range.</param>
-        /// <param name="end">The end of the dimension's range.</param>
-        public void AddRange(uint dimensionIndex, string start, string end)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_start = new MarshaledString(start);
-            using var ms_end = new MarshaledString(end);
-            _ctx.handle_error(Methods.tiledb_subarray_add_range_var(ctxHandle, handle, dimensionIndex, ms_start, (ulong)ms_start.Length, ms_end, (ulong)ms_end.Length));
-        }
-
-        /// <summary>
-        /// Adds a 1D string range along a subarray dimension name, in the form (start, end).
-        /// </summary>
-        /// <param name="dimensionName">The dimension's name.</param>
-        /// <param name="start">The start of the dimension's range.</param>
-        /// <param name="end">The end of the dimension's range.</param>
-        public void AddRange(string dimensionName, string start, string end)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_name = new MarshaledString(dimensionName);
-            using var ms_start = new MarshaledString(start);
-            using var ms_end = new MarshaledString(end);
-            _ctx.handle_error(Methods.tiledb_subarray_add_range_var_by_name(ctxHandle, handle, ms_name, ms_start, (ulong)ms_start.Length, ms_end, (ulong)ms_end.Length));
-        }
-
-        /// <summary>
-        /// Gets the number of ranges for a given dimension index.
-        /// </summary>
-        /// <param name="dimensionIndex">The dimension's index.</param>
-        public ulong GetRangeCount(uint dimensionIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong result;
-            _ctx.handle_error(Methods.tiledb_subarray_get_range_num(ctxHandle, handle, dimensionIndex, &result));
-            return result;
-        }
-
-        /// <summary>
-        /// Gets the number of ranges for a given dimension name.
-        /// </summary>
-        /// <param name="dimensionName">The dimension's name.</param>
-        public ulong GetRangeCount(string dimensionName)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_dimensionName = new MarshaledString(dimensionName);
-            ulong result;
-            _ctx.handle_error(Methods.tiledb_subarray_get_range_num_from_name(ctxHandle, handle, ms_dimensionName, &result));
-            return result;
-        }
-
-        /// <summary>
-        /// Gets the range for a given dimension index and range index.
-        /// </summary>
-        /// <typeparam name="T">The dimension's type.</typeparam>
-        /// <param name="dimensionIndex">The dimension's index.</param>
-        /// <param name="rangeIndex">The range's index.</param>
-        /// <returns>The dimension's start and end values.</returns>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
-        public (T Start, T End) GetRange<T>(uint dimensionIndex, uint rangeIndex) where T : struct
-        {
-            ValidateType<T>(dimensionIndex);
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            void* startPtr, endPtr, stridePtr_unused;
-            _ctx.handle_error(Methods.tiledb_subarray_get_range(ctxHandle, handle, dimensionIndex, rangeIndex, &startPtr, &endPtr, &stridePtr_unused));
-            return (Unsafe.ReadUnaligned<T>(startPtr), Unsafe.ReadUnaligned<T>(endPtr));
-        }
-
-        /// <summary>
-        /// Gets the range for a given dimension name and range index.
-        /// </summary>
-        /// <typeparam name="T">The dimension's type.</typeparam>
-        /// <param name="dimensionName">The dimension's name.</param>
-        /// <param name="rangeIndex">The range's index.</param>
-        /// <returns>The dimension's start and end values.</returns>
-        /// <exception cref="NotSupportedException"><typeparamref name="T"/> is not supported.</exception>
-        public (T Start, T End) GetRange<T>(string dimensionName, uint rangeIndex) where T : struct
-        {
-            ValidateType<T>(dimensionName);
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_dimensionName = new MarshaledString(dimensionName);
-            void* startPtr, endPtr, stridePtr_unused;
-            _ctx.handle_error(Methods.tiledb_subarray_get_range_from_name(ctxHandle, handle, ms_dimensionName, rangeIndex, &startPtr, &endPtr, &stridePtr_unused));
-            return (Unsafe.ReadUnaligned<T>(startPtr), Unsafe.ReadUnaligned<T>(endPtr));
-        }
-
-        /// <summary>
-        /// Gets the string range for a given dimension index and range index.
-        /// </summary>
-        /// <param name="dimensionIndex">The dimension's index.</param>
-        /// <param name="rangeIndex">The range's index.</param>
-        /// <returns>The dimension's start and end values.</returns>
-        public (string Start, string End) GetStringRange(uint dimensionIndex, uint rangeIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            ulong start_size;
-            ulong end_size;
-            _ctx.handle_error(Methods.tiledb_subarray_get_range_var_size(ctxHandle, handle, dimensionIndex, rangeIndex, &start_size, &end_size));
-
-            using var startBuffer = new ScratchBuffer<byte>(checked((int)start_size), stackalloc byte[128]);
-            using var endBuffer = new ScratchBuffer<byte>(checked((int)end_size), stackalloc byte[128]);
-            fixed (byte* startPtr = startBuffer, endPtr = endBuffer)
-            {
-                _ctx.handle_error(Methods.tiledb_subarray_get_range_var(ctxHandle, handle, dimensionIndex, rangeIndex, startPtr, endPtr));
-            }
-
-            var startStr = MarshaledStringOut.GetString(startBuffer.Span);
-            var endStr = MarshaledStringOut.GetString(endBuffer.Span);
-            return (startStr, endStr);
-        }
-
-        /// <summary>
-        /// Gets the string range for a given dimension name and range index.
-        /// </summary>
-        /// <param name="dimensionName">The dimension's name.</param>
-        /// <param name="rangeIndex">The range's index.</param>
-        /// <returns>The dimension's start and end values.</returns>
-        public (string Start, string End) GetStringRange(string dimensionName, uint rangeIndex)
-        {
-            using var ctxHandle = _ctx.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            using var ms_dimensionName = new MarshaledString(dimensionName);
-            ulong start_size;
-            ulong end_size;
-            _ctx.handle_error(Methods.tiledb_subarray_get_range_var_size_from_name(ctxHandle, handle, ms_dimensionName, rangeIndex, &start_size, &end_size));
-
-            using var startBuffer = new ScratchBuffer<byte>(checked((int)start_size), stackalloc byte[128]);
-            using var endBuffer = new ScratchBuffer<byte>(checked((int)end_size), stackalloc byte[128]);
-            fixed (byte* startPtr = startBuffer, endPtr = endBuffer)
-            {
-                _ctx.handle_error(Methods.tiledb_subarray_get_range_var_from_name(ctxHandle, handle, ms_dimensionName, rangeIndex, startPtr, endPtr));
-            }
-
-            var startStr = MarshaledStringOut.GetString(startBuffer.Span);
-            var endStr = MarshaledStringOut.GetString(endBuffer.Span);
-            return (startStr, endStr);
-        }
+        var startStr = MarshaledStringOut.GetString(startBuffer.Span);
+        var endStr = MarshaledStringOut.GetString(endBuffer.Span);
+        return (startStr, endStr);
     }
 }

--- a/sources/TileDB.CSharp/ThrowHelpers.cs
+++ b/sources/TileDB.CSharp/ThrowHelpers.cs
@@ -2,61 +2,60 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+internal static class ThrowHelpers
 {
-    internal static class ThrowHelpers
-    {
-        [DoesNotReturn]
-        public static void ThrowArgumentNull(string? paramName) =>
-            throw new ArgumentNullException(paramName);
+    [DoesNotReturn]
+    public static void ThrowArgumentNull(string? paramName) =>
+        throw new ArgumentNullException(paramName);
 
-        [DoesNotReturn]
-        public static void ThrowInvalidDataType(DataType dataType, [CallerArgumentExpression(nameof(dataType))] string? paramName = null) =>
-            throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Invalid data type.");
+    [DoesNotReturn]
+    public static void ThrowInvalidDataType(DataType dataType, [CallerArgumentExpression(nameof(dataType))] string? paramName = null) =>
+        throw new ArgumentOutOfRangeException(nameof(dataType), dataType, "Invalid data type.");
 
-        [DoesNotReturn]
-        public static void ThrowTypeNotSupported() =>
-            throw new NotSupportedException("Type is not supported.");
+    [DoesNotReturn]
+    public static void ThrowTypeNotSupported() =>
+        throw new NotSupportedException("Type is not supported.");
 
-        // We don't have to specify the type in the type argument, it can be seen from the stacktrace.
-        [DoesNotReturn]
-        public static void ThrowTypeMismatch(DataType type) =>
-            throw new ArgumentException($"Type is not compatible with data type {type}.");
+    // We don't have to specify the type in the type argument, it can be seen from the stacktrace.
+    [DoesNotReturn]
+    public static void ThrowTypeMismatch(DataType type) =>
+        throw new ArgumentException($"Type is not compatible with data type {type}.");
 
-        [DoesNotReturn]
-        public static void ThrowStringTypeMismatch(DataType type) =>
-            throw new ArgumentException($"Cannot encode data type {type} into strings.");
+    [DoesNotReturn]
+    public static void ThrowStringTypeMismatch(DataType type) =>
+        throw new ArgumentException($"Cannot encode data type {type} into strings.");
 
-        [DoesNotReturn]
-        public static void ThrowTooBigSize(ulong size, [CallerArgumentExpression(nameof(size))] string? paramName = null) =>
-            throw new ArgumentOutOfRangeException(paramName, size, "Size argument is too big for the type to fit.");
+    [DoesNotReturn]
+    public static void ThrowTooBigSize(ulong size, [CallerArgumentExpression(nameof(size))] string? paramName = null) =>
+        throw new ArgumentOutOfRangeException(paramName, size, "Size argument is too big for the type to fit.");
 
-        [DoesNotReturn]
-        public static void ThrowQueryConditionDifferentContexts() =>
-            throw new InvalidOperationException("Cannot combine query conditions associated with different contexts.");
+    [DoesNotReturn]
+    public static void ThrowQueryConditionDifferentContexts() =>
+        throw new InvalidOperationException("Cannot combine query conditions associated with different contexts.");
 
-        [DoesNotReturn]
-        public static void ThrowSubarrayLengthMismatch(string paramName) =>
-            throw new ArgumentException("The length of the data is not equal to double the length of dimensions.", paramName);
+    [DoesNotReturn]
+    public static void ThrowSubarrayLengthMismatch(string paramName) =>
+        throw new ArgumentException("The length of the data is not equal to double the length of dimensions.", paramName);
 
-        [DoesNotReturn]
-        public static void ThrowManagedType() =>
-            throw new NotSupportedException("Types with managed references are not supported.");
+    [DoesNotReturn]
+    public static void ThrowManagedType() =>
+        throw new NotSupportedException("Types with managed references are not supported.");
 
-        [DoesNotReturn]
-        public static void ThrowOperationNotAllowedOnReadQueries() =>
-            throw new NotSupportedException("The operation is not allowed on read queries.");
+    [DoesNotReturn]
+    public static void ThrowOperationNotAllowedOnReadQueries() =>
+        throw new NotSupportedException("The operation is not allowed on read queries.");
 
-        [DoesNotReturn]
-        public static void ThrowBufferCannotBeEmpty(string paramName) =>
-            throw new ArgumentException("Buffer cannot be empty.", paramName);
+    [DoesNotReturn]
+    public static void ThrowBufferCannotBeEmpty(string paramName) =>
+        throw new ArgumentException("Buffer cannot be empty.", paramName);
 
-        [DoesNotReturn]
-        public static void ThrowArgumentNullException(string paramName) =>
-            throw new ArgumentNullException(paramName);
+    [DoesNotReturn]
+    public static void ThrowArgumentNullException(string paramName) =>
+        throw new ArgumentNullException(paramName);
 
-        [DoesNotReturn]
-        public static void ThrowBufferUnsafelySet() =>
-            throw new InvalidOperationException("Cannot get the number of elements read into a buffer set with the 'Query.UnsafeSetDataBuffer' method.");
-    }
+    [DoesNotReturn]
+    public static void ThrowBufferUnsafelySet() =>
+        throw new InvalidOperationException("Cannot get the number of elements read into a buffer set with the 'Query.UnsafeSetDataBuffer' method.");
 }

--- a/sources/TileDB.CSharp/TileDBException.cs
+++ b/sources/TileDB.CSharp/TileDBException.cs
@@ -1,36 +1,35 @@
 ﻿using System;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// This exception is thrown when a TileDB Embedded method fails with an error.
+/// </summary>
+/// <remarks>
+/// Almost all methods of this library may throw it.
+/// </remarks>
+public sealed class TileDBException : Exception
 {
     /// <summary>
-    /// This exception is thrown when a TileDB Embedded method fails with an error.
+    /// The exception's status code, as reported by <c>tiledb_status_code</c> function.
     /// </summary>
-    /// <remarks>
-    /// Almost all methods of this library may throw it.
-    /// </remarks>
-    public sealed class TileDBException : Exception
-    {
-        /// <summary>
-        /// The exception's status code, as reported by <c>tiledb_status_code</c> function.
-        /// </summary>
-        public int StatusCode { get; set; }
+    public int StatusCode { get; set; }
 
-        /// <summary>
-        /// Creates a <see cref="TileDBException"/>.
-        /// </summary>
-        public TileDBException() { }
+    /// <summary>
+    /// Creates a <see cref="TileDBException"/>.
+    /// </summary>
+    public TileDBException() { }
 
-        /// <summary>
-        /// Creates a <see cref="TileDBException"/> with a message.
-        /// </summary>
-        /// <param name="message">The exception's message.</param>
-        public TileDBException(string? message) : base(message) { }
+    /// <summary>
+    /// Creates a <see cref="TileDBException"/> with a message.
+    /// </summary>
+    /// <param name="message">The exception's message.</param>
+    public TileDBException(string? message) : base(message) { }
 
-        /// <summary>
-        /// Creates a <see cref="TileDBException"/> with a message and inner exception.
-        /// </summary>
-        /// <param name="message">The exception's message.</param>
-        /// <param name="inner">The exception's inner exception.</param>
-        public TileDBException(string? message, Exception? inner) : base(message, inner) { }
-    }
+    /// <summary>
+    /// Creates a <see cref="TileDBException"/> with a message and inner exception.
+    /// </summary>
+    /// <param name="message">The exception's message.</param>
+    /// <param name="inner">The exception's inner exception.</param>
+    public TileDBException(string? message, Exception? inner) : base(message, inner) { }
 }

--- a/sources/TileDB.CSharp/VFS.cs
+++ b/sources/TileDB.CSharp/VFS.cs
@@ -9,400 +9,399 @@ using TileDB.Interop;
 using ConfigHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigHandle;
 using VFSHandle = TileDB.CSharp.Marshalling.SafeHandles.VFSHandle;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB VFS (Virtual File System) object.
+/// </summary>
+public unsafe sealed class VFS : IDisposable
 {
+    private readonly VFSHandle handle_;
+    private readonly Context ctx_;
+
     /// <summary>
-    /// Represents a TileDB VFS (Virtual File System) object.
+    /// Creates a <see cref="VFS"/>.
     /// </summary>
-    public unsafe sealed class VFS : IDisposable
-    {
-        private readonly VFSHandle handle_;
-        private readonly Context ctx_;
+    public VFS() : this(null, null) { }
 
-        /// <summary>
-        /// Creates a <see cref="VFS"/>.
-        /// </summary>
-        public VFS() : this(null, null) { }
+    /// <summary>
+    /// Creates a <see cref="VFS"/> associated with the given <see cref="Context"/>.
+    /// </summary>
+    /// <param name="ctx">The context to associate the VFS with.</param>
+    public VFS(Context ctx) : this(ctx, null) { }
 
-        /// <summary>
-        /// Creates a <see cref="VFS"/> associated with the given <see cref="Context"/>.
-        /// </summary>
-        /// <param name="ctx">The context to associate the VFS with.</param>
-        public VFS(Context ctx) : this(ctx, null) { }
-
-        /// <summary>
-        /// Creates a <see cref="VFS"/> associated with the given <see cref="Context"/>.
-        /// </summary>
-        /// <param name="ctx">The context to associate the VFS with. Defaults to <see cref="Context.GetDefault"/></param>
-        /// <param name="config">The <see cref="VFS"/>' <see cref="CSharp.Config"/>. Defaults to <paramref name="ctx"/>'s config.</param>
+    /// <summary>
+    /// Creates a <see cref="VFS"/> associated with the given <see cref="Context"/>.
+    /// </summary>
+    /// <param name="ctx">The context to associate the VFS with. Defaults to <see cref="Context.GetDefault"/></param>
+    /// <param name="config">The <see cref="VFS"/>' <see cref="CSharp.Config"/>. Defaults to <paramref name="ctx"/>'s config.</param>
 #pragma warning disable S3427 // Method overloads with default parameter values should not overlap 
-        public VFS(Context? ctx = null, Config? config = null)
+    public VFS(Context? ctx = null, Config? config = null)
 #pragma warning restore S3427 // Method overloads with default parameter values should not overlap 
-        {
-            ctx_ = ctx ?? Context.GetDefault();
-            handle_ = VFSHandle.Create(ctx_, config?.Handle);
-        }
+    {
+        ctx_ = ctx ?? Context.GetDefault();
+        handle_ = VFSHandle.Create(ctx_, config?.Handle);
+    }
 
-        /// <summary>
-        /// Disposes this <see cref="VFS"/>.
-        /// </summary>
-        public void Dispose()
-        {
-            handle_.Dispose();
-        }
+    /// <summary>
+    /// Disposes this <see cref="VFS"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        handle_.Dispose();
+    }
 
-        /// <summary>
-        /// Gets the <see cref="Config"/> associated with this <see cref="VFS"/>.
-        /// </summary>
-        public Config Config()
+    /// <summary>
+    /// Gets the <see cref="Config"/> associated with this <see cref="VFS"/>.
+    /// </summary>
+    public Config Config()
+    {
+        var handle = new ConfigHandle();
+        tiledb_config_t* config = null;
+        var successful = false;
+        try
         {
-            var handle = new ConfigHandle();
-            tiledb_config_t* config = null;
-            var successful = false;
-            try
+            using var ctxHandle = ctx_.Handle.Acquire();
+            using var vfsHandle = handle_.Acquire();
+            ctx_.handle_error(Methods.tiledb_vfs_get_config(ctxHandle, vfsHandle, &config));
+            successful = true;
+        }
+        finally
+        {
+            if (successful)
             {
-                using var ctxHandle = ctx_.Handle.Acquire();
-                using var vfsHandle = handle_.Acquire();
-                ctx_.handle_error(Methods.tiledb_vfs_get_config(ctxHandle, vfsHandle, &config));
-                successful = true;
+                handle.InitHandle(config);
             }
-            finally
+            else
             {
-                if (successful)
-                {
-                    handle.InitHandle(config);
-                }
-                else
-                {
-                    handle.SetHandleAsInvalid();
-                }
+                handle.SetHandleAsInvalid();
             }
-            return new Config(handle);
         }
+        return new Config(handle);
+    }
 
-        /// <summary>
-        /// Creates an object-store bucket.
-        /// </summary>
-        /// <param name="uri">The URI of the bucket to be created.</param>
-        public void CreateBucket(string uri)
+    /// <summary>
+    /// Creates an object-store bucket.
+    /// </summary>
+    /// <param name="uri">The URI of the bucket to be created.</param>
+    public void CreateBucket(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        ctx_.handle_error(Methods.tiledb_vfs_create_bucket(ctxHandle, handle, ms_uri));
+    }
+
+    /// <summary>
+    /// Removes an object-store bucket.
+    /// </summary>
+    /// <param name="uri">The URI of the bucket to be removed.</param>
+    public void RemoveBucket(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        ctx_.handle_error(Methods.tiledb_vfs_remove_bucket(ctxHandle, handle, ms_uri));
+    }
+
+    /// <summary>
+    /// Deletes the contents of an object-store bucket.
+    /// </summary>
+    /// <param name="uri">The URI of the bucket to be emptied.</param>
+    public void EmptyBucket(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        ctx_.handle_error(Methods.tiledb_vfs_empty_bucket(ctxHandle, handle, ms_uri));
+    }
+
+    /// <summary>
+    /// Checks whether a bucket is empty or not.
+    /// </summary>
+    /// <param name="uri">The URI of the bucket to be checked.</param>
+    public bool IsEmptyBucket(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        int is_empty = 0;
+        ctx_.handle_error(Methods.tiledb_vfs_is_empty_bucket(ctxHandle, handle, ms_uri, &is_empty));
+        return is_empty > 0;
+    }
+
+    /// <summary>
+    /// Checks whether a URI points to a bucket.
+    /// </summary>
+    /// <param name="uri">The URI to check.</param>
+    public bool IsBucket(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        int is_bucket = 0;
+        ctx_.handle_error(Methods.tiledb_vfs_is_bucket(ctxHandle, handle, ms_uri, &is_bucket));
+        return is_bucket > 0;
+    }
+
+    /// <summary>
+    /// Creates a directory.
+    /// </summary>
+    /// <param name="uri">The directory's URI.</param>
+    public void CreateDir(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        ctx_.handle_error(Methods.tiledb_vfs_create_dir(ctxHandle, handle, ms_uri));
+    }
+
+    /// <summary>
+    /// Checks whether a URI points to a directory.
+    /// </summary>
+    /// <param name="uri">The URI to check.</param>
+    public bool IsDir(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        int is_dir = 0;
+        ctx_.handle_error(Methods.tiledb_vfs_is_dir(ctxHandle, handle, ms_uri, &is_dir));
+        return is_dir > 0;
+    }
+
+    /// <summary>
+    /// Removes a directory.
+    /// </summary>
+    /// <param name="uri">The directory's URI.</param>
+    public void RemoveDir(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        ctx_.handle_error(Methods.tiledb_vfs_remove_dir(ctxHandle, handle, ms_uri));
+    }
+
+    /// <summary>
+    /// Checks whether a URI points to a file.
+    /// </summary>
+    /// <param name="uri">The URI to check.</param>
+    public bool IsFile(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        int is_file = 0;
+        ctx_.handle_error(Methods.tiledb_vfs_is_file(ctxHandle, handle, ms_uri, &is_file));
+        return is_file > 0;
+    }
+
+    /// <summary>
+    /// Removes a file.
+    /// </summary>
+    /// <param name="uri">The file's URI.</param>
+    public void RemoveFile(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        ctx_.handle_error(Methods.tiledb_vfs_remove_file(ctxHandle, handle, ms_uri));
+    }
+
+    /// <summary>
+    /// Gets the size of a directory.
+    /// </summary>
+    /// <param name="uri">The directory's URI.</param>
+    public ulong DirSize(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        ulong size = 0;
+        ctx_.handle_error(Methods.tiledb_vfs_dir_size(ctxHandle, handle, ms_uri, &size));
+        return size;
+    }
+
+    /// <summary>
+    /// Gets the size of a file.
+    /// </summary>
+    /// <param name="uri">The file's URI.</param>
+    public ulong FileSize(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        ulong size = 0;
+        ctx_.handle_error(Methods.tiledb_vfs_file_size(ctxHandle, handle, ms_uri, &size));
+        return size;
+    }
+
+    /// <summary>
+    /// Renames a file.
+    /// </summary>
+    /// <param name="old_uri">The source URI of the file.</param>
+    /// <param name="new_uri">The destination URI of the file. Will be overwritten if it exists.</param>
+    public void MoveFile(string old_uri, string new_uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_old_uri = new MarshaledString(old_uri);
+        using var ms_new_uri = new MarshaledString(new_uri);
+        ctx_.handle_error(Methods.tiledb_vfs_move_file(ctxHandle, handle, ms_old_uri, ms_new_uri));
+    }
+
+    /// <summary>
+    /// Renames a directory.
+    /// </summary>
+    /// <param name="old_uri">The source URI of the directory.</param>
+    /// <param name="new_uri">The destination URI of the directory. Will be overwritten if it exists.</param>
+    public void MoveDir(string old_uri, string new_uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_old_uri = new MarshaledString(old_uri);
+        using var ms_new_uri = new MarshaledString(new_uri);
+        ctx_.handle_error(Methods.tiledb_vfs_move_dir(ctxHandle, handle, ms_old_uri, ms_new_uri));
+    }
+
+    /// <summary>
+    /// Copies a file.
+    /// </summary>
+    /// <param name="old_uri">The source URI of the file.</param>
+    /// <param name="new_uri">The destination URI of the file. Will be overwritten if it exists.</param>
+    public void CopyFile(string old_uri, string new_uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_old_uri = new MarshaledString(old_uri);
+        using var ms_new_uri = new MarshaledString(new_uri);
+        ctx_.handle_error(Methods.tiledb_vfs_copy_file(ctxHandle, handle, ms_old_uri, ms_new_uri));
+    }
+
+    /// <summary>
+    /// Copies a directory.
+    /// </summary>
+    /// <param name="old_uri">The source URI of the directory.</param>
+    /// <param name="new_uri">The destination URI of the directory. Will be overwritten if it exists.</param>
+    public void CopyDir(string old_uri, string new_uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_old_uri = new MarshaledString(old_uri);
+        using var ms_new_uri = new MarshaledString(new_uri);
+        ctx_.handle_error(Methods.tiledb_vfs_copy_dir(ctxHandle, handle, ms_old_uri, ms_new_uri));
+    }
+
+    /// <summary>
+    /// Touches a file, i.e., creates a new empty file.
+    /// </summary>
+    /// <param name="uri">The file's URI.</param>
+    public void Touch(string uri)
+    {
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        ctx_.handle_error(Methods.tiledb_vfs_touch(ctxHandle, handle, ms_uri));
+    }
+
+    /// <summary>
+    /// Opens a file.
+    /// </summary>
+    /// <param name="uri">The file's URI.</param>
+    /// <param name="mode">The mode in which the file is opened.</param>
+    /// <returns>A <see cref="VFSFile"/> object that can be used to perform operations on the file.</returns>
+    public VFSFile Open(string uri, VfsMode mode)
+    {
+        VFSFileHandle handle = VFSFileHandle.Open(ctx_, handle_, uri, (tiledb_vfs_mode_t)mode);
+        return new(ctx_, handle);
+    }
+
+    [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
+    private static int VisitCallback(sbyte* uriPtr, void* data)
+    {
+        string uri = MarshaledStringOut.GetStringFromNullTerminated(uriPtr);
+        VisitCallbackData* callbackData = (VisitCallbackData*)data;
+        Debug.Assert(callbackData->Exception is null);
+        bool shouldContinue;
+        try
         {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            ctx_.handle_error(Methods.tiledb_vfs_create_bucket(ctxHandle, handle, ms_uri));
+            shouldContinue = callbackData->Invoke(uri);
         }
-
-        /// <summary>
-        /// Removes an object-store bucket.
-        /// </summary>
-        /// <param name="uri">The URI of the bucket to be removed.</param>
-        public void RemoveBucket(string uri)
+        catch (Exception e)
         {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            ctx_.handle_error(Methods.tiledb_vfs_remove_bucket(ctxHandle, handle, ms_uri));
+            callbackData->Exception = ExceptionDispatchInfo.Capture(e);
+            shouldContinue = false;
         }
+        return shouldContinue ? 1 : 0;
+    }
 
-        /// <summary>
-        /// Deletes the contents of an object-store bucket.
-        /// </summary>
-        /// <param name="uri">The URI of the bucket to be emptied.</param>
-        public void EmptyBucket(string uri)
+    /// <summary>
+    /// Lists the top-level children of a directory.
+    /// </summary>
+    /// <param name="uri">The URI of the directory.</param>
+    /// <returns>A <see cref="List{T}"/> containing the children of the directory in <paramref name="uri"/>.</returns>
+    /// <remarks>
+    /// This function does not visit the children recursively; only the
+    /// top-level children of <paramref name="uri"/> will be visited.
+    /// </remarks>
+    public List<string> GetChildren(string uri)
+    {
+        var list = new List<string>();
+        VisitChildren(uri, static (uri, list) =>
         {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            ctx_.handle_error(Methods.tiledb_vfs_empty_bucket(ctxHandle, handle, ms_uri));
-        }
+            list.Add(uri);
+            return true;
+        }, list);
+        return list;
+    }
 
-        /// <summary>
-        /// Checks whether a bucket is empty or not.
-        /// </summary>
-        /// <param name="uri">The URI of the bucket to be checked.</param>
-        public bool IsEmptyBucket(string uri)
+    /// <summary>
+    /// Visits the top-level children of a directory.
+    /// </summary>
+    /// <param name="uri">The URI of the directory to visit.</param>
+    /// <param name="callback">A callback delegate that will be called with the URI of each child and
+    /// <paramref name="callbackArg"/>, and returns whether to continue visiting.</param>
+    /// <param name="callbackArg">An argument that will be passed to <paramref name="callback"/>.</param>
+    /// <typeparam name="T">The type of <paramref name="callbackArg"/>.</typeparam>
+    /// <remarks>
+    /// This function does not visit the children recursively; only the
+    /// top-level children of <paramref name="uri"/> will be visited.
+    /// </remarks>
+    public void VisitChildren<T>(string uri, Func<string, T, bool> callback, T callbackArg)
+    {
+        ValueTuple<Func<string, T, bool>, T> data = (callback, callbackArg);
+        var callbackData = new VisitCallbackData()
         {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            int is_empty = 0;
-            ctx_.handle_error(Methods.tiledb_vfs_is_empty_bucket(ctxHandle, handle, ms_uri, &is_empty));
-            return is_empty > 0;
-        }
-
-        /// <summary>
-        /// Checks whether a URI points to a bucket.
-        /// </summary>
-        /// <param name="uri">The URI to check.</param>
-        public bool IsBucket(string uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            int is_bucket = 0;
-            ctx_.handle_error(Methods.tiledb_vfs_is_bucket(ctxHandle, handle, ms_uri, &is_bucket));
-            return is_bucket > 0;
-        }
-
-        /// <summary>
-        /// Creates a directory.
-        /// </summary>
-        /// <param name="uri">The directory's URI.</param>
-        public void CreateDir(string uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            ctx_.handle_error(Methods.tiledb_vfs_create_dir(ctxHandle, handle, ms_uri));
-        }
-
-        /// <summary>
-        /// Checks whether a URI points to a directory.
-        /// </summary>
-        /// <param name="uri">The URI to check.</param>
-        public bool IsDir(string uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            int is_dir = 0;
-            ctx_.handle_error(Methods.tiledb_vfs_is_dir(ctxHandle, handle, ms_uri, &is_dir));
-            return is_dir > 0;
-        }
-
-        /// <summary>
-        /// Removes a directory.
-        /// </summary>
-        /// <param name="uri">The directory's URI.</param>
-        public void RemoveDir(string uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            ctx_.handle_error(Methods.tiledb_vfs_remove_dir(ctxHandle, handle, ms_uri));
-        }
-
-        /// <summary>
-        /// Checks whether a URI points to a file.
-        /// </summary>
-        /// <param name="uri">The URI to check.</param>
-        public bool IsFile(string uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            int is_file = 0;
-            ctx_.handle_error(Methods.tiledb_vfs_is_file(ctxHandle, handle, ms_uri, &is_file));
-            return is_file > 0;
-        }
-
-        /// <summary>
-        /// Removes a file.
-        /// </summary>
-        /// <param name="uri">The file's URI.</param>
-        public void RemoveFile(string uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            ctx_.handle_error(Methods.tiledb_vfs_remove_file(ctxHandle, handle, ms_uri));
-        }
-
-        /// <summary>
-        /// Gets the size of a directory.
-        /// </summary>
-        /// <param name="uri">The directory's URI.</param>
-        public ulong DirSize(string uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            ulong size = 0;
-            ctx_.handle_error(Methods.tiledb_vfs_dir_size(ctxHandle, handle, ms_uri, &size));
-            return size;
-        }
-
-        /// <summary>
-        /// Gets the size of a file.
-        /// </summary>
-        /// <param name="uri">The file's URI.</param>
-        public ulong FileSize(string uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            ulong size = 0;
-            ctx_.handle_error(Methods.tiledb_vfs_file_size(ctxHandle, handle, ms_uri, &size));
-            return size;
-        }
-
-        /// <summary>
-        /// Renames a file.
-        /// </summary>
-        /// <param name="old_uri">The source URI of the file.</param>
-        /// <param name="new_uri">The destination URI of the file. Will be overwritten if it exists.</param>
-        public void MoveFile(string old_uri, string new_uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_old_uri = new MarshaledString(old_uri);
-            using var ms_new_uri = new MarshaledString(new_uri);
-            ctx_.handle_error(Methods.tiledb_vfs_move_file(ctxHandle, handle, ms_old_uri, ms_new_uri));
-        }
-
-        /// <summary>
-        /// Renames a directory.
-        /// </summary>
-        /// <param name="old_uri">The source URI of the directory.</param>
-        /// <param name="new_uri">The destination URI of the directory. Will be overwritten if it exists.</param>
-        public void MoveDir(string old_uri, string new_uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_old_uri = new MarshaledString(old_uri);
-            using var ms_new_uri = new MarshaledString(new_uri);
-            ctx_.handle_error(Methods.tiledb_vfs_move_dir(ctxHandle, handle, ms_old_uri, ms_new_uri));
-        }
-
-        /// <summary>
-        /// Copies a file.
-        /// </summary>
-        /// <param name="old_uri">The source URI of the file.</param>
-        /// <param name="new_uri">The destination URI of the file. Will be overwritten if it exists.</param>
-        public void CopyFile(string old_uri, string new_uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_old_uri = new MarshaledString(old_uri);
-            using var ms_new_uri = new MarshaledString(new_uri);
-            ctx_.handle_error(Methods.tiledb_vfs_copy_file(ctxHandle, handle, ms_old_uri, ms_new_uri));
-        }
-
-        /// <summary>
-        /// Copies a directory.
-        /// </summary>
-        /// <param name="old_uri">The source URI of the directory.</param>
-        /// <param name="new_uri">The destination URI of the directory. Will be overwritten if it exists.</param>
-        public void CopyDir(string old_uri, string new_uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_old_uri = new MarshaledString(old_uri);
-            using var ms_new_uri = new MarshaledString(new_uri);
-            ctx_.handle_error(Methods.tiledb_vfs_copy_dir(ctxHandle, handle, ms_old_uri, ms_new_uri));
-        }
-
-        /// <summary>
-        /// Touches a file, i.e., creates a new empty file.
-        /// </summary>
-        /// <param name="uri">The file's URI.</param>
-        public void Touch(string uri)
-        {
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            ctx_.handle_error(Methods.tiledb_vfs_touch(ctxHandle, handle, ms_uri));
-        }
-
-        /// <summary>
-        /// Opens a file.
-        /// </summary>
-        /// <param name="uri">The file's URI.</param>
-        /// <param name="mode">The mode in which the file is opened.</param>
-        /// <returns>A <see cref="VFSFile"/> object that can be used to perform operations on the file.</returns>
-        public VFSFile Open(string uri, VfsMode mode)
-        {
-            VFSFileHandle handle = VFSFileHandle.Open(ctx_, handle_, uri, (tiledb_vfs_mode_t)mode);
-            return new(ctx_, handle);
-        }
-
-        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
-        private static int VisitCallback(sbyte* uriPtr, void* data)
-        {
-            string uri = MarshaledStringOut.GetStringFromNullTerminated(uriPtr);
-            VisitCallbackData* callbackData = (VisitCallbackData*)data;
-            Debug.Assert(callbackData->Exception is null);
-            bool shouldContinue;
-            try
+            Callback = static (uri, arg) =>
             {
-                shouldContinue = callbackData->Invoke(uri);
-            }
-            catch (Exception e)
-            {
-                callbackData->Exception = ExceptionDispatchInfo.Capture(e);
-                shouldContinue = false;
-            }
-            return shouldContinue ? 1 : 0;
-        }
+                var dataPtr = (ValueTuple<Func<string, T, bool>, T>*)arg;
+                return dataPtr->Item1(uri, dataPtr->Item2);
+            },
+            CallbackArgument = (IntPtr)(&data)
+        };
 
-        /// <summary>
-        /// Lists the top-level children of a directory.
-        /// </summary>
-        /// <param name="uri">The URI of the directory.</param>
-        /// <returns>A <see cref="List{T}"/> containing the children of the directory in <paramref name="uri"/>.</returns>
-        /// <remarks>
-        /// This function does not visit the children recursively; only the
-        /// top-level children of <paramref name="uri"/> will be visited.
-        /// </remarks>
-        public List<string> GetChildren(string uri)
-        {
-            var list = new List<string>();
-            VisitChildren(uri, static (uri, list) =>
-            {
-                list.Add(uri);
-                return true;
-            }, list);
-            return list;
-        }
+        using var ctxHandle = ctx_.Handle.Acquire();
+        using var handle = handle_.Acquire();
+        using var ms_uri = new MarshaledString(uri);
+        // Taking a pointer to callbackData is safe; the callback will be invoked only
+        // during the call to tiledb_vfs_ls. Contrast this with tiledb_query_submit_async where we
+        // had to use a GCHandle because the callback might be invoked after we return from it.
+        // We also are not susceptible to GC holes; callbackData is in the stack and won't be moved around.
+        ctx_.handle_error(Methods.tiledb_vfs_ls(ctxHandle, handle, ms_uri, &VisitCallback, &callbackData));
+        callbackData.Exception?.Throw();
+    }
 
-        /// <summary>
-        /// Visits the top-level children of a directory.
-        /// </summary>
-        /// <param name="uri">The URI of the directory to visit.</param>
-        /// <param name="callback">A callback delegate that will be called with the URI of each child and
-        /// <paramref name="callbackArg"/>, and returns whether to continue visiting.</param>
-        /// <param name="callbackArg">An argument that will be passed to <paramref name="callback"/>.</param>
-        /// <typeparam name="T">The type of <paramref name="callbackArg"/>.</typeparam>
-        /// <remarks>
-        /// This function does not visit the children recursively; only the
-        /// top-level children of <paramref name="uri"/> will be visited.
-        /// </remarks>
-        public void VisitChildren<T>(string uri, Func<string, T, bool> callback, T callbackArg)
-        {
-            ValueTuple<Func<string, T, bool>, T> data = (callback, callbackArg);
-            var callbackData = new VisitCallbackData()
-            {
-                Callback = static (uri, arg) =>
-                {
-                    var dataPtr = (ValueTuple<Func<string, T, bool>, T>*)arg;
-                    return dataPtr->Item1(uri, dataPtr->Item2);
-                },
-                CallbackArgument = (IntPtr)(&data)
-            };
+    private struct VisitCallbackData
+    {
+        public Func<string, IntPtr, bool> Callback;
 
-            using var ctxHandle = ctx_.Handle.Acquire();
-            using var handle = handle_.Acquire();
-            using var ms_uri = new MarshaledString(uri);
-            // Taking a pointer to callbackData is safe; the callback will be invoked only
-            // during the call to tiledb_vfs_ls. Contrast this with tiledb_query_submit_async where we
-            // had to use a GCHandle because the callback might be invoked after we return from it.
-            // We also are not susceptible to GC holes; callbackData is in the stack and won't be moved around.
-            ctx_.handle_error(Methods.tiledb_vfs_ls(ctxHandle, handle, ms_uri, &VisitCallback, &callbackData));
-            callbackData.Exception?.Throw();
-        }
+        public IntPtr CallbackArgument;
 
-        private struct VisitCallbackData
-        {
-            public Func<string, IntPtr, bool> Callback;
+        // If the callback threw an exception we will save it here and rethrow it once we leave native code.
+        // The reason we do this is that throwing exceptions in P/Invoke is not portable (works only on Windows
+        // and because the native library is compiled with MSVC).
+        public ExceptionDispatchInfo? Exception;
 
-            public IntPtr CallbackArgument;
-
-            // If the callback threw an exception we will save it here and rethrow it once we leave native code.
-            // The reason we do this is that throwing exceptions in P/Invoke is not portable (works only on Windows
-            // and because the native library is compiled with MSVC).
-            public ExceptionDispatchInfo? Exception;
-
-            public bool Invoke(string uri) => Callback(uri, CallbackArgument);
-        }
+        public bool Invoke(string uri) => Callback(uri, CallbackArgument);
     }
 }

--- a/sources/TileDB.CSharp/VFS.cs
+++ b/sources/TileDB.CSharp/VFS.cs
@@ -316,7 +316,7 @@ namespace TileDB.CSharp
             return new(ctx_, handle);
         }
 
-        [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+        [UnmanagedCallersOnly(CallConvs = [typeof(CallConvCdecl)])]
         private static int VisitCallback(sbyte* uriPtr, void* data)
         {
             string uri = MarshaledStringOut.GetStringFromNullTerminated(uriPtr);

--- a/sources/TileDB.CSharp/VFSFile.cs
+++ b/sources/TileDB.CSharp/VFSFile.cs
@@ -3,135 +3,134 @@ using System.Runtime.InteropServices;
 using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 
-namespace TileDB.CSharp
+namespace TileDB.CSharp;
+
+/// <summary>
+/// Represents a TileDB VFS (Virtual File System) file object.
+/// </summary>
+/// <remarks>
+/// This class cannot be directly created.
+/// To obtain an instance of it, use <see cref="VFS.Open"/>.
+/// </remarks>
+public unsafe sealed class VFSFile : IDisposable
 {
+    private readonly Context _context;
+    private readonly VFSFileHandle _handle;
+
+    internal VFSFile(Context context, VFSFileHandle handle)
+    {
+        _context = context;
+        _handle = handle;
+    }
+
     /// <summary>
-    /// Represents a TileDB VFS (Virtual File System) file object.
+    /// Whether the file is closed.
+    /// </summary>
+    public bool IsClosed
+    {
+        get
+        {
+            using var contextHandle = _context.Handle.Acquire();
+            using var handle = _handle.Acquire();
+            int isClosed;
+            _context.handle_error(Methods.tiledb_vfs_fh_is_closed(contextHandle, handle, &isClosed));
+            return isClosed != 0;
+        }
+    }
+
+    /// <summary>
+    /// Disposes this <see cref="VFSFile"/>.
+    /// </summary>
+    public void Dispose() => _handle.Dispose();
+
+    /// <summary>
+    /// Reads from the file at a specified offset.
+    /// </summary>
+    /// <param name="offset">The offset to read from.</param>
+    /// <param name="buffer">A <see cref="Span{T}"/> of bytes where the file's data will be written into.</param>
+    /// <exception cref="Exception">The remaining data in the file after <paramref name="offset"/>
+    /// are less than <paramref name="buffer"/>'s <see cref="Span{T}.Length"/>.</exception>
+    /// <remarks>If you want to read more than <see cref="int.MaxValue"/> bytes
+    /// of data you should call <see cref="ReadExactly(ulong, byte*, ulong)"/>.</remarks>
+    public void ReadExactly(ulong offset, Span<byte> buffer)
+    {
+        fixed(byte* ptr = &MemoryMarshal.GetReference(buffer))
+        {
+            ReadExactly(offset, ptr, (ulong)buffer.Length);
+        }
+    }
+
+    /// <summary>
+    /// Reads from the file at a specified offset.
+    /// </summary>
+    /// <param name="offset">The offset to read from.</param>
+    /// <param name="buffer">A pointer to the memory region where the file's data will be written into.</param>
+    /// <param name="count">The number of bytes to read.</param>
+    /// <exception cref="Exception">The remaining data in the file after <paramref name="offset"/>
+    /// are less than <paramref name="count"/>.</exception>
+    /// <seealso cref="ReadExactly(ulong, Span{byte})"/>
+    public void ReadExactly(ulong offset, byte* buffer, ulong count)
+    {
+        using var contextHandle = _context.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _context.handle_error(Methods.tiledb_vfs_read(contextHandle, handle, offset, buffer, count));
+    }
+
+    /// <summary>
+    /// Writes data to the end of the file.
+    /// </summary>
+    /// <param name="buffer">A <see cref="ReadOnlySpan{T}"/> of bytes whose content will be written.</param>
+    /// <remarks>
+    /// <para>If you want to write more than <see cref="int.MaxValue"/> bytes
+    /// of data you should call <see cref="Write(byte*, ulong)"/>.</para>
+    /// <para>If the file does not exist, it will be created.</para>
+    /// </remarks>
+    public void Write(ReadOnlySpan<byte> buffer)
+    {
+        fixed (byte* ptr = &MemoryMarshal.GetReference(buffer))
+        {
+            Write(ptr, (ulong)buffer.Length);
+        }
+    }
+
+    /// <summary>
+    /// Writes data to the end of the file.
+    /// </summary>
+    /// <param name="buffer">A pointer to the bytes that will be written.</param>
+    /// <param name="count">The number of bytes to write.</param>
+    /// <remarks>
+    /// If the file does not exist, it will be created.
+    /// </remarks>
+    public void Write(byte* buffer, ulong count)
+    {
+        using var contextHandle = _context.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _context.handle_error(Methods.tiledb_vfs_write(contextHandle, handle, buffer, count));
+    }
+
+    /// <summary>
+    /// Closes a file. This flushes the buffered data into the file when the file was opened in write (or append) mode.
     /// </summary>
     /// <remarks>
-    /// This class cannot be directly created.
-    /// To obtain an instance of it, use <see cref="VFS.Open"/>.
+    /// It is particularly important to be called after <see cref="FileSystemType.S3"/> writes, as otherwise the writes will not take effect.
     /// </remarks>
-    public unsafe sealed class VFSFile : IDisposable
+    public void Close()
     {
-        private readonly Context _context;
-        private readonly VFSFileHandle _handle;
+        using var contextHandle = _context.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _context.handle_error(Methods.tiledb_vfs_close(contextHandle, handle));
+    }
 
-        internal VFSFile(Context context, VFSFileHandle handle)
-        {
-            _context = context;
-            _handle = handle;
-        }
-
-        /// <summary>
-        /// Whether the file is closed.
-        /// </summary>
-        public bool IsClosed
-        {
-            get
-            {
-                using var contextHandle = _context.Handle.Acquire();
-                using var handle = _handle.Acquire();
-                int isClosed;
-                _context.handle_error(Methods.tiledb_vfs_fh_is_closed(contextHandle, handle, &isClosed));
-                return isClosed != 0;
-            }
-        }
-
-        /// <summary>
-        /// Disposes this <see cref="VFSFile"/>.
-        /// </summary>
-        public void Dispose() => _handle.Dispose();
-
-        /// <summary>
-        /// Reads from the file at a specified offset.
-        /// </summary>
-        /// <param name="offset">The offset to read from.</param>
-        /// <param name="buffer">A <see cref="Span{T}"/> of bytes where the file's data will be written into.</param>
-        /// <exception cref="Exception">The remaining data in the file after <paramref name="offset"/>
-        /// are less than <paramref name="buffer"/>'s <see cref="Span{T}.Length"/>.</exception>
-        /// <remarks>If you want to read more than <see cref="int.MaxValue"/> bytes
-        /// of data you should call <see cref="ReadExactly(ulong, byte*, ulong)"/>.</remarks>
-        public void ReadExactly(ulong offset, Span<byte> buffer)
-        {
-            fixed(byte* ptr = &MemoryMarshal.GetReference(buffer))
-            {
-                ReadExactly(offset, ptr, (ulong)buffer.Length);
-            }
-        }
-
-        /// <summary>
-        /// Reads from the file at a specified offset.
-        /// </summary>
-        /// <param name="offset">The offset to read from.</param>
-        /// <param name="buffer">A pointer to the memory region where the file's data will be written into.</param>
-        /// <param name="count">The number of bytes to read.</param>
-        /// <exception cref="Exception">The remaining data in the file after <paramref name="offset"/>
-        /// are less than <paramref name="count"/>.</exception>
-        /// <seealso cref="ReadExactly(ulong, Span{byte})"/>
-        public void ReadExactly(ulong offset, byte* buffer, ulong count)
-        {
-            using var contextHandle = _context.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _context.handle_error(Methods.tiledb_vfs_read(contextHandle, handle, offset, buffer, count));
-        }
-
-        /// <summary>
-        /// Writes data to the end of the file.
-        /// </summary>
-        /// <param name="buffer">A <see cref="ReadOnlySpan{T}"/> of bytes whose content will be written.</param>
-        /// <remarks>
-        /// <para>If you want to write more than <see cref="int.MaxValue"/> bytes
-        /// of data you should call <see cref="Write(byte*, ulong)"/>.</para>
-        /// <para>If the file does not exist, it will be created.</para>
-        /// </remarks>
-        public void Write(ReadOnlySpan<byte> buffer)
-        {
-            fixed (byte* ptr = &MemoryMarshal.GetReference(buffer))
-            {
-                Write(ptr, (ulong)buffer.Length);
-            }
-        }
-
-        /// <summary>
-        /// Writes data to the end of the file.
-        /// </summary>
-        /// <param name="buffer">A pointer to the bytes that will be written.</param>
-        /// <param name="count">The number of bytes to write.</param>
-        /// <remarks>
-        /// If the file does not exist, it will be created.
-        /// </remarks>
-        public void Write(byte* buffer, ulong count)
-        {
-            using var contextHandle = _context.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _context.handle_error(Methods.tiledb_vfs_write(contextHandle, handle, buffer, count));
-        }
-
-        /// <summary>
-        /// Closes a file. This flushes the buffered data into the file when the file was opened in write (or append) mode.
-        /// </summary>
-        /// <remarks>
-        /// It is particularly important to be called after <see cref="FileSystemType.S3"/> writes, as otherwise the writes will not take effect.
-        /// </remarks>
-        public void Close()
-        {
-            using var contextHandle = _context.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _context.handle_error(Methods.tiledb_vfs_close(contextHandle, handle));
-        }
-
-        /// <summary>
-        /// Flushes the file's internal buffers.
-        /// </summary>
-        /// <remarks>
-        /// This has no effect for <see cref="FileSystemType.S3"/>.
-        /// </remarks>
-        public void Flush()
-        {
-            using var contextHandle = _context.Handle.Acquire();
-            using var handle = _handle.Acquire();
-            _context.handle_error(Methods.tiledb_vfs_sync(contextHandle, handle));
-        }
+    /// <summary>
+    /// Flushes the file's internal buffers.
+    /// </summary>
+    /// <remarks>
+    /// This has no effect for <see cref="FileSystemType.S3"/>.
+    /// </remarks>
+    public void Flush()
+    {
+        using var contextHandle = _context.Handle.Acquire();
+        using var handle = _handle.Acquire();
+        _context.handle_error(Methods.tiledb_vfs_sync(contextHandle, handle));
     }
 }

--- a/tests/TileDB.CSharp.Test/AggregatesTest.cs
+++ b/tests/TileDB.CSharp.Test/AggregatesTest.cs
@@ -1,111 +1,110 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class AggregatesTest
 {
-    [TestClass]
-    public class AggregatesTest
+    [TestMethod]
+    public unsafe void Test()
     {
-        [TestMethod]
-        public unsafe void Test()
+        var context = Context.GetDefault();
+
+        using var tmpArrayPath = new TemporaryDirectory("aggregate_test");
+
+        using var array = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array);
+
+        using var array_schema = BuildArraySchema(context);
+        Assert.IsNotNull(array_schema);
+
+        array.Create(array_schema);
+
+        array.Open(QueryType.Write);
+
+        int[] data = [62, 26, 81, 86, 93, 0, 60, 25, 68, 28];
+        byte[] validity = [1, 1, 1, 1, 1, 0, 1, 1, 1, 1];
+
+        using (var query = new Query(array))
         {
-            var context = Context.GetDefault();
+            query.SetLayout(LayoutType.RowMajor);
+            query.SetDataBuffer("a1", data);
+            query.SetValidityBuffer("a1", validity);
 
-            using var tmpArrayPath = new TemporaryDirectory("aggregate_test");
-
-            using var array = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array);
-
-            using var array_schema = BuildArraySchema(context);
-            Assert.IsNotNull(array_schema);
-
-            array.Create(array_schema);
-
-            array.Open(QueryType.Write);
-
-            int[] data = [62, 26, 81, 86, 93, 0, 60, 25, 68, 28];
-            byte[] validity = [1, 1, 1, 1, 1, 0, 1, 1, 1, 1];
-
-            using (var query = new Query(array))
-            {
-                query.SetLayout(LayoutType.RowMajor);
-                query.SetDataBuffer("a1", data);
-                query.SetValidityBuffer("a1", validity);
-
-                query.Submit();
-            }
-            array.Close();
-
-            array.Open(QueryType.Read);
-            int[] dataRead = new int[data.Length];
-            byte[] validityRead = new byte[data.Length];
-            ulong count, nullCount;
-            long sum;
-            double mean;
-            int min, max;
-            byte sumValidity, meanValidity, minValidity, maxValidity;
-            using (var query = new Query(array))
-            {
-                query.SetLayout(LayoutType.RowMajor);
-                using var subarray = new Subarray(array);
-                subarray.AddRange(0, 1, 10);
-                query.SetSubarray(subarray);
-
-                using var channel = query.GetDefaultChannel();
-                channel.ApplyAggregate(AggregateOperation.Count, nameof(count));
-                channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.Sum, "a1"), nameof(sum));
-                channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.Mean, "a1"), nameof(mean));
-                channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.Min, "a1"), nameof(min));
-                channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.Max, "a1"), nameof(max));
-                channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.NullCount, "a1"), nameof(nullCount));
-
-                using var countField = query.GetField(nameof(count));
-                Assert.AreEqual(nameof(count), countField.Name);
-                Assert.AreEqual(DataType.UInt64, countField.DataType);
-                Assert.AreEqual(1u, countField.ValuesPerCell);
-                Assert.AreEqual(QueryFieldOrigin.Aggregate, countField.Origin);
-
-                query.SetDataBuffer("a1", dataRead);
-                query.SetValidityBuffer("a1", validityRead);
-                query.SetDataBuffer(nameof(count), &count, 1);
-                query.SetDataBuffer(nameof(sum), &sum, 1);
-                query.SetValidityBuffer(nameof(sum), &sumValidity, 1);
-                query.SetDataBuffer(nameof(mean), &mean, 1);
-                query.SetValidityBuffer(nameof(mean), &meanValidity, 1);
-                query.SetDataBuffer(nameof(min), &min, 1);
-                query.SetValidityBuffer(nameof(min), &minValidity, 1);
-                query.SetDataBuffer(nameof(max), &max, 1);
-                query.SetValidityBuffer(nameof(max), &maxValidity, 1);
-                query.SetDataBuffer(nameof(nullCount), &nullCount, 1);
-
-                query.Submit();
-
-                CollectionAssert.AreEqual(data, dataRead);
-                CollectionAssert.AreEqual(validity, validityRead);
-                Assert.AreEqual((ulong)data.Length, count);
-                Assert.AreEqual(529, sum);
-                Assert.AreEqual(58.8, mean, 0.1);
-                Assert.AreEqual(25, min);
-                Assert.AreEqual(93, max);
-                Assert.AreEqual(1, sumValidity);
-                Assert.AreEqual(1, meanValidity);
-                Assert.AreEqual(1, minValidity);
-                Assert.AreEqual(1, maxValidity);
-            }
+            query.Submit();
         }
+        array.Close();
 
-        private static ArraySchema BuildArraySchema(Context context)
+        array.Open(QueryType.Read);
+        int[] dataRead = new int[data.Length];
+        byte[] validityRead = new byte[data.Length];
+        ulong count, nullCount;
+        long sum;
+        double mean;
+        int min, max;
+        byte sumValidity, meanValidity, minValidity, maxValidity;
+        using (var query = new Query(array))
         {
-            var array_schema = new ArraySchema(context, ArrayType.Dense);
-            using var domain = new Domain(context);
-            using var dimension = Dimension.Create(context, "dim1", 1, 10, 5);
-            domain.AddDimension(dimension);
-            array_schema.SetDomain(domain);
+            query.SetLayout(LayoutType.RowMajor);
+            using var subarray = new Subarray(array);
+            subarray.AddRange(0, 1, 10);
+            query.SetSubarray(subarray);
 
-            using var a1 = new Attribute(context, "a1", DataType.Int32);
-            a1.SetNullable(true);
-            array_schema.AddAttribute(a1);
-            array_schema.Check();
-            return array_schema;
+            using var channel = query.GetDefaultChannel();
+            channel.ApplyAggregate(AggregateOperation.Count, nameof(count));
+            channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.Sum, "a1"), nameof(sum));
+            channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.Mean, "a1"), nameof(mean));
+            channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.Min, "a1"), nameof(min));
+            channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.Max, "a1"), nameof(max));
+            channel.ApplyAggregate(AggregateOperation.Unary(AggregateOperator.NullCount, "a1"), nameof(nullCount));
+
+            using var countField = query.GetField(nameof(count));
+            Assert.AreEqual(nameof(count), countField.Name);
+            Assert.AreEqual(DataType.UInt64, countField.DataType);
+            Assert.AreEqual(1u, countField.ValuesPerCell);
+            Assert.AreEqual(QueryFieldOrigin.Aggregate, countField.Origin);
+
+            query.SetDataBuffer("a1", dataRead);
+            query.SetValidityBuffer("a1", validityRead);
+            query.SetDataBuffer(nameof(count), &count, 1);
+            query.SetDataBuffer(nameof(sum), &sum, 1);
+            query.SetValidityBuffer(nameof(sum), &sumValidity, 1);
+            query.SetDataBuffer(nameof(mean), &mean, 1);
+            query.SetValidityBuffer(nameof(mean), &meanValidity, 1);
+            query.SetDataBuffer(nameof(min), &min, 1);
+            query.SetValidityBuffer(nameof(min), &minValidity, 1);
+            query.SetDataBuffer(nameof(max), &max, 1);
+            query.SetValidityBuffer(nameof(max), &maxValidity, 1);
+            query.SetDataBuffer(nameof(nullCount), &nullCount, 1);
+
+            query.Submit();
+
+            CollectionAssert.AreEqual(data, dataRead);
+            CollectionAssert.AreEqual(validity, validityRead);
+            Assert.AreEqual((ulong)data.Length, count);
+            Assert.AreEqual(529, sum);
+            Assert.AreEqual(58.8, mean, 0.1);
+            Assert.AreEqual(25, min);
+            Assert.AreEqual(93, max);
+            Assert.AreEqual(1, sumValidity);
+            Assert.AreEqual(1, meanValidity);
+            Assert.AreEqual(1, minValidity);
+            Assert.AreEqual(1, maxValidity);
         }
+    }
+
+    private static ArraySchema BuildArraySchema(Context context)
+    {
+        var array_schema = new ArraySchema(context, ArrayType.Dense);
+        using var domain = new Domain(context);
+        using var dimension = Dimension.Create(context, "dim1", 1, 10, 5);
+        domain.AddDimension(dimension);
+        array_schema.SetDomain(domain);
+
+        using var a1 = new Attribute(context, "a1", DataType.Int32);
+        a1.SetNullable(true);
+        array_schema.AddAttribute(a1);
+        array_schema.Check();
+        return array_schema;
     }
 }

--- a/tests/TileDB.CSharp.Test/AggregatesTest.cs
+++ b/tests/TileDB.CSharp.Test/AggregatesTest.cs
@@ -22,8 +22,8 @@ namespace TileDB.CSharp.Test
 
             array.Open(QueryType.Write);
 
-            int[] data = new int[10] { 62, 26, 81, 86, 93, 0, 60, 25, 68, 28 };
-            byte[] validity = new byte[10] { 1, 1, 1, 1, 1, 0, 1, 1, 1, 1 };
+            int[] data = [62, 26, 81, 86, 93, 0, 60, 25, 68, 28];
+            byte[] validity = [1, 1, 1, 1, 1, 0, 1, 1, 1, 1];
 
             using (var query = new Query(array))
             {

--- a/tests/TileDB.CSharp.Test/ArrayMetadataTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayMetadataTest.cs
@@ -2,137 +2,136 @@
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class ArrayMetadataTest
 {
-    [TestClass]
-    public class ArrayMetadataTest
+    [TestMethod]
+    public void TestArrayMetadata()
     {
-        [TestMethod]
-        public void TestArrayMetadata()
+        var tmpArrayPath = TestUtil.MakeTestPath("metadata_array");
+
+        if (Directory.Exists(tmpArrayPath))
         {
-            var tmpArrayPath = TestUtil.MakeTestPath("metadata_array");
-
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
-            createArrayMetadataArray(tmpArrayPath);
-            writeArrayMetadata(tmpArrayPath);
-            readArrayMetadata(tmpArrayPath);
-            clearArrayMetadata(tmpArrayPath);
+            Directory.Delete(tmpArrayPath, true);
         }
+        createArrayMetadataArray(tmpArrayPath);
+        writeArrayMetadata(tmpArrayPath);
+        readArrayMetadata(tmpArrayPath);
+        clearArrayMetadata(tmpArrayPath);
+    }
 
-        private void createArrayMetadataArray(string tmpArrayPath)
-        {
-            var context = Context.GetDefault();
+    private void createArrayMetadataArray(string tmpArrayPath)
+    {
+        var context = Context.GetDefault();
 
-            var rowDim = Dimension.Create(context, "rows", 1, 4, 4);
-            Assert.IsNotNull(rowDim);
+        var rowDim = Dimension.Create(context, "rows", 1, 4, 4);
+        Assert.IsNotNull(rowDim);
 
-            var colDim = Dimension.Create(context, "cols", 1, 4, 4);
-            Assert.IsNotNull(rowDim);
+        var colDim = Dimension.Create(context, "cols", 1, 4, 4);
+        Assert.IsNotNull(rowDim);
 
-            var domain = new Domain(context);
-            Assert.IsNotNull(domain);
+        var domain = new Domain(context);
+        Assert.IsNotNull(domain);
 
-            domain.AddDimensions(rowDim, colDim);
+        domain.AddDimensions(rowDim, colDim);
 
-            var array_schema = new ArraySchema(context, ArrayType.Sparse);
-            Assert.IsNotNull(array_schema);
-            var a1 = new Attribute(context, "a1", DataType.UInt32);
-            Assert.IsNotNull(a1);
+        var array_schema = new ArraySchema(context, ArrayType.Sparse);
+        Assert.IsNotNull(array_schema);
+        var a1 = new Attribute(context, "a1", DataType.UInt32);
+        Assert.IsNotNull(a1);
 
-            array_schema.SetCellOrder(LayoutType.RowMajor);
-            array_schema.SetTileOrder(LayoutType.RowMajor);
+        array_schema.SetCellOrder(LayoutType.RowMajor);
+        array_schema.SetTileOrder(LayoutType.RowMajor);
 
-            array_schema.AddAttribute(a1);
+        array_schema.AddAttribute(a1);
 
-            array_schema.SetDomain(domain);
+        array_schema.SetDomain(domain);
 
-            array_schema.Check();
+        array_schema.Check();
 
-            var array = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array);
+        var array = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array);
 
-            array.Create(array_schema);
-        }
+        array.Create(array_schema);
+    }
 
-        private void writeArrayMetadata(string tmpArrayPath)
-        {
-            var context = Context.GetDefault();
+    private void writeArrayMetadata(string tmpArrayPath)
+    {
+        var context = Context.GetDefault();
 
-            var array = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array);
+        var array = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array);
 
-            array.Open(QueryType.Write);
+        array.Open(QueryType.Write);
 
-            array.PutMetadata<int>("key1", [25]);
+        array.PutMetadata<int>("key1", [25]);
 
-            array.PutMetadata<int>("key2", [25, 26, 27, 28]);
+        array.PutMetadata<int>("key2", [25, 26, 27, 28]);
 
-            array.PutMetadata<float>("key3", [25.1f]);
+        array.PutMetadata<float>("key3", [25.1f]);
 
-            array.PutMetadata<float>("key4", [25.1f, 26.2f, 27.3f, 28.4f]);
+        array.PutMetadata<float>("key4", [25.1f, 26.2f, 27.3f, 28.4f]);
 
-            array.PutMetadata("key5", "This is TileDB array metadata, that supports Unicode characters! 🥳");
+        array.PutMetadata("key5", "This is TileDB array metadata, that supports Unicode characters! 🥳");
 
-            array.Close();
-        }
+        array.Close();
+    }
 
-        private void readArrayMetadata(string tmpArrayPath)
-        {
-            var context = Context.GetDefault();
+    private void readArrayMetadata(string tmpArrayPath)
+    {
+        var context = Context.GetDefault();
 
-            var array = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array);
+        var array = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array);
 
-            array.Open(QueryType.Read);
+        array.Open(QueryType.Read);
 
-            var v1 = array.GetMetadata<int>("key1");
-            CollectionAssert.AreEqual(new int[]{ 25 }, v1);
+        var v1 = array.GetMetadata<int>("key1");
+        CollectionAssert.AreEqual(new int[]{ 25 }, v1);
 
-            var v2 = array.GetMetadata<int>("key2");
-            CollectionAssert.AreEqual(new int[]{ 25, 26, 27, 28 }, v2);
+        var v2 = array.GetMetadata<int>("key2");
+        CollectionAssert.AreEqual(new int[]{ 25, 26, 27, 28 }, v2);
 
-            var v3 = array.GetMetadata<float>("key3");
-            CollectionAssert.AreEqual(new float[]{ 25.1f }, v3);
+        var v3 = array.GetMetadata<float>("key3");
+        CollectionAssert.AreEqual(new float[]{ 25.1f }, v3);
 
-            var v4 = array.GetMetadata<float>("key4");
-            CollectionAssert.AreEqual(new float[]{ 25.1f, 26.2f, 27.3f, 28.4f }, v4);
+        var v4 = array.GetMetadata<float>("key4");
+        CollectionAssert.AreEqual(new float[]{ 25.1f, 26.2f, 27.3f, 28.4f }, v4);
 
-            var s = array.GetMetadata("key5");
-            Assert.AreEqual("This is TileDB array metadata, that supports Unicode characters! 🥳", s);
+        var s = array.GetMetadata("key5");
+        Assert.AreEqual("This is TileDB array metadata, that supports Unicode characters! 🥳", s);
 
-            var num = array.MetadataNum();
-            Assert.AreEqual((ulong)5,  num);
+        var num = array.MetadataNum();
+        Assert.AreEqual((ulong)5,  num);
 
-            var keys = array.MetadataKeys();
-            CollectionAssert.AreEqual(new string[]{"key1", "key2", "key3", "key4", "key5"}, keys);
+        var keys = array.MetadataKeys();
+        CollectionAssert.AreEqual(new string[]{"key1", "key2", "key3", "key4", "key5"}, keys);
 
-            var arrayMetadata = array.GetMetadataFromIndex<float>(3);
-            Assert.AreEqual("key4",  arrayMetadata.key);
-            Assert.AreEqual(4,  arrayMetadata.key.Length);
+        var arrayMetadata = array.GetMetadataFromIndex<float>(3);
+        Assert.AreEqual("key4",  arrayMetadata.key);
+        Assert.AreEqual(4,  arrayMetadata.key.Length);
 
-            Assert.AreEqual(4,  arrayMetadata.data.Length);
+        Assert.AreEqual(4,  arrayMetadata.data.Length);
 
-            array.Close();
-        }
+        array.Close();
+    }
 
-        private void clearArrayMetadata(string tmpArrayPath)
-        {
-            var context = Context.GetDefault();
+    private void clearArrayMetadata(string tmpArrayPath)
+    {
+        var context = Context.GetDefault();
 
-            var array = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array);
+        var array = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array);
 
-            array.Open(QueryType.Write);
+        array.Open(QueryType.Write);
 
-            array.DeleteMetadata("key1");
-            array.DeleteMetadata("key2");
-            array.DeleteMetadata("key3");
-            array.DeleteMetadata("key4");
-            array.DeleteMetadata("key5");
-            array.Close();
-        }
+        array.DeleteMetadata("key1");
+        array.DeleteMetadata("key2");
+        array.DeleteMetadata("key3");
+        array.DeleteMetadata("key4");
+        array.DeleteMetadata("key5");
+        array.Close();
     }
 }

--- a/tests/TileDB.CSharp.Test/ArrayMetadataTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayMetadataTest.cs
@@ -66,13 +66,13 @@ namespace TileDB.CSharp.Test
 
             array.Open(QueryType.Write);
 
-            array.PutMetadata<int>("key1", new int[] { 25 });
+            array.PutMetadata<int>("key1", [25]);
 
-            array.PutMetadata<int>("key2", new int[] { 25, 26, 27, 28 });
+            array.PutMetadata<int>("key2", [25, 26, 27, 28]);
 
-            array.PutMetadata<float>("key3", new float[] { 25.1f });
+            array.PutMetadata<float>("key3", [25.1f]);
 
-            array.PutMetadata<float>("key4", new float[] { 25.1f, 26.2f, 27.3f, 28.4f });
+            array.PutMetadata<float>("key4", [25.1f, 26.2f, 27.3f, 28.4f]);
 
             array.PutMetadata("key5", "This is TileDB array metadata, that supports Unicode characters! 🥳");
 

--- a/tests/TileDB.CSharp.Test/ArraySchemaEvolutionTest.cs
+++ b/tests/TileDB.CSharp.Test/ArraySchemaEvolutionTest.cs
@@ -1,75 +1,74 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class ArraySchemaEvolutionTest
 {
-    [TestClass]
-    public class ArraySchemaEvolutionTest
+    private static readonly string ArrayUri = TestUtil.MakeTestPath("test-schema-evolution");
+
+    [TestInitialize]
+    public void CreateArray()
     {
-        private static readonly string ArrayUri = TestUtil.MakeTestPath("test-schema-evolution");
+        var ctx = Context.GetDefault();
 
-        [TestInitialize]
-        public void CreateArray()
-        {
-            var ctx = Context.GetDefault();
+        var rows = Dimension.Create(ctx, "rows", 1, 4, 4);
+        var cols = Dimension.Create(ctx, "cols", 1, 4, 4);
 
-            var rows = Dimension.Create(ctx, "rows", 1, 4, 4);
-            var cols = Dimension.Create(ctx, "cols", 1, 4, 4);
+        var domain = new Domain(ctx);
+        domain.AddDimensions(rows, cols);
 
-            var domain = new Domain(ctx);
-            domain.AddDimensions(rows, cols);
+        var schema = new ArraySchema(ctx, ArrayType.Dense);
+        schema.SetDomain(domain);
 
-            var schema = new ArraySchema(ctx, ArrayType.Dense);
-            schema.SetDomain(domain);
+        var nullableAttr = new Attribute(ctx, "a1", DataType.Int32);
+        nullableAttr.SetNullable(true);
+        schema.AddAttributes(nullableAttr, new Attribute(ctx, "a2", DataType.Int32),
+            new Attribute(ctx, "a3", DataType.Boolean));
+        schema.Check();
+        TestUtil.CreateArray(ctx, ArrayUri, schema);
+    }
 
-            var nullableAttr = new Attribute(ctx, "a1", DataType.Int32);
-            nullableAttr.SetNullable(true);
-            schema.AddAttributes(nullableAttr, new Attribute(ctx, "a2", DataType.Int32),
-                new Attribute(ctx, "a3", DataType.Boolean));
-            schema.Check();
-            TestUtil.CreateArray(ctx, ArrayUri, schema);
-        }
+    [TestMethod]
+    public void TestSchemaEvolution()
+    {
+        var ctx = Context.GetDefault();
+        var array = new Array(ctx, ArrayUri);
+        TestUtil.PrintLocalSchema(ArrayUri);
 
-        [TestMethod]
-        public void TestSchemaEvolution()
-        {
-            var ctx = Context.GetDefault();
-            var array = new Array(ctx, ArrayUri);
-            TestUtil.PrintLocalSchema(ArrayUri);
+        array.Open(QueryType.Read);
+        // Select existing attribute from schema to delete
+        var delAttr = array.Schema().Attributes()["a3"];
+        array.Close();
 
-            array.Open(QueryType.Read);
-            // Select existing attribute from schema to delete
-            var delAttr = array.Schema().Attributes()["a3"];
-            array.Close();
+        var schemaEvolution = new ArraySchemaEvolution(ctx);
 
-            var schemaEvolution = new ArraySchemaEvolution(ctx);
+        var addAttr = new Attribute(ctx, "a4", DataType.Float32);
+        schemaEvolution.AddAttribute(addAttr);
+        schemaEvolution.DropAttribute("a2");
+        schemaEvolution.DropAttribute(delAttr);
+        Console.WriteLine("Removing attributes `a2`, `a3`; Adding new attribute `a4`");
+        schemaEvolution.EvolveArray(ArrayUri);
 
-            var addAttr = new Attribute(ctx, "a4", DataType.Float32);
-            schemaEvolution.AddAttribute(addAttr);
-            schemaEvolution.DropAttribute("a2");
-            schemaEvolution.DropAttribute(delAttr);
-            Console.WriteLine("Removing attributes `a2`, `a3`; Adding new attribute `a4`");
-            schemaEvolution.EvolveArray(ArrayUri);
+        array.Open(QueryType.Read);
+        var schema = array.Schema();
+        TestUtil.PrintLocalSchema(ArrayUri);
+        Assert.IsTrue(schema.HasAttribute("a1"));
+        Assert.IsFalse(schema.HasAttribute("a2"));
+        Assert.IsFalse(schema.HasAttribute("a3"));
+        Assert.IsTrue(schema.HasAttribute("a4"));
+        array.Close();
 
-            array.Open(QueryType.Read);
-            var schema = array.Schema();
-            TestUtil.PrintLocalSchema(ArrayUri);
-            Assert.IsTrue(schema.HasAttribute("a1"));
-            Assert.IsFalse(schema.HasAttribute("a2"));
-            Assert.IsFalse(schema.HasAttribute("a3"));
-            Assert.IsTrue(schema.HasAttribute("a4"));
-            array.Close();
+        schemaEvolution = new ArraySchemaEvolution(ctx);
+        schemaEvolution.DropAttribute("a1");
+        Console.WriteLine("Removing attribute `a1` using Array.Evolve");
+        array.Evolve(schemaEvolution);
 
-            schemaEvolution = new ArraySchemaEvolution(ctx);
-            schemaEvolution.DropAttribute("a1");
-            Console.WriteLine("Removing attribute `a1` using Array.Evolve");
-            array.Evolve(schemaEvolution);
-
-            array.Open(QueryType.Read);
-            schema = array.Schema();
-            Assert.IsFalse(schema.HasAttribute("a1"));
-            TestUtil.PrintLocalSchema(ArrayUri);
-            array.Close();
-        }
+        array.Open(QueryType.Read);
+        schema = array.Schema();
+        Assert.IsFalse(schema.HasAttribute("a1"));
+        TestUtil.PrintLocalSchema(ArrayUri);
+        array.Close();
     }
 }

--- a/tests/TileDB.CSharp.Test/ArraySchemaTest.cs
+++ b/tests/TileDB.CSharp.Test/ArraySchemaTest.cs
@@ -1,8 +1,8 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
-{
+namespace TileDB.CSharp.Test;
+
 	[TestClass]
 	public class ArraySchemaTest
 	{
@@ -68,24 +68,24 @@ namespace TileDB.CSharp.Test
 			var filter0 = filter_list_return.Filter(0);
 			Assert.AreEqual(FilterType.Bzip2, filter0.FilterType());
 
-            array_schema.SetOffsetsFilterList(filter_list);
-            filter_list_return = array_schema.OffsetsFilterList();
+        array_schema.SetOffsetsFilterList(filter_list);
+        filter_list_return = array_schema.OffsetsFilterList();
 
-            filter0 = filter_list_return.Filter(0);
-            Assert.AreEqual(FilterType.Bzip2, filter0.FilterType());
+        filter0 = filter_list_return.Filter(0);
+        Assert.AreEqual(FilterType.Bzip2, filter0.FilterType());
 
-            array_schema.SetValidityFilterList(filter_list);
-            filter_list_return = array_schema.ValidityFilterList();
+        array_schema.SetValidityFilterList(filter_list);
+        filter_list_return = array_schema.ValidityFilterList();
 
-            filter0 = filter_list_return.Filter(0);
-            Assert.AreEqual(FilterType.Bzip2, filter0.FilterType());
+        filter0 = filter_list_return.Filter(0);
+        Assert.AreEqual(FilterType.Bzip2, filter0.FilterType());
 
-            array_schema.Check();
+        array_schema.Check();
 		}
 
 		[TestMethod]
 		public void TestArraySchemaInt32Simple()
-        {
+    {
 			var context = Context.GetDefault();
 			var domain = new Domain(context);
 			Assert.IsNotNull(domain);
@@ -274,4 +274,3 @@ namespace TileDB.CSharp.Test
 			array_schema.Check();			
 		}
 	}
-}

--- a/tests/TileDB.CSharp.Test/ArrayTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayTest.cs
@@ -141,7 +141,7 @@ namespace TileDB.CSharp.Test
 
             int[] a1Data = Enumerable.Range(1, 10).Select(x => x * x).ToArray();
             byte[] a2Data = "aabbcccdeffggghhhhijj"u8.ToArray();
-            ulong[] a2Offsets = { 0, 2, 4, 7, 8, 9, 11, 14, 17, 18 };
+            ulong[] a2Offsets = [0, 2, 4, 7, 8, 9, 11, 14, 17, 18];
             for (uint i = 0; i < FragmentCount; i++)
             {
                 using var array = new Array(context, uri);

--- a/tests/TileDB.CSharp.Test/ArrayTest.cs
+++ b/tests/TileDB.CSharp.Test/ArrayTest.cs
@@ -3,233 +3,232 @@ using System.IO;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class ArrayTest
 {
-    [TestClass]
-    public class ArrayTest
+    [TestMethod]
+    public void TestDenseArray()
     {
-        [TestMethod]
-        public void TestDenseArray()
+        var context = Context.GetDefault();
+
+        var tmpArrayPath = TestUtil.MakeTestPath("dense_array_test");
+
+        if (Directory.Exists(tmpArrayPath))
         {
-            var context = Context.GetDefault();
-
-            var tmpArrayPath = TestUtil.MakeTestPath("dense_array_test");
-
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
-
-            var array = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array);
-
-            var array_schema = BuildDenseArraySchema(context);
-            Assert.IsNotNull(array_schema);
-
-            array.Create(array_schema);
-
-            Assert.AreEqual(("file://" + tmpArrayPath).Replace('\\', '/').Replace("///","//"), array.Uri().Replace("///","//"));
-
-            array.Open(QueryType.Read);
-
-            array.Reopen();
-
-            array.Close();
-
-            var unixTimestamp = (int)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
-            array.SetOpenTimestampStart((ulong)(unixTimestamp / 1000000));
-
-            array.Open(QueryType.Read);
-
-            array_schema = array.Schema();
-            Assert.IsNotNull(array_schema);
-
-            Assert.AreEqual(LayoutType.RowMajor, array_schema.TileOrder());
-
-            Assert.AreEqual(QueryType.Read, array.QueryType());
-
-            (_, _, bool isEmpty) = array.NonEmptyDomain<short>("dim1");
-            Assert.IsTrue(isEmpty);
-
-            (_, _, isEmpty) = array.NonEmptyDomain<short>(0);
-            Assert.IsTrue(isEmpty);
-
-            array.Close();
-
-            var array_schema_loaded = Array.LoadArraySchema(context, tmpArrayPath);
-            Assert.IsNotNull(array_schema_loaded);
+            Directory.Delete(tmpArrayPath, true);
         }
 
-        [TestMethod]
-        public void TestSparseArray()
+        var array = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array);
+
+        var array_schema = BuildDenseArraySchema(context);
+        Assert.IsNotNull(array_schema);
+
+        array.Create(array_schema);
+
+        Assert.AreEqual(("file://" + tmpArrayPath).Replace('\\', '/').Replace("///","//"), array.Uri().Replace("///","//"));
+
+        array.Open(QueryType.Read);
+
+        array.Reopen();
+
+        array.Close();
+
+        var unixTimestamp = (int)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+        array.SetOpenTimestampStart((ulong)(unixTimestamp / 1000000));
+
+        array.Open(QueryType.Read);
+
+        array_schema = array.Schema();
+        Assert.IsNotNull(array_schema);
+
+        Assert.AreEqual(LayoutType.RowMajor, array_schema.TileOrder());
+
+        Assert.AreEqual(QueryType.Read, array.QueryType());
+
+        (_, _, bool isEmpty) = array.NonEmptyDomain<short>("dim1");
+        Assert.IsTrue(isEmpty);
+
+        (_, _, isEmpty) = array.NonEmptyDomain<short>(0);
+        Assert.IsTrue(isEmpty);
+
+        array.Close();
+
+        var array_schema_loaded = Array.LoadArraySchema(context, tmpArrayPath);
+        Assert.IsNotNull(array_schema_loaded);
+    }
+
+    [TestMethod]
+    public void TestSparseArray()
+    {
+        var context = Context.GetDefault();
+
+        var tmpArrayPath = TestUtil.MakeTestPath("sparse_array_test");
+
+        if (Directory.Exists(tmpArrayPath))
         {
-            var context = Context.GetDefault();
-
-            var tmpArrayPath = TestUtil.MakeTestPath("sparse_array_test");
-
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
-
-            var array = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array);
-
-            var array_schema = BuildSparseArraySchema(context);
-            Assert.IsNotNull(array_schema);
-
-            array.Create(array_schema);
-
-            Assert.AreEqual(("file://" + tmpArrayPath).Replace('\\','/').Replace("///","//"), array.Uri().Replace("///","//"));
-
-            array.Open(QueryType.Read);
-
-            array.Reopen();
-
-            array.Close();
-
-            var unixTimestamp = (int)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
-            array.SetOpenTimestampStart((ulong)(unixTimestamp / 1000000));
-
-            array.Open(QueryType.Read);
-
-            array_schema = array.Schema();
-            Assert.IsNotNull(array_schema);
-
-            Assert.AreEqual(LayoutType.RowMajor, array_schema.TileOrder());
-
-            Assert.AreEqual(QueryType.Read, array.QueryType());
-
-            (_, _, bool isEmpty) = array.NonEmptyDomain<short>("dim1");
-            Assert.IsTrue(isEmpty);
-
-            (_, _, isEmpty) = array.NonEmptyDomain<short>(0);
-            Assert.IsTrue(isEmpty);
-
-            Assert.ThrowsException<ArgumentException>(()=>array.NonEmptyDomain<short>("dim2"));
-            Assert.ThrowsException<ArgumentException>(()=>array.NonEmptyDomain<short>(1));
-
-            (_, _, isEmpty) = array.NonEmptyDomain<float>("dim2");
-            Assert.IsTrue(isEmpty);
-
-            (_, _, isEmpty) = array.NonEmptyDomain<float>(1);
-            Assert.IsTrue(isEmpty);
-
-            (_, isEmpty) = array.NonEmptyDomain();
-            Assert.IsTrue(isEmpty);
-
-            array.Close();
-
-            var array_schema_loaded = Array.LoadArraySchema(context, tmpArrayPath);
-            Assert.IsNotNull(array_schema_loaded);
+            Directory.Delete(tmpArrayPath, true);
         }
 
-        [TestMethod]
-        public void TestConsolidateFragments()
+        var array = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array);
+
+        var array_schema = BuildSparseArraySchema(context);
+        Assert.IsNotNull(array_schema);
+
+        array.Create(array_schema);
+
+        Assert.AreEqual(("file://" + tmpArrayPath).Replace('\\','/').Replace("///","//"), array.Uri().Replace("///","//"));
+
+        array.Open(QueryType.Read);
+
+        array.Reopen();
+
+        array.Close();
+
+        var unixTimestamp = (int)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+        array.SetOpenTimestampStart((ulong)(unixTimestamp / 1000000));
+
+        array.Open(QueryType.Read);
+
+        array_schema = array.Schema();
+        Assert.IsNotNull(array_schema);
+
+        Assert.AreEqual(LayoutType.RowMajor, array_schema.TileOrder());
+
+        Assert.AreEqual(QueryType.Read, array.QueryType());
+
+        (_, _, bool isEmpty) = array.NonEmptyDomain<short>("dim1");
+        Assert.IsTrue(isEmpty);
+
+        (_, _, isEmpty) = array.NonEmptyDomain<short>(0);
+        Assert.IsTrue(isEmpty);
+
+        Assert.ThrowsException<ArgumentException>(()=>array.NonEmptyDomain<short>("dim2"));
+        Assert.ThrowsException<ArgumentException>(()=>array.NonEmptyDomain<short>(1));
+
+        (_, _, isEmpty) = array.NonEmptyDomain<float>("dim2");
+        Assert.IsTrue(isEmpty);
+
+        (_, _, isEmpty) = array.NonEmptyDomain<float>(1);
+        Assert.IsTrue(isEmpty);
+
+        (_, isEmpty) = array.NonEmptyDomain();
+        Assert.IsTrue(isEmpty);
+
+        array.Close();
+
+        var array_schema_loaded = Array.LoadArraySchema(context, tmpArrayPath);
+        Assert.IsNotNull(array_schema_loaded);
+    }
+
+    [TestMethod]
+    public void TestConsolidateFragments()
+    {
+        const uint FragmentCount = 10;
+
+        var context = Context.GetDefault();
+
+        using var uri = new TemporaryDirectory("array_consolidate_fragments");
+
+        using (var schema = BuildDenseArraySchema(context))
+        using (var array = new Array(context, uri))
         {
-            const uint FragmentCount = 10;
-
-            var context = Context.GetDefault();
-
-            using var uri = new TemporaryDirectory("array_consolidate_fragments");
-
-            using (var schema = BuildDenseArraySchema(context))
-            using (var array = new Array(context, uri))
-            {
-                array.Create(schema);
-            }
-
-            int[] a1Data = Enumerable.Range(1, 10).Select(x => x * x).ToArray();
-            byte[] a2Data = "aabbcccdeffggghhhhijj"u8.ToArray();
-            ulong[] a2Offsets = [0, 2, 4, 7, 8, 9, 11, 14, 17, 18];
-            for (uint i = 0; i < FragmentCount; i++)
-            {
-                using var array = new Array(context, uri);
-                array.Open(QueryType.Write);
-
-                using var query = new Query(array, QueryType.Write);
-                query.SetDataBuffer("a1", a1Data);
-                query.SetDataBuffer("a2", a2Data);
-                query.SetOffsetsBuffer("a2", a2Offsets);
-
-                query.Submit();
-            }
-
-            using var fragmentInfo = new FragmentInfo(context, uri);
-            fragmentInfo.Load();
-
-            Assert.AreEqual(FragmentCount, fragmentInfo.FragmentCount);
-
-            string[] fragments = Enumerable.Range(0, (int)FragmentCount).Select(x => fragmentInfo.GetFragmentName((uint)x)).ToArray();
-
-            Array.ConsolidateFragments(context, uri, fragments);
-
-            fragmentInfo.Load();
-
-            Assert.AreEqual(1u, fragmentInfo.FragmentCount);
-            Assert.AreEqual(FragmentCount, fragmentInfo.FragmentToVacuumCount);
+            array.Create(schema);
         }
 
-        private ArraySchema BuildDenseArraySchema(Context context)
+        int[] a1Data = Enumerable.Range(1, 10).Select(x => x * x).ToArray();
+        byte[] a2Data = "aabbcccdeffggghhhhijj"u8.ToArray();
+        ulong[] a2Offsets = [0, 2, 4, 7, 8, 9, 11, 14, 17, 18];
+        for (uint i = 0; i < FragmentCount; i++)
         {
-            var dimension = Dimension.Create<short>(context, "dim1", 1, 10, 5);
-            Assert.IsNotNull(dimension);
-            var domain = new Domain(context);
-            Assert.IsNotNull(domain);
+            using var array = new Array(context, uri);
+            array.Open(QueryType.Write);
 
-            domain.AddDimension(dimension);
+            using var query = new Query(array, QueryType.Write);
+            query.SetDataBuffer("a1", a1Data);
+            query.SetDataBuffer("a2", a2Data);
+            query.SetOffsetsBuffer("a2", a2Offsets);
 
-            var array_schema = new ArraySchema(context, ArrayType.Dense);
-            Assert.IsNotNull(array_schema);
-
-            var a1 = new Attribute(context, "a1", DataType.Int32);
-            Assert.IsNotNull(a1);
-
-            var a2 = new Attribute(context, "a2", DataType.StringAscii);
-            Assert.IsNotNull(a2);
-
-            a2.SetCellValNum(Attribute.VariableSized);
-
-            array_schema.AddAttributes(a1, a2);
-
-            array_schema.SetDomain(domain);
-
-            array_schema.Check();
-
-            return array_schema;
+            query.Submit();
         }
 
-        private ArraySchema BuildSparseArraySchema(Context context)
-        {
-            var dim1 = Dimension.Create<short>(context, "dim1", 1, 10, 5);
-            Assert.IsNotNull(dim1);
+        using var fragmentInfo = new FragmentInfo(context, uri);
+        fragmentInfo.Load();
 
-            var dim2 = Dimension.Create(context, "dim2", 1.0f, 4.0f, 0.5f);
-            Assert.IsNotNull(dim2);
+        Assert.AreEqual(FragmentCount, fragmentInfo.FragmentCount);
 
-            var domain = new Domain(context);
-            Assert.IsNotNull(domain);
+        string[] fragments = Enumerable.Range(0, (int)FragmentCount).Select(x => fragmentInfo.GetFragmentName((uint)x)).ToArray();
 
-            domain.AddDimensions(dim1, dim2);
+        Array.ConsolidateFragments(context, uri, fragments);
 
-            var array_schema = new ArraySchema(context, ArrayType.Sparse);
-            Assert.IsNotNull(array_schema);
+        fragmentInfo.Load();
 
-            var a1 = new Attribute(context, "a1", DataType.Int32);
-            Assert.IsNotNull(a1);
+        Assert.AreEqual(1u, fragmentInfo.FragmentCount);
+        Assert.AreEqual(FragmentCount, fragmentInfo.FragmentToVacuumCount);
+    }
 
-            var a2 = new Attribute(context, "a2", DataType.StringAscii);
-            Assert.IsNotNull(a2);
+    private ArraySchema BuildDenseArraySchema(Context context)
+    {
+        var dimension = Dimension.Create<short>(context, "dim1", 1, 10, 5);
+        Assert.IsNotNull(dimension);
+        var domain = new Domain(context);
+        Assert.IsNotNull(domain);
 
-            a2.SetCellValNum(Attribute.VariableSized);
+        domain.AddDimension(dimension);
 
-            array_schema.AddAttributes(a1, a2);
+        var array_schema = new ArraySchema(context, ArrayType.Dense);
+        Assert.IsNotNull(array_schema);
 
-            array_schema.SetDomain(domain);
+        var a1 = new Attribute(context, "a1", DataType.Int32);
+        Assert.IsNotNull(a1);
 
-            array_schema.Check();
+        var a2 = new Attribute(context, "a2", DataType.StringAscii);
+        Assert.IsNotNull(a2);
 
-            return array_schema;
-        }
+        a2.SetCellValNum(Attribute.VariableSized);
+
+        array_schema.AddAttributes(a1, a2);
+
+        array_schema.SetDomain(domain);
+
+        array_schema.Check();
+
+        return array_schema;
+    }
+
+    private ArraySchema BuildSparseArraySchema(Context context)
+    {
+        var dim1 = Dimension.Create<short>(context, "dim1", 1, 10, 5);
+        Assert.IsNotNull(dim1);
+
+        var dim2 = Dimension.Create(context, "dim2", 1.0f, 4.0f, 0.5f);
+        Assert.IsNotNull(dim2);
+
+        var domain = new Domain(context);
+        Assert.IsNotNull(domain);
+
+        domain.AddDimensions(dim1, dim2);
+
+        var array_schema = new ArraySchema(context, ArrayType.Sparse);
+        Assert.IsNotNull(array_schema);
+
+        var a1 = new Attribute(context, "a1", DataType.Int32);
+        Assert.IsNotNull(a1);
+
+        var a2 = new Attribute(context, "a2", DataType.StringAscii);
+        Assert.IsNotNull(a2);
+
+        a2.SetCellValNum(Attribute.VariableSized);
+
+        array_schema.AddAttributes(a1, a2);
+
+        array_schema.SetDomain(domain);
+
+        array_schema.Check();
+
+        return array_schema;
     }
 }

--- a/tests/TileDB.CSharp.Test/AttributeTest.cs
+++ b/tests/TileDB.CSharp.Test/AttributeTest.cs
@@ -1,276 +1,275 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class AttributeTest
 {
-    [TestClass]
-    public class AttributeTest
+    [TestMethod]
+    public void FillValue()
     {
-        [TestMethod]
-        public void FillValue()
+        var ctx = Context.GetDefault();
+        var attr = new Attribute(ctx, "a", DataType.Int32);
+        var fill_value = 100;
+        attr.SetFillValue(fill_value);
+        var value_size = attr.FillValue<int>();
+        Assert.AreEqual(fill_value, value_size[0]);
+    }
+
+    [TestMethod]
+    public void TestFullAttribute()
+    {
+        var context = Context.GetDefault();
+
+        const string attrName = "a";
+        using var attribute =  new Attribute(context, attrName, DataType.Int32);
+        Assert.AreEqual(attrName, attribute.Name());
+        Assert.AreEqual(DataType.Int32, attribute.Type());
+
+        // Set and get compressor
+        var gzipFilter = new Filter(context, FilterType.Gzip);
+        gzipFilter.SetOption(FilterOption.CompressionLevel, 5);
+        var filter_list = new FilterList(context);
+        filter_list.AddFilter(gzipFilter);
+        attribute.SetFilterList(filter_list);
+
+        var filterListReturn = attribute.FilterList();
+        Assert.AreEqual(filter_list.NFilters(), filterListReturn.NFilters());
+        var filterReturn = filterListReturn.Filter(0);
+        var filterTypeReturn = filterReturn.FilterType();
+        Assert.AreEqual(FilterType.Gzip, filterTypeReturn);
+        var filterOption = gzipFilter.GetOption<int>(FilterOption.CompressionLevel);
+        Assert.AreEqual(5, filterOption);
+
+        attribute.SetCellValNum(10);
+        var cell_size = attribute.CellSize();
+        Assert.AreEqual<ulong>(40, cell_size);
+
+        var cell_val_num = attribute.CellValNum();
+        Assert.AreEqual<ulong>(10, cell_val_num);
+
+        attribute.SetFillValue(12);
+        var value_size = attribute.FillValue<int>();
+        Assert.AreEqual(12, value_size[0]);
+    }
+
+    [TestMethod]
+    public void TestNullableAttribute()
+    {
+        var context = Context.GetDefault();
+
+        const string attrName = "a";
+        using var attribute = new Attribute(context, attrName, DataType.Int32);
+        Assert.AreEqual(attrName, attribute.Name());
+
+        attribute.SetNullable(true);
+
+        Assert.AreEqual(true, attribute.Nullable());
+        Assert.AreEqual(DataType.Int32, attribute.Type());
+
+        // Set and get compressor
+        var gzipFilter = new Filter(context, FilterType.Gzip);
+        gzipFilter.SetOption( FilterOption.CompressionLevel, 5);
+        var filter_list = new FilterList(context);
+        filter_list.AddFilter(gzipFilter);
+        attribute.SetFilterList(filter_list);
+
+        var filterListReturn = attribute.FilterList();
+        Assert.AreEqual(filter_list.NFilters(), filterListReturn.NFilters());
+        var filterReturn = filterListReturn.Filter(0);
+        var filterTypeReturn = filterReturn.FilterType();
+        Assert.AreEqual(FilterType.Gzip, filterTypeReturn);
+        var filterOption = gzipFilter.GetOption<int>(FilterOption.CompressionLevel);
+        Assert.AreEqual(5, filterOption);
+
+        attribute.SetCellValNum(10);
+        var cell_size = attribute.CellSize();
+        Assert.AreEqual<ulong>(40, cell_size);
+
+        var cell_val_num = attribute.CellValNum();
+        Assert.AreEqual<ulong>(10, cell_val_num);
+
+        attribute.SetFillValueNullable(12, true);
+        var fill_value = attribute.FillValueNullable<int>();
+        Assert.AreEqual(12, fill_value.Item1[0]);
+        Assert.AreEqual(true, fill_value.Item2);
+    }
+
+    [TestMethod]
+    public void TestStringAttribute()
+    {
+        var context = Context.GetDefault();
+
+        const string attrName = "a";
+        using var attribute = new Attribute(context, attrName, DataType.StringAscii);
+        Assert.AreEqual(attrName, attribute.Name());
+        Assert.AreEqual(DataType.StringAscii, attribute.Type());
+
+        attribute.SetFillValue("test_fill");
+        var fill_value = attribute.FillValue();
+        Assert.AreEqual("test_fill", fill_value);
+    }//TestStringAttribute
+
+    [TestMethod]
+    public void TestBoolAttribute()
+    {
+        var context = Context.GetDefault();
+
+        const string attrName = "a";
+        using var attribute = new Attribute(context, attrName, DataType.Boolean);
+        Assert.AreEqual(attrName, attribute.Name());
+        Assert.AreEqual(DataType.Boolean, attribute.Type());
+
+        bool fill_value = true;
+        attribute.SetFillValue(fill_value);
+        var value_size = attribute.FillValue<bool>();
+        Assert.AreEqual(true, value_size[0]);
+    }
+
+    [TestMethod]
+    public void TestInt32Attribute()
+    {
+        var context = Context.GetDefault();
+
+        const string attrName = "a";
+        using var attribute = new Attribute(context, attrName, DataType.Int32);
+        Assert.AreEqual(attrName, attribute.Name());
+        Assert.AreEqual(DataType.Int32, attribute.Type());
+
+        int fill_value = 184;
+        attribute.SetFillValue(fill_value);
+        var value_size = attribute.FillValue<int>();
+        Assert.AreEqual(184, value_size[0]);
+    }
+
+    [TestMethod]
+    public void TestVarLengthAttribute()
+    {
+        createVarLengthAttributeArray();
+        writeVarLengthAttributeArray();
+        readVarLengthAttributeArray();
+    }
+
+    private void createVarLengthAttributeArray()
+    {
+        var tmpArrayPath = TestUtil.MakeTestPath("varlength_attributes_array");
+        if (Directory.Exists(tmpArrayPath))
         {
-            var ctx = Context.GetDefault();
-            var attr = new Attribute(ctx, "a", DataType.Int32);
-            var fill_value = 100;
-            attr.SetFillValue(fill_value);
-            var value_size = attr.FillValue<int>();
-            Assert.AreEqual(fill_value, value_size[0]);
+            Directory.Delete(tmpArrayPath, true);
         }
 
-        [TestMethod]
-        public void TestFullAttribute()
-        {
-            var context = Context.GetDefault();
+        var context = Context.GetDefault();
+        var domain = new Domain(context);
+        Assert.IsNotNull(domain);
 
-            const string attrName = "a";
-            using var attribute =  new Attribute(context, attrName, DataType.Int32);
-            Assert.AreEqual(attrName, attribute.Name());
-            Assert.AreEqual(DataType.Int32, attribute.Type());
+        var dim_rows = Dimension.Create(context, "rows", 1, 4, 4);
+        Assert.IsNotNull(dim_rows);
+        domain.AddDimension(dim_rows);
 
-            // Set and get compressor
-            var gzipFilter = new Filter(context, FilterType.Gzip);
-            gzipFilter.SetOption(FilterOption.CompressionLevel, 5);
-            var filter_list = new FilterList(context);
-            filter_list.AddFilter(gzipFilter);
-            attribute.SetFilterList(filter_list);
+        var dim_cols = Dimension.Create(context, "cols", 1, 4, 4);
+        Assert.IsNotNull(dim_cols);
+        domain.AddDimension(dim_cols);
 
-            var filterListReturn = attribute.FilterList();
-            Assert.AreEqual(filter_list.NFilters(), filterListReturn.NFilters());
-            var filterReturn = filterListReturn.Filter(0);
-            var filterTypeReturn = filterReturn.FilterType();
-            Assert.AreEqual(FilterType.Gzip, filterTypeReturn);
-            var filterOption = gzipFilter.GetOption<int>(FilterOption.CompressionLevel);
-            Assert.AreEqual(5, filterOption);
+        var array_schema = new ArraySchema(context, ArrayType.Dense);
+        Assert.IsNotNull(array_schema);
 
-            attribute.SetCellValNum(10);
-            var cell_size = attribute.CellSize();
-            Assert.AreEqual<ulong>(40, cell_size);
+        var attr1 = new Attribute(context, "a1", DataType.StringAscii);
+        Assert.IsNotNull(attr1);
+        attr1.SetCellValNum(Attribute.VariableSized);
+        array_schema.AddAttribute(attr1);
 
-            var cell_val_num = attribute.CellValNum();
-            Assert.AreEqual<ulong>(10, cell_val_num);
+        var attr2 = new Attribute(context, "a2", DataType.Int32);
+        Assert.IsNotNull(attr2);
+        attr2.SetCellValNum(Attribute.VariableSized);
+        array_schema.AddAttribute(attr2);
 
-            attribute.SetFillValue(12);
-            var value_size = attribute.FillValue<int>();
-            Assert.AreEqual(12, value_size[0]);
-        }
+        array_schema.SetDomain(domain);
+        array_schema.SetCellOrder(LayoutType.RowMajor);
+        array_schema.SetTileOrder(LayoutType.RowMajor);
 
-        [TestMethod]
-        public void TestNullableAttribute()
-        {
-            var context = Context.GetDefault();
+        array_schema.Check();
 
-            const string attrName = "a";
-            using var attribute = new Attribute(context, attrName, DataType.Int32);
-            Assert.AreEqual(attrName, attribute.Name());
+        Array.Create(context, tmpArrayPath, array_schema);
+    }
 
-            attribute.SetNullable(true);
+    private void writeVarLengthAttributeArray()
+    {
+        var tmpArrayPath = TestUtil.MakeTestPath("varlength_attributes_array");
+        var context = Context.GetDefault();
+        var array_write = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array_write);
 
-            Assert.AreEqual(true, attribute.Nullable());
-            Assert.AreEqual(DataType.Int32, attribute.Type());
+        array_write.Open(QueryType.Write);
 
-            // Set and get compressor
-            var gzipFilter = new Filter(context, FilterType.Gzip);
-            gzipFilter.SetOption( FilterOption.CompressionLevel, 5);
-            var filter_list = new FilterList(context);
-            filter_list.AddFilter(gzipFilter);
-            attribute.SetFilterList(filter_list);
+        string[] a1_str = [ "a","b","c","d", "aa","bb","cc","dd"
+            ,"aaa","bbb","ccc","ddd","aaaa","bbbb","cccc","dddd" ];
+        var (a1_data, a1_offsets) = CoreUtil.PackStringArray(a1_str);
 
-            var filterListReturn = attribute.FilterList();
-            Assert.AreEqual(filter_list.NFilters(), filterListReturn.NFilters());
-            var filterReturn = filterListReturn.Filter(0);
-            var filterTypeReturn = filterReturn.FilterType();
-            Assert.AreEqual(FilterType.Gzip, filterTypeReturn);
-            var filterOption = gzipFilter.GetOption<int>(FilterOption.CompressionLevel);
-            Assert.AreEqual(5, filterOption);
+        int[] a2_data = [1, 1, 2, 2,  3,  4,  5,  6,  6,  7,  7,  8,  8,
+                          8, 9, 9, 10, 11, 12, 12, 13, 14, 14, 14, 15, 16 ];
+        ulong[] a2_el_off = [0, 2, 4, 5, 6, 7, 9, 11, 14, 16, 17, 18, 20, 21, 24, 25];
+        ulong[] a2_off = CoreUtil.ElementOffsetsToByteOffsets(a2_el_off, DataType.Int32);
 
-            attribute.SetCellValNum(10);
-            var cell_size = attribute.CellSize();
-            Assert.AreEqual<ulong>(40, cell_size);
+        var query_write = new Query(array_write);
+        query_write.SetLayout(LayoutType.RowMajor);
+        // using var subarray = new Subarray(array_write);
+        // subarray.SetSubarray(new int[] { 1, 4, 4, 4 });
 
-            var cell_val_num = attribute.CellValNum();
-            Assert.AreEqual<ulong>(10, cell_val_num);
+        query_write.SetDataBuffer("a1", a1_data);
+        query_write.SetOffsetsBuffer("a1", a1_offsets);
 
-            attribute.SetFillValueNullable(12, true);
-            var fill_value = attribute.FillValueNullable<int>();
-            Assert.AreEqual(12, fill_value.Item1[0]);
-            Assert.AreEqual(true, fill_value.Item2);
-        }
+        query_write.SetDataBuffer("a2", a2_data);
+        query_write.SetOffsetsBuffer("a2", a2_off);
 
-        [TestMethod]
-        public void TestStringAttribute()
-        {
-            var context = Context.GetDefault();
+        query_write.Submit();
 
-            const string attrName = "a";
-            using var attribute = new Attribute(context, attrName, DataType.StringAscii);
-            Assert.AreEqual(attrName, attribute.Name());
-            Assert.AreEqual(DataType.StringAscii, attribute.Type());
+        var status_write = query_write.Status();
+        Assert.AreEqual(QueryStatus.Completed, status_write);
+        query_write.FinalizeQuery();
 
-            attribute.SetFillValue("test_fill");
-            var fill_value = attribute.FillValue();
-            Assert.AreEqual("test_fill", fill_value);
-        }//TestStringAttribute
+        array_write.Close();
+    }
 
-        [TestMethod]
-        public void TestBoolAttribute()
-        {
-            var context = Context.GetDefault();
+    private void readVarLengthAttributeArray()
+    {
+        var tmpArrayPath = TestUtil.MakeTestPath("varlength_attributes_array");
+        var context = Context.GetDefault();
+        var array_read = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array_read);
+        array_read.Open(QueryType.Read);
 
-            const string attrName = "a";
-            using var attribute = new Attribute(context, attrName, DataType.Boolean);
-            Assert.AreEqual(attrName, attribute.Name());
-            Assert.AreEqual(DataType.Boolean, attribute.Type());
+        var query_read = new Query(array_read);
 
-            bool fill_value = true;
-            attribute.SetFillValue(fill_value);
-            var value_size = attribute.FillValue<bool>();
-            Assert.AreEqual(true, value_size[0]);
-        }
+        // Slice only rows 1,2 and cols 2,3,4
+        using var subarray = new Subarray(array_read);
+        subarray.SetSubarray(1, 4, 1, 4);
+        query_read.SetSubarray(subarray);
 
-        [TestMethod]
-        public void TestInt32Attribute()
-        {
-            var context = Context.GetDefault();
+        query_read.SetLayout(LayoutType.RowMajor);
 
-            const string attrName = "a";
-            using var attribute = new Attribute(context, attrName, DataType.Int32);
-            Assert.AreEqual(attrName, attribute.Name());
-            Assert.AreEqual(DataType.Int32, attribute.Type());
+        byte[] a1_data_buffer_read = new byte[128];
+        ulong[] a1_offsets_buffer_read = new ulong[128];
 
-            int fill_value = 184;
-            attribute.SetFillValue(fill_value);
-            var value_size = attribute.FillValue<int>();
-            Assert.AreEqual(184, value_size[0]);
-        }
+        int[] a2_data_buffer_read = new int[128];
+        ulong[] a2_offsets_buffer_read = new ulong[128];
 
-        [TestMethod]
-        public void TestVarLengthAttribute()
-        {
-            createVarLengthAttributeArray();
-            writeVarLengthAttributeArray();
-            readVarLengthAttributeArray();
-        }
+        query_read.SetDataBuffer("a1", a1_data_buffer_read);
+        query_read.SetOffsetsBuffer("a1", a1_offsets_buffer_read);
+        query_read.SetDataBuffer("a2", a2_data_buffer_read);
+        query_read.SetOffsetsBuffer("a2", a2_offsets_buffer_read);
 
-        private void createVarLengthAttributeArray()
-        {
-            var tmpArrayPath = TestUtil.MakeTestPath("varlength_attributes_array");
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
+        query_read.Submit();
+        var status_read = query_read.Status();
+        Assert.AreEqual(QueryStatus.Completed, status_read);
 
-            var context = Context.GetDefault();
-            var domain = new Domain(context);
-            Assert.IsNotNull(domain);
+        var result_size_a1 = query_read.EstResultSize("a1");
+        var result_size_a2 = query_read.EstResultSize("a2");
 
-            var dim_rows = Dimension.Create(context, "rows", 1, 4, 4);
-            Assert.IsNotNull(dim_rows);
-            domain.AddDimension(dim_rows);
-
-            var dim_cols = Dimension.Create(context, "cols", 1, 4, 4);
-            Assert.IsNotNull(dim_cols);
-            domain.AddDimension(dim_cols);
-
-            var array_schema = new ArraySchema(context, ArrayType.Dense);
-            Assert.IsNotNull(array_schema);
-
-            var attr1 = new Attribute(context, "a1", DataType.StringAscii);
-            Assert.IsNotNull(attr1);
-            attr1.SetCellValNum(Attribute.VariableSized);
-            array_schema.AddAttribute(attr1);
-
-            var attr2 = new Attribute(context, "a2", DataType.Int32);
-            Assert.IsNotNull(attr2);
-            attr2.SetCellValNum(Attribute.VariableSized);
-            array_schema.AddAttribute(attr2);
-
-            array_schema.SetDomain(domain);
-            array_schema.SetCellOrder(LayoutType.RowMajor);
-            array_schema.SetTileOrder(LayoutType.RowMajor);
-
-            array_schema.Check();
-
-            Array.Create(context, tmpArrayPath, array_schema);
-        }
-
-        private void writeVarLengthAttributeArray()
-        {
-            var tmpArrayPath = TestUtil.MakeTestPath("varlength_attributes_array");
-            var context = Context.GetDefault();
-            var array_write = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array_write);
-
-            array_write.Open(QueryType.Write);
-
-            string[] a1_str = [ "a","b","c","d", "aa","bb","cc","dd"
-                ,"aaa","bbb","ccc","ddd","aaaa","bbbb","cccc","dddd" ];
-            var (a1_data, a1_offsets) = CoreUtil.PackStringArray(a1_str);
-
-            int[] a2_data = [1, 1, 2, 2,  3,  4,  5,  6,  6,  7,  7,  8,  8,
-                              8, 9, 9, 10, 11, 12, 12, 13, 14, 14, 14, 15, 16 ];
-            ulong[] a2_el_off = [0, 2, 4, 5, 6, 7, 9, 11, 14, 16, 17, 18, 20, 21, 24, 25];
-            ulong[] a2_off = CoreUtil.ElementOffsetsToByteOffsets(a2_el_off, DataType.Int32);
-
-            var query_write = new Query(array_write);
-            query_write.SetLayout(LayoutType.RowMajor);
-            // using var subarray = new Subarray(array_write);
-            // subarray.SetSubarray(new int[] { 1, 4, 4, 4 });
-
-            query_write.SetDataBuffer("a1", a1_data);
-            query_write.SetOffsetsBuffer("a1", a1_offsets);
-
-            query_write.SetDataBuffer("a2", a2_data);
-            query_write.SetOffsetsBuffer("a2", a2_off);
-
-            query_write.Submit();
-
-            var status_write = query_write.Status();
-            Assert.AreEqual(QueryStatus.Completed, status_write);
-            query_write.FinalizeQuery();
-
-            array_write.Close();
-        }
-
-        private void readVarLengthAttributeArray()
-        {
-            var tmpArrayPath = TestUtil.MakeTestPath("varlength_attributes_array");
-            var context = Context.GetDefault();
-            var array_read = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array_read);
-            array_read.Open(QueryType.Read);
-
-            var query_read = new Query(array_read);
-
-            // Slice only rows 1,2 and cols 2,3,4
-            using var subarray = new Subarray(array_read);
-            subarray.SetSubarray(1, 4, 1, 4);
-            query_read.SetSubarray(subarray);
-
-            query_read.SetLayout(LayoutType.RowMajor);
-
-            byte[] a1_data_buffer_read = new byte[128];
-            ulong[] a1_offsets_buffer_read = new ulong[128];
-
-            int[] a2_data_buffer_read = new int[128];
-            ulong[] a2_offsets_buffer_read = new ulong[128];
-
-            query_read.SetDataBuffer("a1", a1_data_buffer_read);
-            query_read.SetOffsetsBuffer("a1", a1_offsets_buffer_read);
-            query_read.SetDataBuffer("a2", a2_data_buffer_read);
-            query_read.SetOffsetsBuffer("a2", a2_offsets_buffer_read);
-
-            query_read.Submit();
-            var status_read = query_read.Status();
-            Assert.AreEqual(QueryStatus.Completed, status_read);
-
-            var result_size_a1 = query_read.EstResultSize("a1");
-            var result_size_a2 = query_read.EstResultSize("a2");
-
-            Assert.AreEqual<ulong>(40, result_size_a1.DataBytesSize);
-            Assert.AreEqual<ulong>(16, result_size_a1.OffsetsSize());
-            Assert.AreEqual<ulong>(26, result_size_a2.DataSize(DataType.Int32));
-            Assert.AreEqual<ulong>(16, result_size_a2.OffsetsSize());
-            array_read.Close();
-        }
+        Assert.AreEqual<ulong>(40, result_size_a1.DataBytesSize);
+        Assert.AreEqual<ulong>(16, result_size_a1.OffsetsSize());
+        Assert.AreEqual<ulong>(26, result_size_a2.DataSize(DataType.Int32));
+        Assert.AreEqual<ulong>(16, result_size_a2.OffsetsSize());
+        array_read.Close();
     }
 }

--- a/tests/TileDB.CSharp.Test/AttributeTest.cs
+++ b/tests/TileDB.CSharp.Test/AttributeTest.cs
@@ -202,13 +202,13 @@ namespace TileDB.CSharp.Test
 
             array_write.Open(QueryType.Write);
 
-            string[] a1_str = new string[16] { "a","b","c","d", "aa","bb","cc","dd"
-                ,"aaa","bbb","ccc","ddd","aaaa","bbbb","cccc","dddd" };
+            string[] a1_str = [ "a","b","c","d", "aa","bb","cc","dd"
+                ,"aaa","bbb","ccc","ddd","aaaa","bbbb","cccc","dddd" ];
             var (a1_data, a1_offsets) = CoreUtil.PackStringArray(a1_str);
 
-            int[] a2_data = new int[26] {1, 1, 2, 2,  3,  4,  5,  6,  6,  7,  7,  8,  8,
-                              8, 9, 9, 10, 11, 12, 12, 13, 14, 14, 14, 15, 16 };
-            ulong[] a2_el_off = new ulong[16] { 0, 2, 4, 5, 6, 7, 9, 11, 14, 16, 17, 18, 20, 21, 24, 25};
+            int[] a2_data = [1, 1, 2, 2,  3,  4,  5,  6,  6,  7,  7,  8,  8,
+                              8, 9, 9, 10, 11, 12, 12, 13, 14, 14, 14, 15, 16 ];
+            ulong[] a2_el_off = [0, 2, 4, 5, 6, 7, 9, 11, 14, 16, 17, 18, 20, 21, 24, 25];
             ulong[] a2_off = CoreUtil.ElementOffsetsToByteOffsets(a2_el_off, DataType.Int32);
 
             var query_write = new Query(array_write);

--- a/tests/TileDB.CSharp.Test/ConfigTest.cs
+++ b/tests/TileDB.CSharp.Test/ConfigTest.cs
@@ -1,204 +1,203 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class ConfigTest
 {
-    [TestClass]
-    public class ConfigTest
+    [TestMethod]
+    public void ConfigSet()
     {
-        [TestMethod]
-        public void ConfigSet()
+        var config = new Config();
+        config.Set("sm.tile_cache_size", "10");
+        var val = config.Get("sm.tile_cache_size");
+        Assert.AreEqual("10", val);
+    }
+
+    [TestMethod]
+    public void ConfigGetNonExistent()
+    {
+        var config = new Config();
+        var val = config.Get("sm.does_not_exist");
+        Assert.AreEqual("", val);
+    }
+
+    [TestMethod]
+    public void ConfigUnSet()
+    {
+        var config = new Config();
+        var defaultVal = config.Get("sm.tile_cache_size");
+        config.Set("sm.tile_cache_size", "10");
+        var val = config.Get("sm.tile_cache_size");
+        Assert.AreEqual("10", val);
+        config.Unset("sm.tile_cache_size");
+        val = config.Get("sm.tile_cache_size");
+        Assert.AreEqual(defaultVal, val);
+    }
+
+    [TestMethod]
+    public void ConfigFromFile()
+    {
+        var config = new Config();
+        config.Set("sm.tile_cache_size", "10");
+        var val = config.Get("sm.tile_cache_size");
+        Assert.AreEqual("10", val);
+
+        // Create temporary path for testing configuration writing/reading
+        var tmpPath = TestUtil.MakeTestPath("tmp.cfg");
+
+        config.SaveToFile(tmpPath);
+
+        var config2 = new Config();
+        config2.LoadFromFile(tmpPath);
+
+        val = config2.Get("sm.tile_cache_size");
+        Assert.AreEqual("10", val);
+    }
+
+    [TestMethod]
+    public void ConfigCompare()
+    {
+        var config = new Config();
+        config.Set("sm.tile_cache_size", "10");
+        var val = config.Get("sm.tile_cache_size");
+        Assert.AreEqual("10", val);
+
+        var config2 = new Config();
+        config2.Set("sm.tile_cache_size", "10");
+        var val2 = config.Get("sm.tile_cache_size");
+        Assert.AreEqual("10", val2);
+
+        var cmp2 = config.Cmp(ref config2);
+        Assert.IsTrue(cmp2);
+
+        var config3 = new Config();
+        config3.Set("sm.tile_cache_size", "11");
+        var val3 = config3.Get("sm.tile_cache_size");
+        Assert.AreEqual("11", val3);
+
+        var cmp3 = config.Cmp(ref config3);
+        Assert.IsFalse(cmp3);
+    }
+
+    [TestMethod]
+    public void ConfigIterator()
+    {
+        var config = new Config();
+
+        // Iterate the configuration
+        var iter = config.Iterate("vfs.s3.");
+
+        while (!iter.Done())
         {
-            var config = new Config();
-            config.Set("sm.tile_cache_size", "10");
-            var val = config.Get("sm.tile_cache_size");
-            Assert.AreEqual("10", val);
-        }
 
-        [TestMethod]
-        public void ConfigGetNonExistent()
-        {
-            var config = new Config();
-            var val = config.Get("sm.does_not_exist");
-            Assert.AreEqual("", val);
-        }
+            // Get current param, value from iterator
+            var config_entry_pair = iter.Here();
 
-        [TestMethod]
-        public void ConfigUnSet()
-        {
-            var config = new Config();
-            var defaultVal = config.Get("sm.tile_cache_size");
-            config.Set("sm.tile_cache_size", "10");
-            var val = config.Get("sm.tile_cache_size");
-            Assert.AreEqual("10", val);
-            config.Unset("sm.tile_cache_size");
-            val = config.Get("sm.tile_cache_size");
-            Assert.AreEqual(defaultVal, val);
-        }
-
-        [TestMethod]
-        public void ConfigFromFile()
-        {
-            var config = new Config();
-            config.Set("sm.tile_cache_size", "10");
-            var val = config.Get("sm.tile_cache_size");
-            Assert.AreEqual("10", val);
-
-            // Create temporary path for testing configuration writing/reading
-            var tmpPath = TestUtil.MakeTestPath("tmp.cfg");
-
-            config.SaveToFile(tmpPath);
-
-            var config2 = new Config();
-            config2.LoadFromFile(tmpPath);
-
-            val = config2.Get("sm.tile_cache_size");
-            Assert.AreEqual("10", val);
-        }
-
-        [TestMethod]
-        public void ConfigCompare()
-        {
-            var config = new Config();
-            config.Set("sm.tile_cache_size", "10");
-            var val = config.Get("sm.tile_cache_size");
-            Assert.AreEqual("10", val);
-
-            var config2 = new Config();
-            config2.Set("sm.tile_cache_size", "10");
-            var val2 = config.Get("sm.tile_cache_size");
-            Assert.AreEqual("10", val2);
-
-            var cmp2 = config.Cmp(ref config2);
-            Assert.IsTrue(cmp2);
-
-            var config3 = new Config();
-            config3.Set("sm.tile_cache_size", "11");
-            var val3 = config3.Get("sm.tile_cache_size");
-            Assert.AreEqual("11", val3);
-
-            var cmp3 = config.Cmp(ref config3);
-            Assert.IsFalse(cmp3);
-        }
-
-        [TestMethod]
-        public void ConfigIterator()
-        {
-            var config = new Config();
-
-            // Iterate the configuration
-            var iter = config.Iterate("vfs.s3.");
-
-            while (!iter.Done())
+            switch (config_entry_pair.Item1)
             {
-
-                // Get current param, value from iterator
-                var config_entry_pair = iter.Here();
-
-                switch (config_entry_pair.Item1)
-                {
-                    case "aws_access_key_id":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "aws_external_id":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "aws_load_frequency":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "aws_role_arn":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "aws_secret_access_key":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "aws_session_name":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "aws_session_token":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "bucket_canned_acl":
-                        Assert.AreEqual("NOT_SET", config_entry_pair.Item2);
-                        break;
-                    case "ca_file":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "ca_path":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "connect_max_tries":
-                        Assert.AreEqual("5", config_entry_pair.Item2);
-                        break;
-                    case "connect_scale_factor":
-                        Assert.AreEqual("25", config_entry_pair.Item2);
-                        break;
-                    case "connect_timeout_ms":
-                        Assert.AreEqual("10800", config_entry_pair.Item2);
-                        break;
-                    case "endpoint_override":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "logging_level":
-                        Assert.AreEqual("Off", config_entry_pair.Item2);
-                        break;
-                    case "max_parallel_ops":
-                        Assert.AreEqual(Environment.ProcessorCount.ToString(), config_entry_pair.Item2);
-                        break;
-                    case "multipart_part_size":
-                        Assert.AreEqual("5242880", config_entry_pair.Item2);
-                        break;
-                    case "object_canned_acl":
-                        Assert.AreEqual("NOT_SET", config_entry_pair.Item2);
-                        break;
-                    case "proxy_host":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "proxy_password":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "proxy_port":
-                        Assert.AreEqual("0", config_entry_pair.Item2);
-                        break;
-                    case "proxy_scheme":
-                        Assert.AreEqual("http", config_entry_pair.Item2);
-                        break;
-                    case "proxy_username":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "region":
-                        Assert.AreEqual("us-east-1", config_entry_pair.Item2);
-                        break;
-                    case "request_timeout_ms":
-                        Assert.AreEqual("3000", config_entry_pair.Item2);
-                        break;
-                    case "requester_pays":
-                        Assert.AreEqual("false", config_entry_pair.Item2);
-                        break;
-                    case "scheme":
-                        Assert.AreEqual("https", config_entry_pair.Item2);
-                        break;
-                    case "skip_init":
-                        Assert.AreEqual("false", config_entry_pair.Item2);
-                        break;
-                    case "sse":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "sse_kms_key_id":
-                        Assert.AreEqual("", config_entry_pair.Item2);
-                        break;
-                    case "use_multipart_upload":
-                        Assert.AreEqual("true", config_entry_pair.Item2);
-                        break;
-                    case "use_virtual_addressing":
-                        Assert.AreEqual("true", config_entry_pair.Item2);
-                        break;
-                    case "verify_ssl":
-                        Assert.AreEqual("true", config_entry_pair.Item2);
-                        break;
-                }
-                iter.Next();
+                case "aws_access_key_id":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "aws_external_id":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "aws_load_frequency":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "aws_role_arn":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "aws_secret_access_key":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "aws_session_name":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "aws_session_token":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "bucket_canned_acl":
+                    Assert.AreEqual("NOT_SET", config_entry_pair.Item2);
+                    break;
+                case "ca_file":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "ca_path":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "connect_max_tries":
+                    Assert.AreEqual("5", config_entry_pair.Item2);
+                    break;
+                case "connect_scale_factor":
+                    Assert.AreEqual("25", config_entry_pair.Item2);
+                    break;
+                case "connect_timeout_ms":
+                    Assert.AreEqual("10800", config_entry_pair.Item2);
+                    break;
+                case "endpoint_override":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "logging_level":
+                    Assert.AreEqual("Off", config_entry_pair.Item2);
+                    break;
+                case "max_parallel_ops":
+                    Assert.AreEqual(Environment.ProcessorCount.ToString(), config_entry_pair.Item2);
+                    break;
+                case "multipart_part_size":
+                    Assert.AreEqual("5242880", config_entry_pair.Item2);
+                    break;
+                case "object_canned_acl":
+                    Assert.AreEqual("NOT_SET", config_entry_pair.Item2);
+                    break;
+                case "proxy_host":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "proxy_password":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "proxy_port":
+                    Assert.AreEqual("0", config_entry_pair.Item2);
+                    break;
+                case "proxy_scheme":
+                    Assert.AreEqual("http", config_entry_pair.Item2);
+                    break;
+                case "proxy_username":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "region":
+                    Assert.AreEqual("us-east-1", config_entry_pair.Item2);
+                    break;
+                case "request_timeout_ms":
+                    Assert.AreEqual("3000", config_entry_pair.Item2);
+                    break;
+                case "requester_pays":
+                    Assert.AreEqual("false", config_entry_pair.Item2);
+                    break;
+                case "scheme":
+                    Assert.AreEqual("https", config_entry_pair.Item2);
+                    break;
+                case "skip_init":
+                    Assert.AreEqual("false", config_entry_pair.Item2);
+                    break;
+                case "sse":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "sse_kms_key_id":
+                    Assert.AreEqual("", config_entry_pair.Item2);
+                    break;
+                case "use_multipart_upload":
+                    Assert.AreEqual("true", config_entry_pair.Item2);
+                    break;
+                case "use_virtual_addressing":
+                    Assert.AreEqual("true", config_entry_pair.Item2);
+                    break;
+                case "verify_ssl":
+                    Assert.AreEqual("true", config_entry_pair.Item2);
+                    break;
             }
+            iter.Next();
         }
     }
 }

--- a/tests/TileDB.CSharp.Test/ContextTest.cs
+++ b/tests/TileDB.CSharp.Test/ContextTest.cs
@@ -3,124 +3,123 @@ using System;
 using System.IO;
 using System.Runtime.InteropServices;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class ContextTest
 {
-    [TestClass]
-    public class ContextTest
+    [TestMethod]
+    public void NewContextIsValid()
     {
-        [TestMethod]
-        public void NewContextIsValid()
+        var config = new Config();
+
+        // Set values
+        config.Set("sm.memory_budget", "512000000");
+        config.Set("vfs.s3.connect_timeout_ms", "5000");
+        config.Set("vfs.s3.endpoint_override", "localhost:8888");
+        using (var ctx = new Context(config))
         {
-            var config = new Config();
-
-            // Set values
-            config.Set("sm.memory_budget", "512000000");
-            config.Set("vfs.s3.connect_timeout_ms", "5000");
-            config.Set("vfs.s3.endpoint_override", "localhost:8888");
-            using (var ctx = new Context(config))
-            {
-                // Get values
-                Assert.AreEqual("512000000", ctx.Config().Get("sm.memory_budget"));
-                Assert.AreEqual("5000", ctx.Config().Get("vfs.s3.connect_timeout_ms"));
-                Assert.AreEqual("localhost:8888", ctx.Config().Get("vfs.s3.endpoint_override"));
-            }
-        }
-
-        [TestMethod]
-        public void ConfigReadWrite()
-        {
-            var config = new Config();
-
-            // Set values
-            config.Set("sm.memory_budget", "512000000");
-            config.Set("vfs.s3.connect_timeout_ms", "5000");
-            config.Set("vfs.s3.endpoint_override", "localhost:8888");
-
             // Get values
-            Assert.AreEqual("512000000", config.Get("sm.memory_budget"));
-            Assert.AreEqual("5000", config.Get("vfs.s3.connect_timeout_ms"));
-            Assert.AreEqual("localhost:8888", config.Get("vfs.s3.endpoint_override"));
-
-            var tempConfigPath = TestUtil.MakeTestPath("temp.cfg");
-            config.SaveToFile(tempConfigPath);
-
-            var config2 = new Config();
-            config2.LoadFromFile(tempConfigPath);
-
-            // Get values from config2
-            Assert.AreEqual("512000000", config2.Get("sm.memory_budget"));
-            Assert.AreEqual("5000", config2.Get("vfs.s3.connect_timeout_ms"));
-            Assert.AreEqual("localhost:8888", config2.Get("vfs.s3.endpoint_override"));
+            Assert.AreEqual("512000000", ctx.Config().Get("sm.memory_budget"));
+            Assert.AreEqual("5000", ctx.Config().Get("vfs.s3.connect_timeout_ms"));
+            Assert.AreEqual("localhost:8888", ctx.Config().Get("vfs.s3.endpoint_override"));
         }
+    }
 
-        [TestMethod]
-        public void TestIsFileSystemSupported()
-        {
-            using var ctx = new Context();
-            Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.InMemory));
-            // While the release binaries support all other filesystems (except for
-            // HDFS), binaries from nightly builds and other custom builds may not.
-            // MemFS is the only filesystem that is known to be always supported.
-        }
+    [TestMethod]
+    public void ConfigReadWrite()
+    {
+        var config = new Config();
 
-        [TestMethod]
-        public void TestObjectMethods()
-        {
-            using var arrayUri = new TemporaryDirectory("ctx-object-methods");
-            var arrayUri2 = Path.Combine(arrayUri, "../ctx-object-methods2");
-            TemporaryDirectory.DeleteDirectory(arrayUri2);
+        // Set values
+        config.Set("sm.memory_budget", "512000000");
+        config.Set("vfs.s3.connect_timeout_ms", "5000");
+        config.Set("vfs.s3.endpoint_override", "localhost:8888");
 
-            using var ctx = new Context();
-            Assert.AreEqual(ObjectType.Invalid, ctx.GetObjectType(arrayUri));
+        // Get values
+        Assert.AreEqual("512000000", config.Get("sm.memory_budget"));
+        Assert.AreEqual("5000", config.Get("vfs.s3.connect_timeout_ms"));
+        Assert.AreEqual("localhost:8888", config.Get("vfs.s3.endpoint_override"));
 
-            CreateArray(ctx, arrayUri);
-            Assert.AreEqual(ObjectType.Array, ctx.GetObjectType(arrayUri));
+        var tempConfigPath = TestUtil.MakeTestPath("temp.cfg");
+        config.SaveToFile(tempConfigPath);
 
-            ctx.MoveObject(arrayUri, arrayUri2);
-            Assert.AreEqual(ObjectType.Invalid, ctx.GetObjectType(arrayUri));
-            Assert.AreEqual(ObjectType.Array, ctx.GetObjectType(arrayUri2));
+        var config2 = new Config();
+        config2.LoadFromFile(tempConfigPath);
 
-            ctx.RemoveObject(arrayUri2);
-            Assert.AreEqual(ObjectType.Invalid, ctx.GetObjectType(arrayUri2));
-        }
+        // Get values from config2
+        Assert.AreEqual("512000000", config2.Get("sm.memory_budget"));
+        Assert.AreEqual("5000", config2.Get("vfs.s3.connect_timeout_ms"));
+        Assert.AreEqual("localhost:8888", config2.Get("vfs.s3.endpoint_override"));
+    }
 
-        [TestMethod]
-        public void TestGetChildObjects()
-        {
-            using var path = new TemporaryDirectory("ctx-child-objects");
-            var arrayUri = Path.Combine(path, "array1");
-            var groupUri = Path.Combine(path, "group1");
-            var arrayUri2 = Path.Combine(groupUri, "array2");
+    [TestMethod]
+    public void TestIsFileSystemSupported()
+    {
+        using var ctx = new Context();
+        Assert.IsTrue(ctx.IsFileSystemSupported(FileSystemType.InMemory));
+        // While the release binaries support all other filesystems (except for
+        // HDFS), binaries from nightly builds and other custom builds may not.
+        // MemFS is the only filesystem that is known to be always supported.
+    }
 
-            using var ctx = new Context();
-            CreateArray(ctx, arrayUri);
-            Group.Create(ctx, groupUri);
-            CreateArray(ctx, arrayUri2);
-            
-            Assert.AreEqual(2, ctx.GetChildObjects(path, null).Count);
-            Assert.AreEqual(3, ctx.GetChildObjects(path, WalkOrderType.PreOrder).Count);
-            Assert.AreEqual(3, ctx.GetChildObjects(path, WalkOrderType.PostOrder).Count);
-        }
+    [TestMethod]
+    public void TestObjectMethods()
+    {
+        using var arrayUri = new TemporaryDirectory("ctx-object-methods");
+        var arrayUri2 = Path.Combine(arrayUri, "../ctx-object-methods2");
+        TemporaryDirectory.DeleteDirectory(arrayUri2);
 
-        private static void CreateArray(Context ctx, string arrayUri)
-        {
-            using Dimension d1 = Dimension.Create(ctx, nameof(d1), 1, 10, 5);
-            using Dimension d2 = Dimension.Create(ctx, nameof(d2), 1, 10, 5);
+        using var ctx = new Context();
+        Assert.AreEqual(ObjectType.Invalid, ctx.GetObjectType(arrayUri));
 
-            using Domain domain = new Domain(ctx);
-            domain.AddDimension(d1);
-            domain.AddDimension(d2);
+        CreateArray(ctx, arrayUri);
+        Assert.AreEqual(ObjectType.Array, ctx.GetObjectType(arrayUri));
 
-            using Attribute a1 = new Attribute(ctx, nameof(a1), DataType.Int32);
+        ctx.MoveObject(arrayUri, arrayUri2);
+        Assert.AreEqual(ObjectType.Invalid, ctx.GetObjectType(arrayUri));
+        Assert.AreEqual(ObjectType.Array, ctx.GetObjectType(arrayUri2));
 
-            using ArraySchema schema = new ArraySchema(ctx, ArrayType.Sparse);
-            schema.SetTileOrder(LayoutType.RowMajor);
-            schema.SetCellOrder(LayoutType.RowMajor);
-            schema.SetCapacity(2);
-            schema.SetDomain(domain);
-            schema.AddAttribute(a1);
+        ctx.RemoveObject(arrayUri2);
+        Assert.AreEqual(ObjectType.Invalid, ctx.GetObjectType(arrayUri2));
+    }
 
-            Array.Create(ctx, arrayUri, schema);
-        }
+    [TestMethod]
+    public void TestGetChildObjects()
+    {
+        using var path = new TemporaryDirectory("ctx-child-objects");
+        var arrayUri = Path.Combine(path, "array1");
+        var groupUri = Path.Combine(path, "group1");
+        var arrayUri2 = Path.Combine(groupUri, "array2");
+
+        using var ctx = new Context();
+        CreateArray(ctx, arrayUri);
+        Group.Create(ctx, groupUri);
+        CreateArray(ctx, arrayUri2);
+        
+        Assert.AreEqual(2, ctx.GetChildObjects(path, null).Count);
+        Assert.AreEqual(3, ctx.GetChildObjects(path, WalkOrderType.PreOrder).Count);
+        Assert.AreEqual(3, ctx.GetChildObjects(path, WalkOrderType.PostOrder).Count);
+    }
+
+    private static void CreateArray(Context ctx, string arrayUri)
+    {
+        using Dimension d1 = Dimension.Create(ctx, nameof(d1), 1, 10, 5);
+        using Dimension d2 = Dimension.Create(ctx, nameof(d2), 1, 10, 5);
+
+        using Domain domain = new Domain(ctx);
+        domain.AddDimension(d1);
+        domain.AddDimension(d2);
+
+        using Attribute a1 = new Attribute(ctx, nameof(a1), DataType.Int32);
+
+        using ArraySchema schema = new ArraySchema(ctx, ArrayType.Sparse);
+        schema.SetTileOrder(LayoutType.RowMajor);
+        schema.SetCellOrder(LayoutType.RowMajor);
+        schema.SetCapacity(2);
+        schema.SetDomain(domain);
+        schema.AddAttribute(a1);
+
+        Array.Create(ctx, arrayUri, schema);
     }
 }

--- a/tests/TileDB.CSharp.Test/CoreUtilTest.cs
+++ b/tests/TileDB.CSharp.Test/CoreUtilTest.cs
@@ -1,16 +1,15 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
-{
-    [TestClass]
-    public class CoreUtilTest
-    {
-        [TestMethod]
-        public void BuildConfigurationNonEmpty()
-        {
-            var buildConfiguration = CoreUtil.GetBuildConfiguration();
+namespace TileDB.CSharp.Test;
 
-            Assert.IsFalse(string.IsNullOrWhiteSpace(buildConfiguration));
-        }
+[TestClass]
+public class CoreUtilTest
+{
+    [TestMethod]
+    public void BuildConfigurationNonEmpty()
+    {
+        var buildConfiguration = CoreUtil.GetBuildConfiguration();
+
+        Assert.IsFalse(string.IsNullOrWhiteSpace(buildConfiguration));
     }
 }

--- a/tests/TileDB.CSharp.Test/DeletesTest.cs
+++ b/tests/TileDB.CSharp.Test/DeletesTest.cs
@@ -6,893 +6,892 @@ using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class DeletesTest
 {
-    [TestClass]
-    public class DeletesTest
+    private static void InitTest(Context ctx, string arrayName, LayoutType layout, bool duplicates)
     {
-        private static void InitTest(Context ctx, string arrayName, LayoutType layout, bool duplicates)
+        using var rows = Dimension.Create(ctx, "rows", 1, 4, 4);
+        using var cols = Dimension.Create(ctx, "cols", 1, 4, 4);
+        using var domain = new Domain(ctx);
+        domain.AddDimensions(rows, cols);
+        // Deletes are only supported for sparse arrays
+        var arrayType = ArrayType.Sparse;
+        using var schema = new ArraySchema(ctx, arrayType);
+        schema.SetDomain(domain);
+        schema.AddAttribute(new Attribute(ctx, "a1", DataType.Int32));
+        schema.SetAllowsDups(duplicates);
+        schema.Check();
+        using var array = new Array(ctx, arrayName);
+        TestUtil.CreateArray(ctx, arrayName, schema);
+        var initialData = new Dictionary<string, System.Array>()
         {
-            using var rows = Dimension.Create(ctx, "rows", 1, 4, 4);
-            using var cols = Dimension.Create(ctx, "cols", 1, 4, 4);
-            using var domain = new Domain(ctx);
-            domain.AddDimensions(rows, cols);
-            // Deletes are only supported for sparse arrays
-            var arrayType = ArrayType.Sparse;
-            using var schema = new ArraySchema(ctx, arrayType);
-            schema.SetDomain(domain);
-            schema.AddAttribute(new Attribute(ctx, "a1", DataType.Int32));
-            schema.SetAllowsDups(duplicates);
-            schema.Check();
-            using var array = new Array(ctx, arrayName);
-            TestUtil.CreateArray(ctx, arrayName, schema);
-            var initialData = new Dictionary<string, System.Array>()
-            {
-                { "a1", Enumerable.Range(1, 16).ToArray() },
-                {"rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
-                { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } }
-            };
-            TestUtil.WriteArray(array, layout, initialData, keepOpen: false);
+            { "a1", Enumerable.Range(1, 16).ToArray() },
+            {"rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
+            { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } }
+        };
+        TestUtil.WriteArray(array, layout, initialData, keepOpen: false);
 
-            var readBuffers = new Dictionary<string, System.Array>
-                { {"rows", new int[16]}, {"cols", new int[16]}, {"a1", new int[16]} };
-            TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-            var expectedData = new Dictionary<string, System.Array>()
-            {
-                { "a1", Enumerable.Range(1, 16).ToArray() },
-                { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
-                { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
-            };
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-        }
-
-        private static void DeleteFour(Context ctx, Array array, LayoutType layout, bool duplicates)
+        var readBuffers = new Dictionary<string, System.Array>
+            { {"rows", new int[16]}, {"cols", new int[16]}, {"a1", new int[16]} };
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+        var expectedData = new Dictionary<string, System.Array>()
         {
-            // Delete multiple cells at once
-            array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(array, QueryType.Delete);
-            using var notCondition = QueryCondition.Create(ctx, "cols", 3, QueryConditionOperatorType.NotEqual);
-            using var andCondition = QueryCondition.Create(ctx, "cols", 2, QueryConditionOperatorType.GreaterThan);
-            using var queryCondition = notCondition & andCondition;
-            deleteQuery.SetCondition(queryCondition);
-            deleteQuery.Submit();
-            Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
-            array.Close();
+            { "a1", Enumerable.Range(1, 16).ToArray() },
+            { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
+            { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
+        };
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+    }
 
-            // Check for expected values
-            var readBuffers = new Dictionary<string, System.Array>()
-                { { "rows", new int[16] }, { "cols", new int[16] }, { "a1", new int[16] } };
-            using var readQuery = TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx);
-            var expectedData = new Dictionary<string, System.Array>()
-            {
-                { "a1", new[] { 1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15, 0, 0, 0, 0 } },
-                { "rows", new[] { 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 0, 0, 0, 0 } },
-                { "cols", new[] { 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 0, 0, 0, 0 } },
-            };
+    private static void DeleteFour(Context ctx, Array array, LayoutType layout, bool duplicates)
+    {
+        // Delete multiple cells at once
+        array.Open(QueryType.Delete);
+        using var deleteQuery = new Query(array, QueryType.Delete);
+        using var notCondition = QueryCondition.Create(ctx, "cols", 3, QueryConditionOperatorType.NotEqual);
+        using var andCondition = QueryCondition.Create(ctx, "cols", 2, QueryConditionOperatorType.GreaterThan);
+        using var queryCondition = notCondition & andCondition;
+        deleteQuery.SetCondition(queryCondition);
+        deleteQuery.Submit();
+        Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
+        array.Close();
 
-            array.Open(QueryType.Read);
-            Assert.AreEqual(12UL, readQuery.ResultBufferElements()["a1"].Item1);
-            Assert.AreEqual(12UL, readQuery.GetResultDataElements("a1"));
-            array.Close();
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-        }
-
-        // Params for all tests are (layout, legacy, duplicates)
-        [DataRow(LayoutType.Unordered, "legacy", true)]
-        [DataRow(LayoutType.Unordered, "legacy", false)]
-        [DataRow(LayoutType.Unordered, "refactored", true)]
-        [DataRow(LayoutType.Unordered, "refactored", false)]
-        [DataRow(LayoutType.RowMajor, "legacy", true)]
-        [DataRow(LayoutType.RowMajor, "legacy", false)]
-        [DataRow(LayoutType.RowMajor, "refactored", true)]
-        [DataRow(LayoutType.RowMajor, "refactored", false)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", true)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", false)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", true)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", false)]
-        [DataTestMethod]
-        public void MultipleCells(LayoutType layout, string queryReader, bool duplicates)
+        // Check for expected values
+        var readBuffers = new Dictionary<string, System.Array>()
+            { { "rows", new int[16] }, { "cols", new int[16] }, { "a1", new int[16] } };
+        using var readQuery = TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx);
+        var expectedData = new Dictionary<string, System.Array>()
         {
-            string arrayName = "deletes-multiple-cells";
-            var ctx = Context.GetDefault();
-            ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
-            ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
-            InitTest(ctx, arrayName, layout, duplicates);
-            using var array = new Array(ctx, arrayName);
+            { "a1", new[] { 1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15, 0, 0, 0, 0 } },
+            { "rows", new[] { 1, 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 0, 0, 0, 0 } },
+            { "cols", new[] { 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 0, 0, 0, 0 } },
+        };
 
-            DeleteFour(ctx, array, layout, duplicates);
-        }
+        array.Open(QueryType.Read);
+        Assert.AreEqual(12UL, readQuery.ResultBufferElements()["a1"].Item1);
+        Assert.AreEqual(12UL, readQuery.GetResultDataElements("a1"));
+        array.Close();
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+    }
 
-        [DataRow(LayoutType.Unordered, "legacy", true)]
-        [DataRow(LayoutType.Unordered, "legacy", false)]
-        [DataRow(LayoutType.Unordered, "refactored", true)]
-        [DataRow(LayoutType.Unordered, "refactored", false)]
-        [DataRow(LayoutType.RowMajor, "legacy", true)]
-        [DataRow(LayoutType.RowMajor, "legacy", false)]
-        [DataRow(LayoutType.RowMajor, "refactored", true)]
-        [DataRow(LayoutType.RowMajor, "refactored", false)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", true)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", false)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", true)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", false)]
-        [DataTestMethod]
-        public void SingleCell(LayoutType layout, string queryReader, bool duplicates)
+    // Params for all tests are (layout, legacy, duplicates)
+    [DataRow(LayoutType.Unordered, "legacy", true)]
+    [DataRow(LayoutType.Unordered, "legacy", false)]
+    [DataRow(LayoutType.Unordered, "refactored", true)]
+    [DataRow(LayoutType.Unordered, "refactored", false)]
+    [DataRow(LayoutType.RowMajor, "legacy", true)]
+    [DataRow(LayoutType.RowMajor, "legacy", false)]
+    [DataRow(LayoutType.RowMajor, "refactored", true)]
+    [DataRow(LayoutType.RowMajor, "refactored", false)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", true)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", false)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", true)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", false)]
+    [DataTestMethod]
+    public void MultipleCells(LayoutType layout, string queryReader, bool duplicates)
+    {
+        string arrayName = "deletes-multiple-cells";
+        var ctx = Context.GetDefault();
+        ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
+        ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
+        InitTest(ctx, arrayName, layout, duplicates);
+        using var array = new Array(ctx, arrayName);
+
+        DeleteFour(ctx, array, layout, duplicates);
+    }
+
+    [DataRow(LayoutType.Unordered, "legacy", true)]
+    [DataRow(LayoutType.Unordered, "legacy", false)]
+    [DataRow(LayoutType.Unordered, "refactored", true)]
+    [DataRow(LayoutType.Unordered, "refactored", false)]
+    [DataRow(LayoutType.RowMajor, "legacy", true)]
+    [DataRow(LayoutType.RowMajor, "legacy", false)]
+    [DataRow(LayoutType.RowMajor, "refactored", true)]
+    [DataRow(LayoutType.RowMajor, "refactored", false)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", true)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", false)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", true)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", false)]
+    [DataTestMethod]
+    public void SingleCell(LayoutType layout, string queryReader, bool duplicates)
+    {
+        string arrayName = "deletes-single-cell";
+        using var ctx = Context.GetDefault();
+        ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
+        ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
+        InitTest(ctx, arrayName, layout, duplicates);
+        using var array = new Array(ctx, arrayName);
+
+        // Delete one cell
+        array.Open(QueryType.Delete);
+        using var deleteQuery = new Query(array, QueryType.Delete);
+        using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
+        using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
+        using var andCondition = colsCondition & rowsCondition;
+        deleteQuery.SetCondition(andCondition);
+        deleteQuery.Submit();
+        array.Close();
+        Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
+
+        // Check for expected values
+        var readBuffers = new Dictionary<string, System.Array>()
+            { { "rows", new int[16] }, { "cols", new int[16] }, { "a1", new int[16] } };
+        using var readQuery = TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx);
+
+        array.Open(QueryType.Read);
+        Assert.AreEqual(15UL, readQuery.ResultBufferElements()["a1"].Item1);
+        Assert.AreEqual(15UL, readQuery.GetResultDataElements("a1"));
+        array.Close();
+        var expectedData = new Dictionary<string, System.Array>()
         {
-            string arrayName = "deletes-single-cell";
-            using var ctx = Context.GetDefault();
-            ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
-            ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
-            InitTest(ctx, arrayName, layout, duplicates);
-            using var array = new Array(ctx, arrayName);
+            { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
+            { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0 } },
+            { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
+        };
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+    }
 
-            // Delete one cell
-            array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(array, QueryType.Delete);
-            using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
-            using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
-            using var andCondition = colsCondition & rowsCondition;
-            deleteQuery.SetCondition(andCondition);
-            deleteQuery.Submit();
-            array.Close();
-            Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
+    [DataRow(LayoutType.Unordered, "legacy", true)]
+    [DataRow(LayoutType.Unordered, "legacy", false)]
+    [DataRow(LayoutType.Unordered, "refactored", true)]
+    [DataRow(LayoutType.Unordered, "refactored", false)]
+    [DataRow(LayoutType.RowMajor, "legacy", true)]
+    [DataRow(LayoutType.RowMajor, "legacy", false)]
+    [DataRow(LayoutType.RowMajor, "refactored", true)]
+    [DataRow(LayoutType.RowMajor, "refactored", false)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", true)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", false)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", true)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", false)]
+    [DataTestMethod]
+    public void VaryingCells(LayoutType layout, string queryReader, bool duplicates)
+    {
+        string arrayName = "deletes-varying-cells";
+        using var ctx = Context.GetDefault();
+        ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
+        ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
+        InitTest(ctx, arrayName, layout, duplicates);
+        using var array = new Array(ctx, arrayName);
 
-            // Check for expected values
-            var readBuffers = new Dictionary<string, System.Array>()
-                { { "rows", new int[16] }, { "cols", new int[16] }, { "a1", new int[16] } };
-            using var readQuery = TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx);
+        DeleteFour(ctx, array, layout, duplicates);
 
+        // Delete 1 cell
+        array.Open(QueryType.Delete);
+        using var deleteQuery = new Query(array, QueryType.Delete);
+        using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
+        using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
+        using var andCondition = colsCondition & rowsCondition;
+        deleteQuery.SetCondition(andCondition);
+        deleteQuery.Submit();
+        array.Close();
+        Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
+        var readBuffers = new Dictionary<string, System.Array>
+            { { "rows", new int[16] }, { "cols", new int[16] }, { "a1", new int[16] } };
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+        var expectedData = new Dictionary<string, System.Array>()
+        {
+            { "a1", new[] { 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15, 0, 0, 0, 0, 0 } },
+            { "rows", new[] { 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 0, 0, 0, 0, 0 } },
+            { "cols", new[] { 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 0, 0, 0, 0, 0 } },
+        };
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+
+        // Delete 6 cells
+        // + The OR condition overlaps on (3, 4)
+        // + (3, 2) was deleted by a previous delete query
+        array.Open(QueryType.Delete);
+        using var deleteQuery2 = new Query(array, QueryType.Delete);
+        using var colsCondition2 = QueryCondition.Create(ctx, "cols", 4, QueryConditionOperatorType.Equal);
+        using var rowsCondition2 = QueryCondition.Create(ctx, "rows", 3, QueryConditionOperatorType.Equal);
+        using var orCondition = colsCondition2 | rowsCondition2;
+        deleteQuery2.SetCondition(orCondition);
+        deleteQuery2.Submit();
+        array.Close();
+        Assert.AreEqual(QueryStatus.Completed, deleteQuery2.Status());
+
+        // Check for expected values
+        readBuffers = new()
+            { { "rows", new int[16] }, { "cols", new int[16] }, { "a1", new int[16] } };
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+        expectedData["a1"] = new[] { 2, 3, 5, 6, 7, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0 };
+        expectedData["rows"] = new[] { 1, 1, 2, 2, 2, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0 };
+        expectedData["cols"] = new[] { 2, 3, 1, 2, 3, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0 };
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+    }
+
+    [DataRow(LayoutType.Unordered, "legacy", true)]
+    [DataRow(LayoutType.Unordered, "legacy", false)]
+    [DataRow(LayoutType.Unordered, "refactored", true)]
+    [DataRow(LayoutType.Unordered, "refactored", false)]
+    [DataRow(LayoutType.RowMajor, "legacy", true)]
+    [DataRow(LayoutType.RowMajor, "legacy", false)]
+    [DataRow(LayoutType.RowMajor, "refactored", true)]
+    [DataRow(LayoutType.RowMajor, "refactored", false)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", true)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", false)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", true)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", false)]
+    [DataTestMethod]
+    public void MultipleFragments(LayoutType layout, string queryReader, bool duplicates)
+    {
+        string arrayName = "deletes-multiple-fragments";
+        using var ctx = Context.GetDefault();
+        ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
+        ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
+        InitTest(ctx, arrayName, layout, duplicates);
+        using var array = new Array(ctx, arrayName);
+
+        // Delete single cell
+        array.Open(QueryType.Delete);
+        using var deleteQuery = new Query(array, QueryType.Delete);
+        using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
+        using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
+        using var andCondition = rowsCondition & colsCondition;
+        deleteQuery.SetCondition(andCondition);
+        deleteQuery.Submit();
+        array.Close();
+        Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
+
+        int bufferSize = 16;
+        var readBuffers = new Dictionary<string, System.Array>
+            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
+        using (var readQuery = TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx)) {
             array.Open(QueryType.Read);
             Assert.AreEqual(15UL, readQuery.ResultBufferElements()["a1"].Item1);
             Assert.AreEqual(15UL, readQuery.GetResultDataElements("a1"));
             array.Close();
-            var expectedData = new Dictionary<string, System.Array>()
+        }
+        var expectedData = new Dictionary<string, System.Array>()
+        {
+            { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
+            { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0 } },
+            { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
+        };
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+
+        // Re-add; If duplicates are enabled result buffer size will grow
+        bufferSize = duplicates ? ++bufferSize : bufferSize;
+        using var writeQuery = TestUtil.WriteArray(array, layout, new()
+            { {"rows", new[] {1}}, {"cols", new[] {1}}, {"a1", new[] {17}} }, ctx: ctx);
+        Assert.AreEqual(QueryStatus.Completed, writeQuery.Status());
+        readBuffers = new()
+            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
+
+        // Scale buffers to fit extra value if duplicates enabled
+        if (duplicates)
+        {
+            expectedData["a1"] = new[] { 17, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 };
+            expectedData["rows"] = new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0 };
+            expectedData["cols"] = new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 };
+        }
+        else
+        {
+            expectedData["a1"] = new[] { 17, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+            expectedData["rows"] = new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 };
+            expectedData["cols"] = new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 };
+        }
+
+        using (var readQuery = TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx))
+        {
+            array.Open(QueryType.Read);
+            // For duplicates we allocate for 17 values including deleted cell, but we only retrieve 16 valid results
+            Assert.AreEqual(16UL, readQuery.ResultBufferElements()["a1"].Item1);
+            Assert.AreEqual(16UL, readQuery.GetResultDataElements("a1"));
+            array.Close();
+        }
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+    }
+
+    [DataRow(LayoutType.Unordered, "legacy", true)]
+    [DataRow(LayoutType.Unordered, "legacy", false)]
+    [DataRow(LayoutType.Unordered, "refactored", true)]
+    [DataRow(LayoutType.Unordered, "refactored", false)]
+    [DataRow(LayoutType.RowMajor, "legacy", true)]
+    [DataRow(LayoutType.RowMajor, "legacy", false)]
+    [DataRow(LayoutType.RowMajor, "refactored", true)]
+    [DataRow(LayoutType.RowMajor, "refactored", false)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", true)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", false)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", true)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", false)]
+    [DataTestMethod]
+    public void SchemaEvolution(LayoutType layout, string queryReader, bool duplicates)
+    {
+        string arrayName = "deletes-schema-evolution";
+        using var ctx = Context.GetDefault();
+        ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
+        ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
+        InitTest(ctx, arrayName, layout, duplicates);
+        using var array = new Array(ctx, arrayName);
+
+        // We will increment this value according to writes if duplicates are enabled
+        int bufferSize = 16;
+        var readBuffers = new Dictionary<string, System.Array>()
+            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+        var expectedData = new Dictionary<string, System.Array>()
+        {
+            { "a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
+            { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
+            { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
+        };
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+
+        // Evolve schema; Write to evolved array; Read and output array attributes
+        using var schemaEvolution = new ArraySchemaEvolution(ctx);
+        using var a2 = new Attribute(ctx, "a2", DataType.Float64);
+        a2.SetFillValue(-1.0);
+        schemaEvolution.AddAttribute(a2);
+        array.Evolve(schemaEvolution);
+        Logger.LogMessage("Initial array schema: ");
+        TestUtil.PrintLocalSchema(arrayName);
+        array.Open(QueryType.Read);
+        Assert.IsTrue(array.Schema().HasAttribute("a2"));
+        array.Close();
+
+        // Write to evolved array
+        var writeData = new Dictionary<string, System.Array>()
+        {
+            { "a1", new[] { 1 } },
+            { "a2", new[] { 1.0 } },
+            { "rows", new[] { 1 } },
+            { "cols", new[] { 1 } },
+        };
+        using var writeQuery = TestUtil.WriteArray(array, layout, writeData, ctx: ctx);
+        Assert.AreEqual(QueryStatus.Completed, writeQuery.Status());
+        bufferSize = duplicates ? ++bufferSize : bufferSize;
+        readBuffers = new()
+        { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] },
+            { "a1", new int[bufferSize] }, { "a2", new double[bufferSize] } };
+
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+        if (duplicates)
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
+                { "a2", new[] { -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
+                    -1.0, -1.0, -1.0, } },
+                { "rows", new[] { 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
+                { "cols", new[] { 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
+            };
+        }
+        else
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
+                { "a2", new[] { 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
+                    -1.0, -1.0, } },
+                { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
+                { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
+            };
+        }
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+
+        // Repeat write to produce another fragment
+        writeData = new Dictionary<string, System.Array>()
+        {
+            { "a1", new[] { 1 } },
+            { "a2", new[] { 1.0 } },
+            { "rows", new[] { 1 } },
+            { "cols", new[] { 1 } },
+        };
+        bufferSize = duplicates ? ++bufferSize : bufferSize;
+        TestUtil.WriteArray(array, layout, writeData, ctx: ctx, keepOpen: false);
+        readBuffers = new()
+        { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] },
+            { "a1", new int[bufferSize] }, { "a2", new double[bufferSize] } };
+
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+        if (duplicates)
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
+                { "a2", new[] { 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
+                    -1.0, -1.0, -1.0, -1.0, } },
+                { "rows", new[] { 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
+                { "cols", new[] { 1, 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
+            };
+        }
+        else
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
+                { "a2", new[] { 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
+                    -1.0, -1.0, } },
+                { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
+                { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
+            };
+        }
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+
+        // Issue a delete
+        var deleteTime = (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds();
+        using var delArray = new Array(ctx, arrayName);
+        delArray.SetOpenTimestampStart(deleteTime);
+        delArray.SetOpenTimestampEnd(deleteTime);
+        delArray.Open(QueryType.Delete);
+        using var deleteQuery = new Query(delArray, QueryType.Delete);
+        using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
+        using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
+        using var andCondition = rowsCondition & colsCondition;
+        deleteQuery.SetCondition(andCondition);
+        deleteQuery.Submit();
+        Logger.LogMessage($"Delete timestamp: {deleteTime}");
+        delArray.Close();
+        Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
+
+        // Read before the timestamp of the delete
+        readBuffers = new()
+        { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] },
+            { "a1", new int[bufferSize] }, { "a2", new double[bufferSize] } };
+        TestUtil.ReadArray(array, layout, readBuffers, timestampRange: (0, deleteTime-1), ctx: ctx, keepOpen: false);
+        Logger.LogMessage("\nArray set to open before delete");
+        // We opened pre-delete so expectedData should not change
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+
+        // Read after the timestamp of the delete
+        readBuffers = new()
+        { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] },
+            { "a1", new int[bufferSize] }, { "a2", new double[bufferSize] } };
+        TestUtil.ReadArray(array, layout, readBuffers, timestampRange: (0, deleteTime), ctx: ctx, keepOpen: false);
+
+        if (duplicates)
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0 } },
+                { "a2", new[] { -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
+                    -1.0, 0, 0, 0 } },
+                { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0, 0, 0 } },
+                { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0 } },
+            };
+        }
+        else
+        {
+            expectedData = new Dictionary<string, System.Array>()
             {
                 { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
-                { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0 } },
+                { "a2", new[] { -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
+                    -1.0, 0 } },
+                { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0} },
                 { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
             };
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
         }
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
 
-        [DataRow(LayoutType.Unordered, "legacy", true)]
-        [DataRow(LayoutType.Unordered, "legacy", false)]
-        [DataRow(LayoutType.Unordered, "refactored", true)]
-        [DataRow(LayoutType.Unordered, "refactored", false)]
-        [DataRow(LayoutType.RowMajor, "legacy", true)]
-        [DataRow(LayoutType.RowMajor, "legacy", false)]
-        [DataRow(LayoutType.RowMajor, "refactored", true)]
-        [DataRow(LayoutType.RowMajor, "refactored", false)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", true)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", false)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", true)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", false)]
-        [DataTestMethod]
-        public void VaryingCells(LayoutType layout, string queryReader, bool duplicates)
+        // Remove attribute (a2)
+        using var schemaEvolution2 = new ArraySchemaEvolution(ctx);
+        schemaEvolution2.DropAttribute("a2");
+        array.Evolve(schemaEvolution2);
+        Logger.LogMessage($"Schema after removing attribute (a2)");
+        TestUtil.PrintLocalSchema(array.Uri());
+        array.SetOpenTimestampStart(0);
+        array.SetOpenTimestampEnd(ulong.MaxValue);
+        array.Open(QueryType.Read);
+        Assert.IsFalse(array.Schema().HasAttribute("a2"));
+        array.Close();
+
+        // Read remaining attribute before delete and evolution
+        readBuffers = new()
+            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
+        TestUtil.ReadArray(array, layout, readBuffers, timestampRange: (0, deleteTime-1), ctx: ctx, keepOpen: false);
+        Assert.IsTrue(expectedData.Remove("a2"));
+
+        if (duplicates)
         {
-            string arrayName = "deletes-varying-cells";
-            using var ctx = Context.GetDefault();
-            ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
-            ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
-            InitTest(ctx, arrayName, layout, duplicates);
-            using var array = new Array(ctx, arrayName);
-
-            DeleteFour(ctx, array, layout, duplicates);
-
-            // Delete 1 cell
-            array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(array, QueryType.Delete);
-            using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
-            using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
-            using var andCondition = colsCondition & rowsCondition;
-            deleteQuery.SetCondition(andCondition);
-            deleteQuery.Submit();
-            array.Close();
-            Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
-            var readBuffers = new Dictionary<string, System.Array>
-                { { "rows", new int[16] }, { "cols", new int[16] }, { "a1", new int[16] } };
-            TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-            var expectedData = new Dictionary<string, System.Array>()
+            expectedData = new Dictionary<string, System.Array>()
             {
-                { "a1", new[] { 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15, 0, 0, 0, 0, 0 } },
-                { "rows", new[] { 1, 1, 2, 2, 2, 3, 3, 3, 4, 4, 4, 0, 0, 0, 0, 0 } },
-                { "cols", new[] { 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 0, 0, 0, 0, 0 } },
+                { "a1", new[] { 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
+                { "rows", new[] { 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
+                { "cols", new[] { 1, 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
             };
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-
-            // Delete 6 cells
-            // + The OR condition overlaps on (3, 4)
-            // + (3, 2) was deleted by a previous delete query
-            array.Open(QueryType.Delete);
-            using var deleteQuery2 = new Query(array, QueryType.Delete);
-            using var colsCondition2 = QueryCondition.Create(ctx, "cols", 4, QueryConditionOperatorType.Equal);
-            using var rowsCondition2 = QueryCondition.Create(ctx, "rows", 3, QueryConditionOperatorType.Equal);
-            using var orCondition = colsCondition2 | rowsCondition2;
-            deleteQuery2.SetCondition(orCondition);
-            deleteQuery2.Submit();
-            array.Close();
-            Assert.AreEqual(QueryStatus.Completed, deleteQuery2.Status());
-
-            // Check for expected values
-            readBuffers = new()
-                { { "rows", new int[16] }, { "cols", new int[16] }, { "a1", new int[16] } };
-            TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-            expectedData["a1"] = new[] { 2, 3, 5, 6, 7, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0 };
-            expectedData["rows"] = new[] { 1, 1, 2, 2, 2, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0 };
-            expectedData["cols"] = new[] { 2, 3, 1, 2, 3, 1, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0 };
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
         }
-
-        [DataRow(LayoutType.Unordered, "legacy", true)]
-        [DataRow(LayoutType.Unordered, "legacy", false)]
-        [DataRow(LayoutType.Unordered, "refactored", true)]
-        [DataRow(LayoutType.Unordered, "refactored", false)]
-        [DataRow(LayoutType.RowMajor, "legacy", true)]
-        [DataRow(LayoutType.RowMajor, "legacy", false)]
-        [DataRow(LayoutType.RowMajor, "refactored", true)]
-        [DataRow(LayoutType.RowMajor, "refactored", false)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", true)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", false)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", true)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", false)]
-        [DataTestMethod]
-        public void MultipleFragments(LayoutType layout, string queryReader, bool duplicates)
+        else
         {
-            string arrayName = "deletes-multiple-fragments";
-            using var ctx = Context.GetDefault();
-            ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
-            ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
-            InitTest(ctx, arrayName, layout, duplicates);
-            using var array = new Array(ctx, arrayName);
-
-            // Delete single cell
-            array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(array, QueryType.Delete);
-            using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
-            using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
-            using var andCondition = rowsCondition & colsCondition;
-            deleteQuery.SetCondition(andCondition);
-            deleteQuery.Submit();
-            array.Close();
-            Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
-
-            int bufferSize = 16;
-            var readBuffers = new Dictionary<string, System.Array>
-                { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
-            using (var readQuery = TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx)) {
-                array.Open(QueryType.Read);
-                Assert.AreEqual(15UL, readQuery.ResultBufferElements()["a1"].Item1);
-                Assert.AreEqual(15UL, readQuery.GetResultDataElements("a1"));
-                array.Close();
-            }
-            var expectedData = new Dictionary<string, System.Array>()
-            {
-                { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
-                { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0 } },
-                { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
-            };
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-
-            // Re-add; If duplicates are enabled result buffer size will grow
-            bufferSize = duplicates ? ++bufferSize : bufferSize;
-            using var writeQuery = TestUtil.WriteArray(array, layout, new()
-                { {"rows", new[] {1}}, {"cols", new[] {1}}, {"a1", new[] {17}} }, ctx: ctx);
-            Assert.AreEqual(QueryStatus.Completed, writeQuery.Status());
-            readBuffers = new()
-                { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
-
-            // Scale buffers to fit extra value if duplicates enabled
-            if (duplicates)
-            {
-                expectedData["a1"] = new[] { 17, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 };
-                expectedData["rows"] = new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0 };
-                expectedData["cols"] = new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 };
-            }
-            else
-            {
-                expectedData["a1"] = new[] { 17, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
-                expectedData["rows"] = new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 };
-                expectedData["cols"] = new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 };
-            }
-
-            using (var readQuery = TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx))
-            {
-                array.Open(QueryType.Read);
-                // For duplicates we allocate for 17 values including deleted cell, but we only retrieve 16 valid results
-                Assert.AreEqual(16UL, readQuery.ResultBufferElements()["a1"].Item1);
-                Assert.AreEqual(16UL, readQuery.GetResultDataElements("a1"));
-                array.Close();
-            }
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-        }
-
-        [DataRow(LayoutType.Unordered, "legacy", true)]
-        [DataRow(LayoutType.Unordered, "legacy", false)]
-        [DataRow(LayoutType.Unordered, "refactored", true)]
-        [DataRow(LayoutType.Unordered, "refactored", false)]
-        [DataRow(LayoutType.RowMajor, "legacy", true)]
-        [DataRow(LayoutType.RowMajor, "legacy", false)]
-        [DataRow(LayoutType.RowMajor, "refactored", true)]
-        [DataRow(LayoutType.RowMajor, "refactored", false)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", true)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", false)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", true)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", false)]
-        [DataTestMethod]
-        public void SchemaEvolution(LayoutType layout, string queryReader, bool duplicates)
-        {
-            string arrayName = "deletes-schema-evolution";
-            using var ctx = Context.GetDefault();
-            ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
-            ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
-            InitTest(ctx, arrayName, layout, duplicates);
-            using var array = new Array(ctx, arrayName);
-
-            // We will increment this value according to writes if duplicates are enabled
-            int bufferSize = 16;
-            var readBuffers = new Dictionary<string, System.Array>()
-                { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
-            TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-            var expectedData = new Dictionary<string, System.Array>()
+            expectedData = new Dictionary<string, System.Array>()
             {
                 { "a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
                 { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
                 { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
             };
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+        }
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
 
-            // Evolve schema; Write to evolved array; Read and output array attributes
-            using var schemaEvolution = new ArraySchemaEvolution(ctx);
-            using var a2 = new Attribute(ctx, "a2", DataType.Float64);
-            a2.SetFillValue(-1.0);
-            schemaEvolution.AddAttribute(a2);
-            array.Evolve(schemaEvolution);
-            Logger.LogMessage("Initial array schema: ");
-            TestUtil.PrintLocalSchema(arrayName);
-            array.Open(QueryType.Read);
-            Assert.IsTrue(array.Schema().HasAttribute("a2"));
-            array.Close();
+        readBuffers = new()
+            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
+        TestUtil.ReadArray(array, layout, readBuffers, timestampRange: (0, deleteTime), ctx: ctx, keepOpen: false);
 
-            // Write to evolved array
-            var writeData = new Dictionary<string, System.Array>()
+        // Read remaining attribute after delete
+        if (duplicates)
+        {
+            expectedData = new Dictionary<string, System.Array>()
             {
-                { "a1", new[] { 1 } },
-                { "a2", new[] { 1.0 } },
-                { "rows", new[] { 1 } },
-                { "cols", new[] { 1 } },
+                { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0 } },
+                { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0, 0, 0 } },
+                { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0 } },
             };
-            using var writeQuery = TestUtil.WriteArray(array, layout, writeData, ctx: ctx);
+        }
+        else
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
+                { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0} },
+                { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
+            };
+        }
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+
+        // Write some cells
+        TestUtil.WriteArray(array, layout, new()
+            { {"rows", new[] {2}}, {"cols", new[] {1}}, {"a1", new[] {18}} }, ctx: ctx, keepOpen: false);
+        bufferSize = duplicates ? ++bufferSize : bufferSize;
+        readBuffers = new()
+            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+
+        if (duplicates)
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 2, 3, 4, 5, 18, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0 } },
+                { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0, 0, 0 } },
+                { "cols", new[] { 2, 3, 4, 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0 } },
+            };
+        }
+        else
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 2, 3, 4, 18, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
+                { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0} },
+                { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
+            };
+        }
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+
+        // Make a delete condition on an attribute
+        array.Open(QueryType.Delete);
+        using var deleteQuery2 = new Query(array, QueryType.Delete);
+        using var attrCondition = QueryCondition.Create(ctx, "a1", 10, QueryConditionOperatorType.LessThan);
+        deleteQuery2.SetCondition(attrCondition);
+        deleteQuery2.Submit();
+        array.Close();
+        Assert.AreEqual(QueryStatus.Completed, deleteQuery2.Status());
+
+        // Check for expected values
+        readBuffers = new()
+            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+
+        if (duplicates)
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 18, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+                { "rows", new[] {  2, 3, 3, 3, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+                { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
+            };
+        }
+        else
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 18, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 0, 0, 0, 0 } },
+                { "rows", new[] {  2, 3, 3, 3, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0 } },
+                { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0 } },
+            };
+        }
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+    }
+
+    [DataRow(LayoutType.Unordered, "legacy", true)]
+    [DataRow(LayoutType.Unordered, "legacy", false)]
+    [DataRow(LayoutType.Unordered, "refactored", true)]
+    [DataRow(LayoutType.Unordered, "refactored", false)]
+    [DataRow(LayoutType.RowMajor, "legacy", true)]
+    [DataRow(LayoutType.RowMajor, "legacy", false)]
+    [DataRow(LayoutType.RowMajor, "refactored", true)]
+    [DataRow(LayoutType.RowMajor, "refactored", false)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", true)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", false)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", true)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", false)]
+    [DataTestMethod]
+    public void SameFragment(LayoutType layout, string queryReader, bool duplicates)
+    {
+        string arrayName = "deletes-same-fragment";
+        using var ctx = Context.GetDefault();
+        ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
+        ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
+        using var array = new Array(ctx, arrayName);
+        InitTest(ctx, arrayName, layout, duplicates);
+        // For tests with duplicates we will increment bufferSize with write queries
+        int bufferSize = 16;
+
+        // Write a value to the array, creating a second fragment; Get fragment timestamp from writeQuery
+        bufferSize = duplicates ? ++bufferSize : bufferSize;
+        using var writeQuery = TestUtil.WriteArray(array, layout, new()
+            { {"rows", new[] { 1 }}, {"cols", new[] { 1 }}, {"a1", new[] { 17 }}, }, ctx: ctx);
+        Assert.AreEqual(1U, writeQuery.FragmentNum());
+        var writeTime = writeQuery.FragmentTimestampRange(0);
+        Logger.LogMessage($"Second fragment timestamp range: {writeTime}");
+        // Apply same write operation to local array used to check expected attribute values
+        var readBuffers = new Dictionary<string, System.Array>()
+            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+
+        var expectedData = new Dictionary<string, System.Array>();
+        if (duplicates)
+        {
+            expectedData = new()
+            {
+                { "a1", new[] { 1, 17, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
+                { "rows", new[] { 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
+                { "cols", new[] { 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
+            };
+        }
+        else
+        {
+            expectedData = new()
+            {
+                { "a1", new[] { 17, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16} },
+                { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
+                { "cols", new[] {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
+            };
+        }
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+
+        // Delete the new value from the array, opening at previous write fragment timestamp
+        array.SetOpenTimestampStart(ulong.MinValue);
+        array.SetOpenTimestampEnd(writeTime.Item1);
+        array.Open(QueryType.Delete);
+        Logger.LogMessage($"Array opened at between {array.OpenTimestampStart()} and {array.OpenTimestampEnd()}");
+        using var deleteQuery = new Query(array, QueryType.Delete);
+        using var attrCondition = QueryCondition.Create(ctx, "a1", 17, QueryConditionOperatorType.Equal);
+        deleteQuery.SetCondition(attrCondition);
+        deleteQuery.Submit();
+        array.Close();
+        Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
+
+        // Check for expected values
+        readBuffers = new()
+            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+        if (duplicates)
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
+                { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0 } },
+                { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
+            };
+        }
+        else
+        {
+            expectedData = new Dictionary<string, System.Array>()
+            {
+                { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
+                { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0 } },
+                { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
+            };
+        }
+
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+    }
+
+    [DataRow(LayoutType.Unordered, "legacy", true)]
+    [DataRow(LayoutType.Unordered, "legacy", false)]
+    [DataRow(LayoutType.Unordered, "refactored", true)]
+    [DataRow(LayoutType.Unordered, "refactored", false)]
+    [DataRow(LayoutType.RowMajor, "legacy", true)]
+    [DataRow(LayoutType.RowMajor, "legacy", false)]
+    [DataRow(LayoutType.RowMajor, "refactored", true)]
+    [DataRow(LayoutType.RowMajor, "refactored", false)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", true)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", false)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", true)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", false)]
+    [DataTestMethod]
+    public void SequenceTest(LayoutType layout, string queryReader, bool duplicates)
+    {
+        var arrayName = "deletes-sequence-test";
+
+        using var ctx = Context.GetDefault();
+        ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
+        ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
+
+        using var cols = Dimension.Create(ctx, "cols", 1, 6, 2);
+        using var a0 = Attribute.Create<int>(ctx, "a0");
+        using var domain = new Domain(ctx);
+        domain.AddDimension(cols);
+        using var schema = new ArraySchema(ctx, ArrayType.Sparse);
+        schema.SetDomain(domain);
+        schema.AddAttribute(a0);
+        schema.SetAllowsDups(duplicates);
+        schema.Check();
+        if (Directory.Exists(arrayName))
+        {
+            Directory.Delete(arrayName, true);
+        }
+
+        Array.Create(ctx, arrayName, schema);
+        using var array = new Array(ctx, arrayName);
+
+        // Write { 1, 2, 3 }
+        ulong nextOpen = 0;
+        var readBuffers = new Dictionary<string, System.Array>
+            { {"cols", new int[6]}, {"a0", new int[6]} };
+        var expectedData = new Dictionary<string, System.Array>()
+        {
+            { "a0", new[] { 1, 2, 3, 0, 0, 0 } },
+            { "cols", new[] { 1, 2, 3, 0, 0, 0 } },
+        };
+        using (var writeQuery = TestUtil.WriteArray(array, layout, new()
+                   { { "cols", new[] { 1, 2, 3 } }, { "a0", new[] { 1, 2, 3 } } }, ctx: ctx))
+        {
             Assert.AreEqual(QueryStatus.Completed, writeQuery.Status());
-            bufferSize = duplicates ? ++bufferSize : bufferSize;
-            readBuffers = new()
-            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] },
-                { "a1", new int[bufferSize] }, { "a2", new double[bufferSize] } };
-
             TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-            if (duplicates)
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
-                    { "a2", new[] { -1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
-                        -1.0, -1.0, -1.0, } },
-                    { "rows", new[] { 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
-                    { "cols", new[] { 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
-                };
-            }
-            else
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
-                    { "a2", new[] { 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
-                        -1.0, -1.0, } },
-                    { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
-                    { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
-                };
-            }
             TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-
-            // Repeat write to produce another fragment
-            writeData = new Dictionary<string, System.Array>()
-            {
-                { "a1", new[] { 1 } },
-                { "a2", new[] { 1.0 } },
-                { "rows", new[] { 1 } },
-                { "cols", new[] { 1 } },
-            };
-            bufferSize = duplicates ? ++bufferSize : bufferSize;
-            TestUtil.WriteArray(array, layout, writeData, ctx: ctx, keepOpen: false);
-            readBuffers = new()
-            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] },
-                { "a1", new int[bufferSize] }, { "a2", new double[bufferSize] } };
-
-            TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-            if (duplicates)
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
-                    { "a2", new[] { 1.0, 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
-                        -1.0, -1.0, -1.0, -1.0, } },
-                    { "rows", new[] { 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
-                    { "cols", new[] { 1, 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
-                };
-            }
-            else
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
-                    { "a2", new[] { 1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
-                        -1.0, -1.0, } },
-                    { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
-                    { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
-                };
-            }
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-
-            // Issue a delete
-            var deleteTime = (ulong)DateTimeOffset.Now.ToUnixTimeMilliseconds();
-            using var delArray = new Array(ctx, arrayName);
-            delArray.SetOpenTimestampStart(deleteTime);
-            delArray.SetOpenTimestampEnd(deleteTime);
-            delArray.Open(QueryType.Delete);
-            using var deleteQuery = new Query(delArray, QueryType.Delete);
-            using var rowsCondition = QueryCondition.Create(ctx, "rows", 1, QueryConditionOperatorType.Equal);
-            using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
-            using var andCondition = rowsCondition & colsCondition;
-            deleteQuery.SetCondition(andCondition);
-            deleteQuery.Submit();
-            Logger.LogMessage($"Delete timestamp: {deleteTime}");
-            delArray.Close();
-            Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
-
-            // Read before the timestamp of the delete
-            readBuffers = new()
-            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] },
-                { "a1", new int[bufferSize] }, { "a2", new double[bufferSize] } };
-            TestUtil.ReadArray(array, layout, readBuffers, timestampRange: (0, deleteTime-1), ctx: ctx, keepOpen: false);
-            Logger.LogMessage("\nArray set to open before delete");
-            // We opened pre-delete so expectedData should not change
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-
-            // Read after the timestamp of the delete
-            readBuffers = new()
-            { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] },
-                { "a1", new int[bufferSize] }, { "a2", new double[bufferSize] } };
-            TestUtil.ReadArray(array, layout, readBuffers, timestampRange: (0, deleteTime), ctx: ctx, keepOpen: false);
-
-            if (duplicates)
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0 } },
-                    { "a2", new[] { -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
-                        -1.0, 0, 0, 0 } },
-                    { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0, 0, 0 } },
-                    { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0 } },
-                };
-            }
-            else
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
-                    { "a2", new[] { -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0,
-                        -1.0, 0 } },
-                    { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0} },
-                    { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
-                };
-            }
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-
-            // Remove attribute (a2)
-            using var schemaEvolution2 = new ArraySchemaEvolution(ctx);
-            schemaEvolution2.DropAttribute("a2");
-            array.Evolve(schemaEvolution2);
-            Logger.LogMessage($"Schema after removing attribute (a2)");
-            TestUtil.PrintLocalSchema(array.Uri());
-            array.SetOpenTimestampStart(0);
-            array.SetOpenTimestampEnd(ulong.MaxValue);
-            array.Open(QueryType.Read);
-            Assert.IsFalse(array.Schema().HasAttribute("a2"));
-            array.Close();
-
-            // Read remaining attribute before delete and evolution
-            readBuffers = new()
-                { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
-            TestUtil.ReadArray(array, layout, readBuffers, timestampRange: (0, deleteTime-1), ctx: ctx, keepOpen: false);
-            Assert.IsTrue(expectedData.Remove("a2"));
-
-            if (duplicates)
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 1, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
-                    { "rows", new[] { 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
-                    { "cols", new[] { 1, 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
-                };
-            }
-            else
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
-                    { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
-                    { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
-                };
-            }
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-
-            readBuffers = new()
-                { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
-            TestUtil.ReadArray(array, layout, readBuffers, timestampRange: (0, deleteTime), ctx: ctx, keepOpen: false);
-
-            // Read remaining attribute after delete
-            if (duplicates)
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0 } },
-                    { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0, 0, 0 } },
-                    { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0 } },
-                };
-            }
-            else
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
-                    { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0} },
-                    { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
-                };
-            }
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-
-            // Write some cells
-            TestUtil.WriteArray(array, layout, new()
-                { {"rows", new[] {2}}, {"cols", new[] {1}}, {"a1", new[] {18}} }, ctx: ctx, keepOpen: false);
-            bufferSize = duplicates ? ++bufferSize : bufferSize;
-            readBuffers = new()
-                { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
-            TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-
-            if (duplicates)
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 2, 3, 4, 5, 18, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0 } },
-                    { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0, 0, 0 } },
-                    { "cols", new[] { 2, 3, 4, 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0 } },
-                };
-            }
-            else
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 2, 3, 4, 18, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
-                    { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0} },
-                    { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
-                };
-            }
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-
-            // Make a delete condition on an attribute
-            array.Open(QueryType.Delete);
-            using var deleteQuery2 = new Query(array, QueryType.Delete);
-            using var attrCondition = QueryCondition.Create(ctx, "a1", 10, QueryConditionOperatorType.LessThan);
-            deleteQuery2.SetCondition(attrCondition);
-            deleteQuery2.Submit();
-            array.Close();
-            Assert.AreEqual(QueryStatus.Completed, deleteQuery2.Status());
-
-            // Check for expected values
-            readBuffers = new()
-                { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
-            TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-
-            if (duplicates)
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 18, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
-                    { "rows", new[] {  2, 3, 3, 3, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
-                    { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 } },
-                };
-            }
-            else
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 18, 10, 11, 12, 13, 14, 15, 16, 0, 0, 0, 0, 0, 0, 0, 0 } },
-                    { "rows", new[] {  2, 3, 3, 3, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0 } },
-                    { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0 } },
-                };
-            }
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-        }
-
-        [DataRow(LayoutType.Unordered, "legacy", true)]
-        [DataRow(LayoutType.Unordered, "legacy", false)]
-        [DataRow(LayoutType.Unordered, "refactored", true)]
-        [DataRow(LayoutType.Unordered, "refactored", false)]
-        [DataRow(LayoutType.RowMajor, "legacy", true)]
-        [DataRow(LayoutType.RowMajor, "legacy", false)]
-        [DataRow(LayoutType.RowMajor, "refactored", true)]
-        [DataRow(LayoutType.RowMajor, "refactored", false)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", true)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", false)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", true)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", false)]
-        [DataTestMethod]
-        public void SameFragment(LayoutType layout, string queryReader, bool duplicates)
-        {
-            string arrayName = "deletes-same-fragment";
-            using var ctx = Context.GetDefault();
-            ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
-            ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
-            using var array = new Array(ctx, arrayName);
-            InitTest(ctx, arrayName, layout, duplicates);
-            // For tests with duplicates we will increment bufferSize with write queries
-            int bufferSize = 16;
-
-            // Write a value to the array, creating a second fragment; Get fragment timestamp from writeQuery
-            bufferSize = duplicates ? ++bufferSize : bufferSize;
-            using var writeQuery = TestUtil.WriteArray(array, layout, new()
-                { {"rows", new[] { 1 }}, {"cols", new[] { 1 }}, {"a1", new[] { 17 }}, }, ctx: ctx);
-            Assert.AreEqual(1U, writeQuery.FragmentNum());
             var writeTime = writeQuery.FragmentTimestampRange(0);
-            Logger.LogMessage($"Second fragment timestamp range: {writeTime}");
-            // Apply same write operation to local array used to check expected attribute values
-            var readBuffers = new Dictionary<string, System.Array>()
-                { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
-            TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-
-            var expectedData = new Dictionary<string, System.Array>();
-            if (duplicates)
-            {
-                expectedData = new()
-                {
-                    { "a1", new[] { 1, 17, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 } },
-                    { "rows", new[] { 1, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
-                    { "cols", new[] { 1, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
-                };
-            }
-            else
-            {
-                expectedData = new()
-                {
-                    { "a1", new[] { 17, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16} },
-                    { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 } },
-                    { "cols", new[] {1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 } },
-                };
-            }
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-
-            // Delete the new value from the array, opening at previous write fragment timestamp
-            array.SetOpenTimestampStart(ulong.MinValue);
-            array.SetOpenTimestampEnd(writeTime.Item1);
-            array.Open(QueryType.Delete);
-            Logger.LogMessage($"Array opened at between {array.OpenTimestampStart()} and {array.OpenTimestampEnd()}");
-            using var deleteQuery = new Query(array, QueryType.Delete);
-            using var attrCondition = QueryCondition.Create(ctx, "a1", 17, QueryConditionOperatorType.Equal);
-            deleteQuery.SetCondition(attrCondition);
-            deleteQuery.Submit();
-            array.Close();
-            Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
-
-            // Check for expected values
-            readBuffers = new()
-                { { "rows", new int[bufferSize] }, { "cols", new int[bufferSize] }, { "a1", new int[bufferSize] } };
-            TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-            if (duplicates)
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
-                    { "rows", new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0 } },
-                    { "cols", new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
-                };
-            }
-            else
-            {
-                expectedData = new Dictionary<string, System.Array>()
-                {
-                    { "a1", new[] { 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 0 } },
-                    { "rows", new[] { 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 0 } },
-                    { "cols", new[] { 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 0 } },
-                };
-            }
-
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+            nextOpen = writeTime.Item2 + 20;
+            // Delete[4]
+            array.SetOpenTimestampEnd(writeTime.Item2+10);
         }
 
-        [DataRow(LayoutType.Unordered, "legacy", true)]
-        [DataRow(LayoutType.Unordered, "legacy", false)]
-        [DataRow(LayoutType.Unordered, "refactored", true)]
-        [DataRow(LayoutType.Unordered, "refactored", false)]
-        [DataRow(LayoutType.RowMajor, "legacy", true)]
-        [DataRow(LayoutType.RowMajor, "legacy", false)]
-        [DataRow(LayoutType.RowMajor, "refactored", true)]
-        [DataRow(LayoutType.RowMajor, "refactored", false)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", true)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", false)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", true)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", false)]
-        [DataTestMethod]
-        public void SequenceTest(LayoutType layout, string queryReader, bool duplicates)
+        array.Open(QueryType.Delete);
+        using var deleteQuery = new Query(array, QueryType.Delete);
+        using var attrCondition = QueryCondition.Create(ctx, "a0", 4, QueryConditionOperatorType.Equal);
+        deleteQuery.SetCondition(attrCondition);
+        deleteQuery.Submit();
+        array.Close();
+        Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
+
+        // Write { 4, 5, 6 }
+        // Ensure that the write is performed with a unique timestamp
+        // + If the previous DELETE happens at the same timestamp of this WRITE the DELETE will win
+        array.SetOpenTimestampEnd(nextOpen);
+        using (var writeQuery = TestUtil.WriteArray(array, layout, new()
+                   { { "cols", new[] { 4, 5, 6 } }, { "a0", new[] { 4, 5, 6 } } }, ctx: ctx))
         {
-            var arrayName = "deletes-sequence-test";
+            Assert.AreEqual(QueryStatus.Completed, writeQuery.Status());
 
-            using var ctx = Context.GetDefault();
-            ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
-            ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
-
-            using var cols = Dimension.Create(ctx, "cols", 1, 6, 2);
-            using var a0 = Attribute.Create<int>(ctx, "a0");
-            using var domain = new Domain(ctx);
-            domain.AddDimension(cols);
-            using var schema = new ArraySchema(ctx, ArrayType.Sparse);
-            schema.SetDomain(domain);
-            schema.AddAttribute(a0);
-            schema.SetAllowsDups(duplicates);
-            schema.Check();
-            if (Directory.Exists(arrayName))
-            {
-                Directory.Delete(arrayName, true);
-            }
-
-            Array.Create(ctx, arrayName, schema);
-            using var array = new Array(ctx, arrayName);
-
-            // Write { 1, 2, 3 }
-            ulong nextOpen = 0;
-            var readBuffers = new Dictionary<string, System.Array>
-                { {"cols", new int[6]}, {"a0", new int[6]} };
-            var expectedData = new Dictionary<string, System.Array>()
-            {
-                { "a0", new[] { 1, 2, 3, 0, 0, 0 } },
-                { "cols", new[] { 1, 2, 3, 0, 0, 0 } },
-            };
-            using (var writeQuery = TestUtil.WriteArray(array, layout, new()
-                       { { "cols", new[] { 1, 2, 3 } }, { "a0", new[] { 1, 2, 3 } } }, ctx: ctx))
-            {
-                Assert.AreEqual(QueryStatus.Completed, writeQuery.Status());
-                TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-                TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
-                var writeTime = writeQuery.FragmentTimestampRange(0);
-                nextOpen = writeTime.Item2 + 20;
-                // Delete[4]
-                array.SetOpenTimestampEnd(writeTime.Item2+10);
-            }
-
-            array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(array, QueryType.Delete);
-            using var attrCondition = QueryCondition.Create(ctx, "a0", 4, QueryConditionOperatorType.Equal);
-            deleteQuery.SetCondition(attrCondition);
-            deleteQuery.Submit();
-            array.Close();
-            Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
-
-            // Write { 4, 5, 6 }
-            // Ensure that the write is performed with a unique timestamp
-            // + If the previous DELETE happens at the same timestamp of this WRITE the DELETE will win
-            array.SetOpenTimestampEnd(nextOpen);
-            using (var writeQuery = TestUtil.WriteArray(array, layout, new()
-                       { { "cols", new[] { 4, 5, 6 } }, { "a0", new[] { 4, 5, 6 } } }, ctx: ctx))
-            {
-                Assert.AreEqual(QueryStatus.Completed, writeQuery.Status());
-
-            }
-
-            // Check for expected values
-            readBuffers = new() { {"cols", new int[6]}, {"a0", new int[6]} };
-            TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
-            expectedData["a0"] = new[] { 1, 2, 3, 4, 5, 6 };
-            expectedData["cols"] = new[] { 1, 2, 3, 4, 5, 6 };
-            TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
         }
 
-        [DataRow(LayoutType.Unordered, "legacy", true)]
-        [DataRow(LayoutType.Unordered, "legacy", false)]
-        [DataRow(LayoutType.Unordered, "refactored", true)]
-        [DataRow(LayoutType.Unordered, "refactored", false)]
-        [DataRow(LayoutType.RowMajor, "legacy", true)]
-        [DataRow(LayoutType.RowMajor, "legacy", false)]
-        [DataRow(LayoutType.RowMajor, "refactored", true)]
-        [DataRow(LayoutType.RowMajor, "refactored", false)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", true)]
-        [DataRow(LayoutType.GlobalOrder, "legacy", false)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", true)]
-        [DataRow(LayoutType.GlobalOrder, "refactored", false)]
-        [DataTestMethod]
-        public void TestStrings(LayoutType layout, string queryReader, bool duplicates)
+        // Check for expected values
+        readBuffers = new() { {"cols", new int[6]}, {"a0", new int[6]} };
+        TestUtil.ReadArray(array, layout, readBuffers, ctx: ctx, keepOpen: false);
+        expectedData["a0"] = new[] { 1, 2, 3, 4, 5, 6 };
+        expectedData["cols"] = new[] { 1, 2, 3, 4, 5, 6 };
+        TestUtil.CompareBuffers(expectedData, readBuffers, duplicates);
+    }
+
+    [DataRow(LayoutType.Unordered, "legacy", true)]
+    [DataRow(LayoutType.Unordered, "legacy", false)]
+    [DataRow(LayoutType.Unordered, "refactored", true)]
+    [DataRow(LayoutType.Unordered, "refactored", false)]
+    [DataRow(LayoutType.RowMajor, "legacy", true)]
+    [DataRow(LayoutType.RowMajor, "legacy", false)]
+    [DataRow(LayoutType.RowMajor, "refactored", true)]
+    [DataRow(LayoutType.RowMajor, "refactored", false)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", true)]
+    [DataRow(LayoutType.GlobalOrder, "legacy", false)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", true)]
+    [DataRow(LayoutType.GlobalOrder, "refactored", false)]
+    [DataTestMethod]
+    public void TestStrings(LayoutType layout, string queryReader, bool duplicates)
+    {
+        var arrayName = "deletes-strings-test";
+
+        using var ctx = Context.GetDefault();
+        ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
+        ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
+
+        using var cols = Dimension.Create(ctx, "cols", 1, 6, 2);
+        using var a1 = Attribute.Create<string>(ctx, "a1");
+        using var domain = new Domain(ctx);
+        domain.AddDimension(cols);
+        using var schema = new ArraySchema(ctx, ArrayType.Sparse);
+        schema.SetDomain(domain);
+        schema.AddAttribute(a1);
+        schema.SetAllowsDups(duplicates);
+        schema.Check();
+        if (Directory.Exists(arrayName))
         {
-            var arrayName = "deletes-strings-test";
+            Directory.Delete(arrayName, true);
+        }
 
-            using var ctx = Context.GetDefault();
-            ctx.Config().Set("sm.query.sparse_global_order.reader", queryReader);
-            ctx.Config().Set("sm.query.sparse_unordered_with_dups.reader", queryReader);
+        Array.Create(ctx, arrayName, schema);
+        using var array = new Array(ctx, arrayName);
 
-            using var cols = Dimension.Create(ctx, "cols", 1, 6, 2);
-            using var a1 = Attribute.Create<string>(ctx, "a1");
-            using var domain = new Domain(ctx);
-            domain.AddDimension(cols);
-            using var schema = new ArraySchema(ctx, ArrayType.Sparse);
-            schema.SetDomain(domain);
-            schema.AddAttribute(a1);
-            schema.SetAllowsDups(duplicates);
-            schema.Check();
-            if (Directory.Exists(arrayName))
-            {
-                Directory.Delete(arrayName, true);
-            }
+        using var writeQuery = TestUtil.WriteArray(array, layout,
+            buffers: new()
+                { {"cols", new[] {1, 2, 3}}, {"a1", Encoding.UTF8.GetBytes("onetwothree")} },
+            offsets: new Dictionary<string, ulong[]>() { {"a1", new ulong[] { 0, 3, 6 }} });
 
-            Array.Create(ctx, arrayName, schema);
-            using var array = new Array(ctx, arrayName);
-
-            using var writeQuery = TestUtil.WriteArray(array, layout,
-                buffers: new()
-                    { {"cols", new[] {1, 2, 3}}, {"a1", Encoding.UTF8.GetBytes("onetwothree")} },
-                offsets: new Dictionary<string, ulong[]>() { {"a1", new ulong[] { 0, 3, 6 }} });
-
-            var readBuffers = new Dictionary<string, System.Array>() { {"cols", new int[6]}, { "a1", new byte[11] } };
-            var readOffsetBuffers = new Dictionary<string, ulong[]>() { { "a1", new ulong[3] } };
-            using (var readQuery = TestUtil.ReadArray(array, layout, readBuffers, offsets: readOffsetBuffers))
-            {
-                array.Open(QueryType.Read);
-                var bufferElements = readQuery.ResultBufferElements();
-                array.Close();
-                var elementCount = (int)bufferElements["a1"].Item1;
-                Assert.AreEqual((ulong)elementCount, readQuery.GetResultDataElements("a1"));
-                var offsetCount = (int)bufferElements["a1"].Item2!;
-                Assert.AreEqual((ulong)offsetCount, readQuery.GetResultOffsets("a1"));
-                var a1Data = new List<string>();
-                for (int i = 0; i < offsetCount; i++)
-                {
-                    int cellSize = i == offsetCount - 1
-                        ? elementCount - (int)readOffsetBuffers["a1"][i]
-                        : (int)readOffsetBuffers["a1"][i + 1] - (int)readOffsetBuffers["a1"][i];
-                    a1Data.Add(new (Encoding.ASCII.GetChars((byte[])readBuffers["a1"], (int)readOffsetBuffers["a1"][i],
-                        cellSize)));
-                }
-                CollectionAssert.AreEqual(new[] {"one", "two", "three"}, a1Data);
-            }
-
-            array.Open(QueryType.Delete);
-            using var deleteQuery = new Query(array, QueryType.Delete);
-            using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
-            deleteQuery.SetCondition(colsCondition);
-            deleteQuery.Submit();
+        var readBuffers = new Dictionary<string, System.Array>() { {"cols", new int[6]}, { "a1", new byte[11] } };
+        var readOffsetBuffers = new Dictionary<string, ulong[]>() { { "a1", new ulong[3] } };
+        using (var readQuery = TestUtil.ReadArray(array, layout, readBuffers, offsets: readOffsetBuffers))
+        {
+            array.Open(QueryType.Read);
+            var bufferElements = readQuery.ResultBufferElements();
             array.Close();
-            Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
-
-            readBuffers = new Dictionary<string, System.Array>()
-                { {"cols", new int[6]}, { "a1", new byte[11] } };
-            readOffsetBuffers = new Dictionary<string, ulong[]>() { { "a1", new ulong[17] } };
-            using (var readQuery = TestUtil.ReadArray(array, layout, readBuffers, offsets: readOffsetBuffers))
+            var elementCount = (int)bufferElements["a1"].Item1;
+            Assert.AreEqual((ulong)elementCount, readQuery.GetResultDataElements("a1"));
+            var offsetCount = (int)bufferElements["a1"].Item2!;
+            Assert.AreEqual((ulong)offsetCount, readQuery.GetResultOffsets("a1"));
+            var a1Data = new List<string>();
+            for (int i = 0; i < offsetCount; i++)
             {
-                array.Open(QueryType.Read);
-                var bufferElements = readQuery.ResultBufferElements();
-                array.Close();
-
-                var elementCount = (int)bufferElements["a1"].Item1;
-                Assert.AreEqual((ulong)elementCount, readQuery.GetResultDataElements("a1"));
-                var offsetCount = (int)bufferElements["a1"].Item2!;
-                Assert.AreEqual((ulong)offsetCount, readQuery.GetResultOffsets("a1"));
-                var a1Data = new List<string>();
-                for (int i = 0; i < offsetCount; i++)
-                {
-                    int cellSize = i == offsetCount - 1
-                        ? elementCount - (int)readOffsetBuffers["a1"][i]
-                        : (int)readOffsetBuffers["a1"][i + 1] - (int)readOffsetBuffers["a1"][i];
-                    a1Data.Add(new (Encoding.ASCII.GetChars((byte[])readBuffers["a1"], (int)readOffsetBuffers["a1"][i],
-                        cellSize)));
-                }
-
-                Logger.LogMessage(string.Join(", ", a1Data));
-                CollectionAssert.AreEqual(new[] {"two", "three"}, a1Data);
+                int cellSize = i == offsetCount - 1
+                    ? elementCount - (int)readOffsetBuffers["a1"][i]
+                    : (int)readOffsetBuffers["a1"][i + 1] - (int)readOffsetBuffers["a1"][i];
+                a1Data.Add(new (Encoding.ASCII.GetChars((byte[])readBuffers["a1"], (int)readOffsetBuffers["a1"][i],
+                    cellSize)));
             }
+            CollectionAssert.AreEqual(new[] {"one", "two", "three"}, a1Data);
+        }
+
+        array.Open(QueryType.Delete);
+        using var deleteQuery = new Query(array, QueryType.Delete);
+        using var colsCondition = QueryCondition.Create(ctx, "cols", 1, QueryConditionOperatorType.Equal);
+        deleteQuery.SetCondition(colsCondition);
+        deleteQuery.Submit();
+        array.Close();
+        Assert.AreEqual(QueryStatus.Completed, deleteQuery.Status());
+
+        readBuffers = new Dictionary<string, System.Array>()
+            { {"cols", new int[6]}, { "a1", new byte[11] } };
+        readOffsetBuffers = new Dictionary<string, ulong[]>() { { "a1", new ulong[17] } };
+        using (var readQuery = TestUtil.ReadArray(array, layout, readBuffers, offsets: readOffsetBuffers))
+        {
+            array.Open(QueryType.Read);
+            var bufferElements = readQuery.ResultBufferElements();
+            array.Close();
+
+            var elementCount = (int)bufferElements["a1"].Item1;
+            Assert.AreEqual((ulong)elementCount, readQuery.GetResultDataElements("a1"));
+            var offsetCount = (int)bufferElements["a1"].Item2!;
+            Assert.AreEqual((ulong)offsetCount, readQuery.GetResultOffsets("a1"));
+            var a1Data = new List<string>();
+            for (int i = 0; i < offsetCount; i++)
+            {
+                int cellSize = i == offsetCount - 1
+                    ? elementCount - (int)readOffsetBuffers["a1"][i]
+                    : (int)readOffsetBuffers["a1"][i + 1] - (int)readOffsetBuffers["a1"][i];
+                a1Data.Add(new (Encoding.ASCII.GetChars((byte[])readBuffers["a1"], (int)readOffsetBuffers["a1"][i],
+                    cellSize)));
+            }
+
+            Logger.LogMessage(string.Join(", ", a1Data));
+            CollectionAssert.AreEqual(new[] {"two", "three"}, a1Data);
         }
     }
 }

--- a/tests/TileDB.CSharp.Test/DimensionTest.cs
+++ b/tests/TileDB.CSharp.Test/DimensionTest.cs
@@ -1,32 +1,31 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class DimensionTest
 {
-    [TestClass]
-    public class DimensionTest
+    [TestMethod]
+    public void TestDimension() {
+        var context = Context.GetDefault();
+
+        int bound_lower=1, bound_upper=10, extent = 5;
+        var dimension = Dimension.Create(context, "test", bound_lower, bound_upper, extent);
+
+        Assert.AreEqual("test", dimension.Name());
+        Assert.AreEqual(DataType.Int32, dimension.Type());
+        Assert.AreEqual(extent, dimension.TileExtent<int>());
+        var dim_domain = dimension.GetDomain<int>();
+        Assert.AreEqual((1, 10), dim_domain);
+    }
+
+    [TestMethod]
+    public void TestStringDimension()
     {
-        [TestMethod]
-        public void TestDimension() {
-            var context = Context.GetDefault();
+        var context = Context.GetDefault();
 
-            int bound_lower=1, bound_upper=10, extent = 5;
-            var dimension = Dimension.Create(context, "test", bound_lower, bound_upper, extent);
-
-            Assert.AreEqual("test", dimension.Name());
-            Assert.AreEqual(DataType.Int32, dimension.Type());
-            Assert.AreEqual(extent, dimension.TileExtent<int>());
-            var dim_domain = dimension.GetDomain<int>();
-            Assert.AreEqual((1, 10), dim_domain);
-        }
-
-        [TestMethod]
-        public void TestStringDimension()
-        {
-            var context = Context.GetDefault();
-
-            var dimension = Dimension.CreateString(context, "strdim");
-            Assert.AreEqual("strdim", dimension.Name());
-            Assert.AreEqual(DataType.StringAscii, dimension.Type());
-        }
+        var dimension = Dimension.CreateString(context, "strdim");
+        Assert.AreEqual("strdim", dimension.Name());
+        Assert.AreEqual(DataType.StringAscii, dimension.Type());
     }
 }

--- a/tests/TileDB.CSharp.Test/DomainTest.cs
+++ b/tests/TileDB.CSharp.Test/DomainTest.cs
@@ -1,49 +1,48 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class DomainTest
 {
-    [TestClass]
-    public class DomainTest
-    {
-        [TestMethod]
-        public void TestDomain() {
-            // Test context with config
-            var context = Context.GetDefault();
+    [TestMethod]
+    public void TestDomain() {
+        // Test context with config
+        var context = Context.GetDefault();
 
-            // Test creating domain
-            var domain = new Domain(context);
+        // Test creating domain
+        var domain = new Domain(context);
 
-            // Test create dimension
-            uint bound_lower=1, bound_upper=10, extent = 5;
-            var dimension = Dimension.Create(context, "testuint", bound_lower, bound_upper, extent);
+        // Test create dimension
+        uint bound_lower=1, bound_upper=10, extent = 5;
+        var dimension = Dimension.Create(context, "testuint", bound_lower, bound_upper, extent);
 
-            Assert.AreEqual(false, domain.HasDimension("testuint"));
-            domain.AddDimension(dimension);
-            Assert.AreEqual(true, domain.HasDimension("testuint"));
-            Assert.AreEqual(DataType.UInt32, domain.Type());
-            Assert.AreEqual<uint>(1, domain.NDim());
+        Assert.AreEqual(false, domain.HasDimension("testuint"));
+        domain.AddDimension(dimension);
+        Assert.AreEqual(true, domain.HasDimension("testuint"));
+        Assert.AreEqual(DataType.UInt32, domain.Type());
+        Assert.AreEqual<uint>(1, domain.NDim());
 
-            // Test create another dimension
-            int bound_lower2=1, bound_upper2=10, extent2 = 5;
-            var dimension2 = Dimension.Create(context, "testint", bound_lower2, bound_upper2, extent2);
-            domain.AddDimension(dimension2);
-            Assert.AreEqual(true, domain.HasDimension("testint"));
-            Assert.ThrowsException<TileDBException>(() => domain.Type());
-            Assert.AreEqual<uint>(2, domain.NDim());
+        // Test create another dimension
+        int bound_lower2=1, bound_upper2=10, extent2 = 5;
+        var dimension2 = Dimension.Create(context, "testint", bound_lower2, bound_upper2, extent2);
+        domain.AddDimension(dimension2);
+        Assert.AreEqual(true, domain.HasDimension("testint"));
+        Assert.ThrowsException<TileDBException>(() => domain.Type());
+        Assert.AreEqual<uint>(2, domain.NDim());
 
-            var dim1 = domain.Dimension(0);
-            Assert.AreEqual(DataType.UInt32, dim1.Type());
-            var dim2 = domain.Dimension(1);
-            Assert.AreEqual(DataType.Int32, dim2.Type());
+        var dim1 = domain.Dimension(0);
+        Assert.AreEqual(DataType.UInt32, dim1.Type());
+        var dim2 = domain.Dimension(1);
+        Assert.AreEqual(DataType.Int32, dim2.Type());
 
-            dim1 = domain.Dimension("testuint");
-            Assert.AreEqual(DataType.UInt32, dim1.Type());
-            Assert.AreEqual("testuint", dim1.Name());
+        dim1 = domain.Dimension("testuint");
+        Assert.AreEqual(DataType.UInt32, dim1.Type());
+        Assert.AreEqual("testuint", dim1.Name());
 
-            dim2 = domain.Dimension("testint");
-            Assert.AreEqual(DataType.Int32, dim2.Type());
-            Assert.AreEqual("testint", dim2.Name());
-        }
+        dim2 = domain.Dimension("testint");
+        Assert.AreEqual(DataType.Int32, dim2.Type());
+        Assert.AreEqual("testint", dim2.Name());
     }
 }

--- a/tests/TileDB.CSharp.Test/EnumerationTest.cs
+++ b/tests/TileDB.CSharp.Test/EnumerationTest.cs
@@ -2,97 +2,96 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class EnumerationTest
 {
-    [TestClass]
-    public class EnumerationTest
+    [TestMethod]
+    public void TestString()
     {
-        [TestMethod]
-        public void TestString()
-        {
-            string[] expectedValues = ["Hello", "World", "👋"];
-            using Enumeration e = Enumeration.Create(Context.GetDefault(), "test_string", true, expectedValues);
+        string[] expectedValues = ["Hello", "World", "👋"];
+        using Enumeration e = Enumeration.Create(Context.GetDefault(), "test_string", true, expectedValues);
 
-            System.Array values = e.GetValues();
-            byte[] rawData = e.GetRawData();
-            ulong[] rawOffsets = e.GetRawOffsets();
+        System.Array values = e.GetValues();
+        byte[] rawData = e.GetRawData();
+        ulong[] rawOffsets = e.GetRawOffsets();
 
-            Assert.AreEqual("test_string", e.GetName());
-            Assert.IsTrue(e.IsOrdered);
-            Assert.AreEqual(DataType.StringUtf8, e.DataType);
-            Assert.AreEqual(Enumeration.VariableSized, e.ValuesPerMember);
-            CollectionAssert.AreEqual(expectedValues, values);
-            CollectionAssert.AreEqual("HelloWorld👋"u8.ToArray(), rawData);
-            CollectionAssert.AreEqual(new ulong[] { 0, 5, 10 }, rawOffsets);
-        }
+        Assert.AreEqual("test_string", e.GetName());
+        Assert.IsTrue(e.IsOrdered);
+        Assert.AreEqual(DataType.StringUtf8, e.DataType);
+        Assert.AreEqual(Enumeration.VariableSized, e.ValuesPerMember);
+        CollectionAssert.AreEqual(expectedValues, values);
+        CollectionAssert.AreEqual("HelloWorld👋"u8.ToArray(), rawData);
+        CollectionAssert.AreEqual(new ulong[] { 0, 5, 10 }, rawOffsets);
+    }
 
-        [TestMethod]
-        [DataRow(1u)]
-        [DataRow(2u)]
-        [DataRow(4u)]
-        public void TestFixedSize(uint cellValNum)
-        {
-            int[] expectedValues = [1, 2, 3, 4];
+    [TestMethod]
+    [DataRow(1u)]
+    [DataRow(2u)]
+    [DataRow(4u)]
+    public void TestFixedSize(uint cellValNum)
+    {
+        int[] expectedValues = [1, 2, 3, 4];
 
-            using Enumeration e = Enumeration.Create<int>(Context.GetDefault(), "test_fixed", false, expectedValues, cellValNum);
+        using Enumeration e = Enumeration.Create<int>(Context.GetDefault(), "test_fixed", false, expectedValues, cellValNum);
 
-            System.Array values = e.GetValues();
-            byte[] rawData = e.GetRawData();
-            ulong[] rawOffsets = e.GetRawOffsets();
+        System.Array values = e.GetValues();
+        byte[] rawData = e.GetRawData();
+        ulong[] rawOffsets = e.GetRawOffsets();
 
-            Assert.AreEqual("test_fixed", e.GetName());
-            Assert.IsFalse(e.IsOrdered);
-            Assert.AreEqual(DataType.Int32, e.DataType);
-            Assert.AreEqual(cellValNum, e.ValuesPerMember);
-            CollectionAssert.AreEqual(expectedValues, values);
-            CollectionAssert.AreEqual(new byte[] { 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0 }, rawData);
-            Assert.AreEqual(0, rawOffsets.Length);
-        }
+        Assert.AreEqual("test_fixed", e.GetName());
+        Assert.IsFalse(e.IsOrdered);
+        Assert.AreEqual(DataType.Int32, e.DataType);
+        Assert.AreEqual(cellValNum, e.ValuesPerMember);
+        CollectionAssert.AreEqual(expectedValues, values);
+        CollectionAssert.AreEqual(new byte[] { 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0 }, rawData);
+        Assert.AreEqual(0, rawOffsets.Length);
+    }
 
-        [TestMethod]
-        public void TestVarSize()
-        {
-            int[] expectedValues = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4];
-            ulong[] expectedOffsets = [0, 4, 12, 24];
+    [TestMethod]
+    public void TestVarSize()
+    {
+        int[] expectedValues = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4];
+        ulong[] expectedOffsets = [0, 4, 12, 24];
 
-            using Enumeration e = Enumeration.Create<int>(Context.GetDefault(), "test_var", false, expectedValues, expectedOffsets);
+        using Enumeration e = Enumeration.Create<int>(Context.GetDefault(), "test_var", false, expectedValues, expectedOffsets);
 
-            int[][]? values = e.GetValues() as int[][];
-            byte[] rawData = e.GetRawData();
-            ulong[] rawOffsets = e.GetRawOffsets();
+        int[][]? values = e.GetValues() as int[][];
+        byte[] rawData = e.GetRawData();
+        ulong[] rawOffsets = e.GetRawOffsets();
 
-            Assert.AreEqual("test_var", e.GetName());
-            Assert.IsFalse(e.IsOrdered);
-            Assert.AreEqual(DataType.Int32, e.DataType);
-            Assert.AreEqual(Enumeration.VariableSized, e.ValuesPerMember);
-            Assert.IsNotNull(values);
-            CollectionAssert.AreEqual(new int[] { 1 }, values[0]);
-            CollectionAssert.AreEqual(new int[] { 2, 2 }, values[1]);
-            CollectionAssert.AreEqual(new int[] { 3, 3, 3 }, values[2]);
-            CollectionAssert.AreEqual(new int[] { 4, 4, 4, 4 }, values[3]);
-            CollectionAssert.AreEqual(MemoryMarshal.AsBytes(expectedValues.AsSpan()).ToArray(), rawData);
-            Assert.AreEqual(4, rawOffsets.Length);
-        }
+        Assert.AreEqual("test_var", e.GetName());
+        Assert.IsFalse(e.IsOrdered);
+        Assert.AreEqual(DataType.Int32, e.DataType);
+        Assert.AreEqual(Enumeration.VariableSized, e.ValuesPerMember);
+        Assert.IsNotNull(values);
+        CollectionAssert.AreEqual(new int[] { 1 }, values[0]);
+        CollectionAssert.AreEqual(new int[] { 2, 2 }, values[1]);
+        CollectionAssert.AreEqual(new int[] { 3, 3, 3 }, values[2]);
+        CollectionAssert.AreEqual(new int[] { 4, 4, 4, 4 }, values[3]);
+        CollectionAssert.AreEqual(MemoryMarshal.AsBytes(expectedValues.AsSpan()).ToArray(), rawData);
+        Assert.AreEqual(4, rawOffsets.Length);
+    }
 
-        [TestMethod]
-        public void TestExtend()
-        {
-            string[] expectedValues = ["Hello", "World", "👋"];
-            using Enumeration e = Enumeration.Create(Context.GetDefault(), "test_string", true, expectedValues);
+    [TestMethod]
+    public void TestExtend()
+    {
+        string[] expectedValues = ["Hello", "World", "👋"];
+        using Enumeration e = Enumeration.Create(Context.GetDefault(), "test_string", true, expectedValues);
 
-            using Enumeration extended = e.Extend(new[] {"👋👋👋"});
+        using Enumeration extended = e.Extend(new[] {"👋👋👋"});
 
-            System.Array values = extended.GetValues();
-            byte[] rawData = extended.GetRawData();
-            ulong[] rawOffsets = extended.GetRawOffsets();
+        System.Array values = extended.GetValues();
+        byte[] rawData = extended.GetRawData();
+        ulong[] rawOffsets = extended.GetRawOffsets();
 
-            Assert.AreEqual("test_string", extended.GetName());
-            Assert.IsTrue(extended.IsOrdered);
-            Assert.AreEqual(DataType.StringUtf8, extended.DataType);
-            Assert.AreEqual(Enumeration.VariableSized, extended.ValuesPerMember);
-            CollectionAssert.AreEqual(new[] { "Hello", "World", "👋", "👋👋👋" }, values);
-            CollectionAssert.AreEqual("HelloWorld👋👋👋👋"u8.ToArray(), rawData);
-            CollectionAssert.AreEqual(new ulong[] { 0, 5, 10, 14 }, rawOffsets);
-        }
+        Assert.AreEqual("test_string", extended.GetName());
+        Assert.IsTrue(extended.IsOrdered);
+        Assert.AreEqual(DataType.StringUtf8, extended.DataType);
+        Assert.AreEqual(Enumeration.VariableSized, extended.ValuesPerMember);
+        CollectionAssert.AreEqual(new[] { "Hello", "World", "👋", "👋👋👋" }, values);
+        CollectionAssert.AreEqual("HelloWorld👋👋👋👋"u8.ToArray(), rawData);
+        CollectionAssert.AreEqual(new ulong[] { 0, 5, 10, 14 }, rawOffsets);
     }
 }

--- a/tests/TileDB.CSharp.Test/EnumerationTest.cs
+++ b/tests/TileDB.CSharp.Test/EnumerationTest.cs
@@ -10,7 +10,7 @@ namespace TileDB.CSharp.Test
         [TestMethod]
         public void TestString()
         {
-            string[] expectedValues = new[] { "Hello", "World", "👋" };
+            string[] expectedValues = ["Hello", "World", "👋"];
             using Enumeration e = Enumeration.Create(Context.GetDefault(), "test_string", true, expectedValues);
 
             System.Array values = e.GetValues();
@@ -32,7 +32,7 @@ namespace TileDB.CSharp.Test
         [DataRow(4u)]
         public void TestFixedSize(uint cellValNum)
         {
-            int[] expectedValues = new[] { 1, 2, 3, 4 };
+            int[] expectedValues = [1, 2, 3, 4];
 
             using Enumeration e = Enumeration.Create<int>(Context.GetDefault(), "test_fixed", false, expectedValues, cellValNum);
 
@@ -52,8 +52,8 @@ namespace TileDB.CSharp.Test
         [TestMethod]
         public void TestVarSize()
         {
-            int[] expectedValues = new int[] { 1, 2, 2, 3, 3, 3, 4, 4, 4, 4 };
-            ulong[] expectedOffsets = new ulong[] { 0, 4, 12, 24 };
+            int[] expectedValues = [1, 2, 2, 3, 3, 3, 4, 4, 4, 4];
+            ulong[] expectedOffsets = [0, 4, 12, 24];
 
             using Enumeration e = Enumeration.Create<int>(Context.GetDefault(), "test_var", false, expectedValues, expectedOffsets);
 
@@ -77,7 +77,7 @@ namespace TileDB.CSharp.Test
         [TestMethod]
         public void TestExtend()
         {
-            string[] expectedValues = new[] { "Hello", "World", "👋" };
+            string[] expectedValues = ["Hello", "World", "👋"];
             using Enumeration e = Enumeration.Create(Context.GetDefault(), "test_string", true, expectedValues);
 
             using Enumeration extended = e.Extend(new[] {"👋👋👋"});

--- a/tests/TileDB.CSharp.Test/FilterListTest.cs
+++ b/tests/TileDB.CSharp.Test/FilterListTest.cs
@@ -1,46 +1,45 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class FilterListTest
 {
-    [TestClass]
-    public class FilterListTest
+    [TestMethod]
+    public void NewFilterListIsValid()
     {
-        [TestMethod]
-        public void NewFilterListIsValid()
-        {
-            var ctx = Context.GetDefault();
-            using var filter_list = new FilterList(ctx);
-            var gzipFilter = new Filter(ctx, FilterType.Gzip);
-            var gzip_compression_level = 3;
-            gzipFilter.SetOption(FilterOption.CompressionLevel, gzip_compression_level);
-            filter_list.AddFilter(gzipFilter);
+        var ctx = Context.GetDefault();
+        using var filter_list = new FilterList(ctx);
+        var gzipFilter = new Filter(ctx, FilterType.Gzip);
+        var gzip_compression_level = 3;
+        gzipFilter.SetOption(FilterOption.CompressionLevel, gzip_compression_level);
+        filter_list.AddFilter(gzipFilter);
 
-            var bit_shuffle_filter = new Filter(ctx, FilterType.BitShuffle);
-            filter_list.AddFilter(bit_shuffle_filter);
+        var bit_shuffle_filter = new Filter(ctx, FilterType.BitShuffle);
+        filter_list.AddFilter(bit_shuffle_filter);
 
-            var positive_delta_filter = new Filter(ctx, FilterType.PositiveDelta);
-            const uint positiveDeltaMaxWindow = 1024;
-            positive_delta_filter.SetOption(FilterOption.PositiveDeltaMaxWindow, positiveDeltaMaxWindow);
-            filter_list.AddFilter(positive_delta_filter);
+        var positive_delta_filter = new Filter(ctx, FilterType.PositiveDelta);
+        const uint positiveDeltaMaxWindow = 1024;
+        positive_delta_filter.SetOption(FilterOption.PositiveDeltaMaxWindow, positiveDeltaMaxWindow);
+        filter_list.AddFilter(positive_delta_filter);
 
-            const uint maxChunkSize = 512;
-            filter_list.SetMaxChunkSize(maxChunkSize);
+        const uint maxChunkSize = 512;
+        filter_list.SetMaxChunkSize(maxChunkSize);
 
-            const uint numFilters = 3;
+        const uint numFilters = 3;
 
-            Assert.AreEqual(numFilters, filter_list.NFilters());
-            Assert.AreEqual(maxChunkSize, filter_list.MaxChunkSize());
+        Assert.AreEqual(numFilters, filter_list.NFilters());
+        Assert.AreEqual(maxChunkSize, filter_list.MaxChunkSize());
 
-            var filter0 = filter_list.Filter(0);
-            Assert.AreEqual(FilterType.Gzip, filter0.FilterType());
-            Assert.AreEqual(gzip_compression_level, filter0.GetOption<int>(FilterOption.CompressionLevel));
+        var filter0 = filter_list.Filter(0);
+        Assert.AreEqual(FilterType.Gzip, filter0.FilterType());
+        Assert.AreEqual(gzip_compression_level, filter0.GetOption<int>(FilterOption.CompressionLevel));
 
-            var filter1 = filter_list.Filter(1);
-            Assert.AreEqual(FilterType.BitShuffle, filter1.FilterType());
+        var filter1 = filter_list.Filter(1);
+        Assert.AreEqual(FilterType.BitShuffle, filter1.FilterType());
 
-            var filter2 = filter_list.Filter(2);
-            Assert.AreEqual(FilterType.PositiveDelta, filter2.FilterType());
-            Assert.AreEqual(positiveDeltaMaxWindow, filter2.GetOption<uint>(FilterOption.PositiveDeltaMaxWindow));
-        }
+        var filter2 = filter_list.Filter(2);
+        Assert.AreEqual(FilterType.PositiveDelta, filter2.FilterType());
+        Assert.AreEqual(positiveDeltaMaxWindow, filter2.GetOption<uint>(FilterOption.PositiveDeltaMaxWindow));
     }
 }

--- a/tests/TileDB.CSharp.Test/FilterTest.cs
+++ b/tests/TileDB.CSharp.Test/FilterTest.cs
@@ -1,104 +1,103 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class FilterTest
 {
-    [TestClass]
-    public class FilterTest
+    [TestMethod]
+    public void NewBitShuffleFilterIsValid()
     {
-        [TestMethod]
-        public void NewBitShuffleFilterIsValid()
-        {
-            var ctx = Context.GetDefault();
-            using var filter = new Filter(ctx, FilterType.BitShuffle);
-            Assert.AreEqual(FilterType.BitShuffle, filter.FilterType());
-        }
+        var ctx = Context.GetDefault();
+        using var filter = new Filter(ctx, FilterType.BitShuffle);
+        Assert.AreEqual(FilterType.BitShuffle, filter.FilterType());
+    }
 
-        [TestMethod]
-        public void NewGzipFilterIsValid()
-        {
-            var ctx = Context.GetDefault();
-            using var filter = new Filter(ctx, FilterType.Gzip);
-            Assert.AreEqual(FilterType.Gzip, filter.FilterType());
+    [TestMethod]
+    public void NewGzipFilterIsValid()
+    {
+        var ctx = Context.GetDefault();
+        using var filter = new Filter(ctx, FilterType.Gzip);
+        Assert.AreEqual(FilterType.Gzip, filter.FilterType());
 
-            const int compressionLevel = 6;
-            filter.SetOption(FilterOption.CompressionLevel, compressionLevel);
-            Assert.AreEqual(compressionLevel, filter.GetOption<int>(FilterOption.CompressionLevel));
-        }
+        const int compressionLevel = 6;
+        filter.SetOption(FilterOption.CompressionLevel, compressionLevel);
+        Assert.AreEqual(compressionLevel, filter.GetOption<int>(FilterOption.CompressionLevel));
+    }
 
-        [TestMethod]
-        public void NewPositiveDeltaFilterIsValid()
-        {
-            var ctx = Context.GetDefault();
-            using var filter = new Filter(ctx, FilterType.PositiveDelta);
-            Assert.AreEqual(FilterType.PositiveDelta, filter.FilterType());
+    [TestMethod]
+    public void NewPositiveDeltaFilterIsValid()
+    {
+        var ctx = Context.GetDefault();
+        using var filter = new Filter(ctx, FilterType.PositiveDelta);
+        Assert.AreEqual(FilterType.PositiveDelta, filter.FilterType());
 
-            const uint positiveDeltaMaxWindow = 1024;
-            filter.SetOption(FilterOption.PositiveDeltaMaxWindow, positiveDeltaMaxWindow);
-            Assert.AreEqual(positiveDeltaMaxWindow, filter.GetOption<uint>(FilterOption.PositiveDeltaMaxWindow));
-        }
+        const uint positiveDeltaMaxWindow = 1024;
+        filter.SetOption(FilterOption.PositiveDeltaMaxWindow, positiveDeltaMaxWindow);
+        Assert.AreEqual(positiveDeltaMaxWindow, filter.GetOption<uint>(FilterOption.PositiveDeltaMaxWindow));
+    }
 
-        [TestMethod]
-        public void NewBitWidthReductionFilterIsValid()
-        {
-            var ctx = Context.GetDefault();
-            using var filter = new Filter(ctx, FilterType.BitWidthReduction);
-            Assert.AreEqual(FilterType.BitWidthReduction, filter.FilterType());
+    [TestMethod]
+    public void NewBitWidthReductionFilterIsValid()
+    {
+        var ctx = Context.GetDefault();
+        using var filter = new Filter(ctx, FilterType.BitWidthReduction);
+        Assert.AreEqual(FilterType.BitWidthReduction, filter.FilterType());
 
-            const uint bidWidthMaxWindow = 256;
-            filter.SetOption(FilterOption.BitWidthMaxWindow, bidWidthMaxWindow);
-            Assert.AreEqual(bidWidthMaxWindow, filter.GetOption<uint>(FilterOption.BitWidthMaxWindow));
-        }
+        const uint bidWidthMaxWindow = 256;
+        filter.SetOption(FilterOption.BitWidthMaxWindow, bidWidthMaxWindow);
+        Assert.AreEqual(bidWidthMaxWindow, filter.GetOption<uint>(FilterOption.BitWidthMaxWindow));
+    }
 
-        [TestMethod]
-        public void NewDictionaryFilterIsValid()
-        {
-            var ctx = Context.GetDefault();
-            using var filter = new Filter(ctx, FilterType.Dictionary);
-            Assert.AreEqual(FilterType.Dictionary, filter.FilterType());
+    [TestMethod]
+    public void NewDictionaryFilterIsValid()
+    {
+        var ctx = Context.GetDefault();
+        using var filter = new Filter(ctx, FilterType.Dictionary);
+        Assert.AreEqual(FilterType.Dictionary, filter.FilterType());
 
-            const int compressionLevel = 4;
-            filter.SetOption(FilterOption.CompressionLevel, compressionLevel);
-            Assert.AreEqual(compressionLevel, filter.GetOption<int>(FilterOption.CompressionLevel));
-        }
+        const int compressionLevel = 4;
+        filter.SetOption(FilterOption.CompressionLevel, compressionLevel);
+        Assert.AreEqual(compressionLevel, filter.GetOption<int>(FilterOption.CompressionLevel));
+    }
 
-        [TestMethod]
-        public void NewFloatScalingFilterIsValid()
-        {
-            var ctx = Context.GetDefault();
-            using var filter = new Filter(ctx, FilterType.ScaleFloat);
-            Assert.AreEqual(FilterType.ScaleFloat, filter.FilterType());
+    [TestMethod]
+    public void NewFloatScalingFilterIsValid()
+    {
+        var ctx = Context.GetDefault();
+        using var filter = new Filter(ctx, FilterType.ScaleFloat);
+        Assert.AreEqual(FilterType.ScaleFloat, filter.FilterType());
 
-            const double scale = 4.0;
-            filter.SetOption(FilterOption.ScaleFloatFactor, scale);
-            Assert.AreEqual(scale, filter.GetOption<double>(FilterOption.ScaleFloatFactor));
+        const double scale = 4.0;
+        filter.SetOption(FilterOption.ScaleFloatFactor, scale);
+        Assert.AreEqual(scale, filter.GetOption<double>(FilterOption.ScaleFloatFactor));
 
-            const double offset = 1.0;
-            filter.SetOption(FilterOption.ScaleFloatOffset, offset);
-            Assert.AreEqual(offset, filter.GetOption<double>(FilterOption.ScaleFloatOffset));
+        const double offset = 1.0;
+        filter.SetOption(FilterOption.ScaleFloatOffset, offset);
+        Assert.AreEqual(offset, filter.GetOption<double>(FilterOption.ScaleFloatOffset));
 
-            const ulong byteWidth = 4;
-            filter.SetOption(FilterOption.ScaleFloatByteWidth, byteWidth);
-            Assert.AreEqual(byteWidth, filter.GetOption<ulong>(FilterOption.ScaleFloatByteWidth));
-        }
+        const ulong byteWidth = 4;
+        filter.SetOption(FilterOption.ScaleFloatByteWidth, byteWidth);
+        Assert.AreEqual(byteWidth, filter.GetOption<ulong>(FilterOption.ScaleFloatByteWidth));
+    }
 
-        [TestMethod]
-        public void NewWebpFilterIsValid()
-        {
-            var ctx = Context.GetDefault();
-            using var filter = new Filter(ctx, FilterType.Webp);
-            Assert.AreEqual(FilterType.Webp, filter.FilterType());
+    [TestMethod]
+    public void NewWebpFilterIsValid()
+    {
+        var ctx = Context.GetDefault();
+        using var filter = new Filter(ctx, FilterType.Webp);
+        Assert.AreEqual(FilterType.Webp, filter.FilterType());
 
-            const float quality = 59.0f;
-            filter.SetOption(FilterOption.WebpQuality, quality);
-            Assert.AreEqual(quality, filter.GetOption<float>(FilterOption.WebpQuality));
+        const float quality = 59.0f;
+        filter.SetOption(FilterOption.WebpQuality, quality);
+        Assert.AreEqual(quality, filter.GetOption<float>(FilterOption.WebpQuality));
 
-            const WebpInputFormat inputFormat = WebpInputFormat.Bgra;
-            filter.SetOption(FilterOption.WebpInputFormat, inputFormat);
-            Assert.AreEqual(inputFormat, filter.GetOption<WebpInputFormat>(FilterOption.WebpInputFormat));
+        const WebpInputFormat inputFormat = WebpInputFormat.Bgra;
+        filter.SetOption(FilterOption.WebpInputFormat, inputFormat);
+        Assert.AreEqual(inputFormat, filter.GetOption<WebpInputFormat>(FilterOption.WebpInputFormat));
 
-            const bool lossless = false;
-            filter.SetOption(FilterOption.WebpLossless, lossless);
-            Assert.AreEqual(lossless, filter.GetOption<bool>(FilterOption.WebpLossless));
-        }
+        const bool lossless = false;
+        filter.SetOption(FilterOption.WebpLossless, lossless);
+        Assert.AreEqual(lossless, filter.GetOption<bool>(FilterOption.WebpLossless));
     }
 }

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -3,601 +3,600 @@ using System;
 using System.IO;
 using System.Text;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class FragmentInfoTest
 {
-    [TestClass]
-    public class FragmentInfoTest
+    private const uint FragmentCount = 10;
+
+    private Context _ctx = null!;
+
+    [TestInitialize]
+    public void Setup()
     {
-        private const uint FragmentCount = 10;
+        _ctx = new Context();
+    }
 
-        private Context _ctx = null!;
+    [TestCleanup]
+    public void Cleanup()
+    {
+        _ctx.Dispose();
+    }
 
-        [TestInitialize]
-        public void Setup()
+    [DataTestMethod]
+    [DataRow(true, DisplayName = "Dense")]
+    [DataRow(false, DisplayName = "Sparse")]
+    public void TestFragmentCount(bool isDense)
+    {
+        using var uri = new TemporaryDirectory("fragment_info_fragment_num");
+        CreateArray(uri, isDense);
+        for (uint i = 0; i < FragmentCount; i++)
         {
-            _ctx = new Context();
+            WriteArray(uri, isDense);
         }
 
-        [TestCleanup]
-        public void Cleanup()
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        Assert.AreEqual(FragmentCount, info.FragmentCount);
+    }
+
+    [DataTestMethod]
+    [DataRow(true, DisplayName = "Dense")]
+    [DataRow(false, DisplayName = "Sparse")]
+    public void TestArraySchemaName(bool isDense)
+    {
+        using var uri = new TemporaryDirectory("fragment_info_array_schema_name");
+        CreateArray(uri, isDense);
+        for (uint i = 0; i < FragmentCount; i++)
         {
-            _ctx.Dispose();
+            WriteArray(uri, isDense);
         }
 
-        [DataTestMethod]
-        [DataRow(true, DisplayName = "Dense")]
-        [DataRow(false, DisplayName = "Sparse")]
-        public void TestFragmentCount(bool isDense)
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        uint fragmentCount = info.FragmentCount;
+
+        for (uint i = 0; i < fragmentCount; i++)
         {
-            using var uri = new TemporaryDirectory("fragment_info_fragment_num");
-            CreateArray(uri, isDense);
-            for (uint i = 0; i < FragmentCount; i++)
-            {
-                WriteArray(uri, isDense);
-            }
-
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
-
-            Assert.AreEqual(FragmentCount, info.FragmentCount);
+            Assert.IsNotNull(info.GetSchemaName(i));
         }
 
-        [DataTestMethod]
-        [DataRow(true, DisplayName = "Dense")]
-        [DataRow(false, DisplayName = "Sparse")]
-        public void TestArraySchemaName(bool isDense)
+        Assert.AreEqual(FragmentCount, fragmentCount);
+    }
+
+    [DataTestMethod]
+    [DataRow(true, DisplayName = "Dense")]
+    [DataRow(false, DisplayName = "Sparse")]
+    public void TestGetFragmentSize(bool isDense)
+    {
+        using var uri = new TemporaryDirectory("fragment_info_fragment_size");
+
+        CreateArray(uri, isDense);
+
+        for (uint i = 0; i < FragmentCount; i++)
         {
-            using var uri = new TemporaryDirectory("fragment_info_array_schema_name");
-            CreateArray(uri, isDense);
-            for (uint i = 0; i < FragmentCount; i++)
-            {
-                WriteArray(uri, isDense);
-            }
-
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
-
-            uint fragmentCount = info.FragmentCount;
-
-            for (uint i = 0; i < fragmentCount; i++)
-            {
-                Assert.IsNotNull(info.GetSchemaName(i));
-            }
-
-            Assert.AreEqual(FragmentCount, fragmentCount);
+            WriteArray(uri, isDense);
         }
 
-        [DataTestMethod]
-        [DataRow(true, DisplayName = "Dense")]
-        [DataRow(false, DisplayName = "Sparse")]
-        public void TestGetFragmentSize(bool isDense)
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        uint fragmentCount = info.FragmentCount;
+
+        for (uint i = 0; i < fragmentCount; i++)
         {
-            using var uri = new TemporaryDirectory("fragment_info_fragment_size");
+            Uri fragmentUri = new(info.GetFragmentUri(i));
 
-            CreateArray(uri, isDense);
+            var dirLength = (ulong)TestUtil.GetDirectorySize(fragmentUri.LocalPath);
 
-            for (uint i = 0; i < FragmentCount; i++)
-            {
-                WriteArray(uri, isDense);
-            }
+            Assert.AreEqual(dirLength, info.GetFragmentSize(i));
+        }
+    }
 
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
+    [DataTestMethod]
+    [DataRow(true, DisplayName = "Dense")]
+    [DataRow(false, DisplayName = "Sparse")]
+    public void TestIsDenseSparse(bool isDense)
+    {
+        using var uri = new TemporaryDirectory("fragment_info_is_dense_sparse");
 
-            uint fragmentCount = info.FragmentCount;
-
-            for (uint i = 0; i < fragmentCount; i++)
-            {
-                Uri fragmentUri = new(info.GetFragmentUri(i));
-
-                var dirLength = (ulong)TestUtil.GetDirectorySize(fragmentUri.LocalPath);
-
-                Assert.AreEqual(dirLength, info.GetFragmentSize(i));
-            }
+        CreateArray(uri, isDense);
+        for (uint i = 0; i < FragmentCount; i++)
+        {
+            WriteArray(uri, isDense);
         }
 
-        [DataTestMethod]
-        [DataRow(true, DisplayName = "Dense")]
-        [DataRow(false, DisplayName = "Sparse")]
-        public void TestIsDenseSparse(bool isDense)
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        uint fragmentCount = info.FragmentCount;
+
+        for (uint i = 0; i < fragmentCount; i++)
         {
-            using var uri = new TemporaryDirectory("fragment_info_is_dense_sparse");
+            Assert.AreEqual(isDense, info.IsDense(i));
+            Assert.AreEqual(!isDense, info.IsSparse(i));
+        }
+    }
 
-            CreateArray(uri, isDense);
-            for (uint i = 0; i < FragmentCount; i++)
-            {
-                WriteArray(uri, isDense);
-            }
+    [DataTestMethod]
+    [DataRow(true, DisplayName = "Dense")]
+    [DataRow(false, DisplayName = "Sparse")]
+    public void TestGetTimestampRange(bool isDense)
+    {
+        using var uri = new TemporaryDirectory("fragment_info_timestamp_range");
 
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
+        CreateArray(uri, isDense);
 
-            uint fragmentCount = info.FragmentCount;
-
-            for (uint i = 0; i < fragmentCount; i++)
-            {
-                Assert.AreEqual(isDense, info.IsDense(i));
-                Assert.AreEqual(!isDense, info.IsSparse(i));
-            }
+        for (uint i = 0; i < FragmentCount; i++)
+        {
+            WriteArray(uri, isDense);
         }
 
-        [DataTestMethod]
-        [DataRow(true, DisplayName = "Dense")]
-        [DataRow(false, DisplayName = "Sparse")]
-        public void TestGetTimestampRange(bool isDense)
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        uint fragmentCount = info.FragmentCount;
+
+        for (uint i = 0; i < fragmentCount; i++)
         {
-            using var uri = new TemporaryDirectory("fragment_info_timestamp_range");
+            Uri fragmentUri = new(info.GetFragmentUri(i));
 
-            CreateArray(uri, isDense);
+            (ulong, ulong) expectedTimestampRange = info.GetTimestampRange(i);
 
-            for (uint i = 0; i < FragmentCount; i++)
-            {
-                WriteArray(uri, isDense);
-            }
+            string[] dirNameSplit = Path.GetFileName(fragmentUri.LocalPath)!.Split('_');
 
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
+            ulong start = ulong.Parse(dirNameSplit[2]);
+            ulong end = ulong.Parse(dirNameSplit[3]);
 
-            uint fragmentCount = info.FragmentCount;
+            Assert.AreEqual(expectedTimestampRange, (start, end));
+        }
+    }
 
-            for (uint i = 0; i < fragmentCount; i++)
-            {
-                Uri fragmentUri = new(info.GetFragmentUri(i));
+    [TestMethod]
+    public void TestMinimumBoundedRectanglesString()
+    {
+        using var uri = new TemporaryDirectory("fragment_info_mbr_var");
+        CreateSparseVarDimArrayForMbrTesting(uri);
+        WriteSparseVarDimArrayForMbrTesting(uri);
 
-                (ulong, ulong) expectedTimestampRange = info.GetTimestampRange(i);
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
 
-                string[] dirNameSplit = Path.GetFileName(fragmentUri.LocalPath)!.Split('_');
+        Assert.AreEqual(1u, info.FragmentCount);
 
-                ulong start = ulong.Parse(dirNameSplit[2]);
-                ulong end = ulong.Parse(dirNameSplit[3]);
+        Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(0));
 
-                Assert.AreEqual(expectedTimestampRange, (start, end));
-            }
+        Assert.AreEqual(("a", "bb"), info.GetMinimumBoundedRectangle<string>(0, 0, 0));
+        Assert.AreEqual(("c", "ddd"), info.GetMinimumBoundedRectangle<string>(0, 1, "d"));
+
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(0, 0, 0));
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(0, 0, 0));
+        Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(0, 1, "d"));
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(0, 1, "d"));
+        Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 1, "d"));
+    }
+
+    [TestMethod]
+    public void TestMinimumBoundedRectangles()
+    {
+        using var uri = new TemporaryDirectory("fragment_info_mbr");
+        CreateSparseArrayNoVarDim(uri);
+        WriteSparseArrayNoVarDim3Frags(uri);
+
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        Assert.AreEqual(3u, info.FragmentCount);
+
+        Assert.AreEqual(1ul, info.GetMinimumBoundedRectangleCount(0));
+        Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(1));
+        Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(2));
+
+        Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<long>(0, 0, 0));
+        Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<long>(1, 1, "d1"));
+
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(0, 0, 0));
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(0, 0, 0));
+        Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(1, 1, "d1"));
+        Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(1, 1, "d1"));
+    }
+
+    [TestMethod]
+    public void TestMinimumBoundedRectanglesInt32()
+    {
+        using var uri = new TemporaryDirectory("fragment_info_mbr_int32");
+        CreateSparseArrayNoVarDimInt32(uri);
+        WriteSparseArrayNoVarDim3FragsInt32(uri);
+
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        Assert.AreEqual(3u, info.FragmentCount);
+
+        Assert.AreEqual(1ul, info.GetMinimumBoundedRectangleCount(0));
+        Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(1));
+        Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(2));
+
+        Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<int>(0, 0, 0));
+        Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
+
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(0, 0, 0));
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(0, 0, 0));
+        Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(1, 1, "d1"));
+        Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(1, 1, "d1"));
+        Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(1, 1, "d1"));
+    }
+
+    [TestMethod]
+    public void TestNonEmptyDomain()
+    {
+        using var uri = new TemporaryDirectory("fragment_info_non_empty_domain");
+        CreateDenseArray(uri);
+        for (uint i = 0; i < FragmentCount; i++)
+        {
+            WriteDenseArray(uri);
         }
 
-        [TestMethod]
-        public void TestMinimumBoundedRectanglesString()
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        uint fragmentCount = info.FragmentCount;
+
+        for (uint i = 0; i < fragmentCount; i++)
         {
-            using var uri = new TemporaryDirectory("fragment_info_mbr_var");
-            CreateSparseVarDimArrayForMbrTesting(uri);
-            WriteSparseVarDimArrayForMbrTesting(uri);
+            using Array arr = new Array(_ctx, uri);
+            arr.Open(QueryType.Read);
+            using ArraySchema schema = arr.Schema();
+            using Domain domain = schema.Domain();
 
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
+            uint ndim = domain.NDim();
 
-            Assert.AreEqual(1u, info.FragmentCount);
-
-            Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(0));
-
-            Assert.AreEqual(("a", "bb"), info.GetMinimumBoundedRectangle<string>(0, 0, 0));
-            Assert.AreEqual(("c", "ddd"), info.GetMinimumBoundedRectangle<string>(0, 1, "d"));
-
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(0, 0, 0));
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(0, 0, 0));
-            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(0, 1, "d"));
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(0, 1, "d"));
-            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 1, "d"));
-        }
-
-        [TestMethod]
-        public void TestMinimumBoundedRectangles()
-        {
-            using var uri = new TemporaryDirectory("fragment_info_mbr");
-            CreateSparseArrayNoVarDim(uri);
-            WriteSparseArrayNoVarDim3Frags(uri);
-
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
-
-            Assert.AreEqual(3u, info.FragmentCount);
-
-            Assert.AreEqual(1ul, info.GetMinimumBoundedRectangleCount(0));
-            Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(1));
-            Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(2));
-
-            Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<long>(0, 0, 0));
-            Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<long>(1, 1, "d1"));
-
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(0, 0, 0));
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(0, 0, 0));
-            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(1, 1, "d1"));
-            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(1, 1, "d1"));
-        }
-
-        [TestMethod]
-        public void TestMinimumBoundedRectanglesInt32()
-        {
-            using var uri = new TemporaryDirectory("fragment_info_mbr_int32");
-            CreateSparseArrayNoVarDimInt32(uri);
-            WriteSparseArrayNoVarDim3FragsInt32(uri);
-
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
-
-            Assert.AreEqual(3u, info.FragmentCount);
-
-            Assert.AreEqual(1ul, info.GetMinimumBoundedRectangleCount(0));
-            Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(1));
-            Assert.AreEqual(2ul, info.GetMinimumBoundedRectangleCount(2));
-
-            Assert.AreEqual((1, 2), info.GetMinimumBoundedRectangle<int>(0, 0, 0));
-            Assert.AreEqual((7, 8), info.GetMinimumBoundedRectangle<int>(1, 1, "d1"));
-
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(0, 0, 0));
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(0, 0, 0));
-            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(0, 0, 0));
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<long>(1, 1, "d1"));
-            Assert.ThrowsException<ArgumentException>(() => info.GetMinimumBoundedRectangle<string>(1, 1, "d1"));
-            Assert.ThrowsException<NotSupportedException>(() => info.GetMinimumBoundedRectangle<Guid>(1, 1, "d1"));
-        }
-
-        [TestMethod]
-        public void TestNonEmptyDomain()
-        {
-            using var uri = new TemporaryDirectory("fragment_info_non_empty_domain");
-            CreateDenseArray(uri);
-            for (uint i = 0; i < FragmentCount; i++)
+            for (uint dim = 0; dim < ndim; dim++)
             {
-                WriteDenseArray(uri);
-            }
+                using Dimension d = domain.Dimension(dim);
 
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
-
-            uint fragmentCount = info.FragmentCount;
-
-            for (uint i = 0; i < fragmentCount; i++)
-            {
-                using Array arr = new Array(_ctx, uri);
-                arr.Open(QueryType.Read);
-                using ArraySchema schema = arr.Schema();
-                using Domain domain = schema.Domain();
-
-                uint ndim = domain.NDim();
-
-                for (uint dim = 0; dim < ndim; dim++)
+                var expectedNonEmptyDomain = info.GetNonEmptyDomain<int>(i, dim);
+                var actualNonEmptyDomain = arr.NonEmptyDomain<int>(dim) switch
                 {
-                    using Dimension d = domain.Dimension(dim);
+                    (int Start, int End, _) => (Start, End)
+                };
+                Assert.AreEqual(expectedNonEmptyDomain, actualNonEmptyDomain);
+                Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<long>(i, dim));
+                Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<string>(i, dim));
+                Assert.ThrowsException<NotSupportedException>(() => info.GetNonEmptyDomain<Guid>(i, dim));
 
-                    var expectedNonEmptyDomain = info.GetNonEmptyDomain<int>(i, dim);
-                    var actualNonEmptyDomain = arr.NonEmptyDomain<int>(dim) switch
-                    {
-                        (int Start, int End, _) => (Start, End)
-                    };
-                    Assert.AreEqual(expectedNonEmptyDomain, actualNonEmptyDomain);
-                    Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<long>(i, dim));
-                    Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<string>(i, dim));
-                    Assert.ThrowsException<NotSupportedException>(() => info.GetNonEmptyDomain<Guid>(i, dim));
-
-                    string name = d.Name();
-                    expectedNonEmptyDomain = info.GetNonEmptyDomain<int>(i, name);
-                    actualNonEmptyDomain = arr.NonEmptyDomain<int>(name) switch
-                    {
-                        (int Start, int End, _) => (Start, End)
-                    };
-                    Assert.AreEqual(expectedNonEmptyDomain, actualNonEmptyDomain);
-                    Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<long>(i, name));
-                    Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<string>(i, name));
-                    Assert.ThrowsException<NotSupportedException>(() => info.GetNonEmptyDomain<Guid>(i, name));
-                }
+                string name = d.Name();
+                expectedNonEmptyDomain = info.GetNonEmptyDomain<int>(i, name);
+                actualNonEmptyDomain = arr.NonEmptyDomain<int>(name) switch
+                {
+                    (int Start, int End, _) => (Start, End)
+                };
+                Assert.AreEqual(expectedNonEmptyDomain, actualNonEmptyDomain);
+                Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<long>(i, name));
+                Assert.ThrowsException<ArgumentException>(() => info.GetNonEmptyDomain<string>(i, name));
+                Assert.ThrowsException<NotSupportedException>(() => info.GetNonEmptyDomain<Guid>(i, name));
             }
         }
+    }
 
-        [DataTestMethod]
-        [DataRow(true, DisplayName = "Dense")]
-        [DataRow(false, DisplayName = "Sparse")]
-        public void TestGetCellCount(bool isDense)
+    [DataTestMethod]
+    [DataRow(true, DisplayName = "Dense")]
+    [DataRow(false, DisplayName = "Sparse")]
+    public void TestGetCellCount(bool isDense)
+    {
+        using var uri = new TemporaryDirectory("fragment_info_cell_num");
+        CreateArray(uri, isDense);
+        for (uint i = 0; i < FragmentCount; i++)
         {
-            using var uri = new TemporaryDirectory("fragment_info_cell_num");
-            CreateArray(uri, isDense);
-            for (uint i = 0; i < FragmentCount; i++)
-            {
-                WriteArray(uri, isDense);
-            }
-
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
-
-            uint fragmentCount = info.FragmentCount;
-
-            for (uint i = 0; i < fragmentCount; i++)
-            {
-                Assert.AreEqual(isDense ? 8u : 5u, info.GetCellsWritten(i));
-            }
+            WriteArray(uri, isDense);
         }
 
-        [DataTestMethod]
-        [DataRow(true, DisplayName = "Dense")]
-        [DataRow(false, DisplayName = "Sparse")]
-        public void TestGetFormatVersion(bool isDense)
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        uint fragmentCount = info.FragmentCount;
+
+        for (uint i = 0; i < fragmentCount; i++)
         {
-            using var uri = new TemporaryDirectory("fragment_info_version");
-            CreateArray(uri, isDense);
-            for (uint i = 0; i < FragmentCount; i++)
-            {
-                WriteArray(uri, isDense);
-            }
+            Assert.AreEqual(isDense ? 8u : 5u, info.GetCellsWritten(i));
+        }
+    }
 
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
-
-            uint fragmentCount = info.FragmentCount;
-
-            for (uint i = 0; i < fragmentCount; i++)
-            {
-                Uri fragmentUri = new(info.GetFragmentUri(i));
-
-                ulong formatVersionFromPath = ulong.Parse(fragmentUri.LocalPath.Split('_')[^1]);
-
-                Assert.AreEqual(formatVersionFromPath, info.GetFormatVersion(i));
-            }
+    [DataTestMethod]
+    [DataRow(true, DisplayName = "Dense")]
+    [DataRow(false, DisplayName = "Sparse")]
+    public void TestGetFormatVersion(bool isDense)
+    {
+        using var uri = new TemporaryDirectory("fragment_info_version");
+        CreateArray(uri, isDense);
+        for (uint i = 0; i < FragmentCount; i++)
+        {
+            WriteArray(uri, isDense);
         }
 
-        [DataTestMethod]
-        [DataRow(true, DisplayName = "Dense")]
-        [DataRow(false, DisplayName = "Sparse")]
-        public void TestHasConsolidatedMetadata(bool isDense)
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        uint fragmentCount = info.FragmentCount;
+
+        for (uint i = 0; i < fragmentCount; i++)
         {
-            using var uri = new TemporaryDirectory("fragment_info_has_consolidated_metadata");
-            CreateArray(uri, isDense);
-            for (uint i = 0; i < FragmentCount; i++)
-            {
-                WriteArray(uri, isDense);
-            }
+            Uri fragmentUri = new(info.GetFragmentUri(i));
 
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
+            ulong formatVersionFromPath = ulong.Parse(fragmentUri.LocalPath.Split('_')[^1]);
 
-            uint fragmentCount = info.FragmentCount;
+            Assert.AreEqual(formatVersionFromPath, info.GetFormatVersion(i));
+        }
+    }
 
-            for (uint i = 0; i < fragmentCount; i++)
-            {
-                Assert.IsFalse(info.HasConsolidatedMetadata(i));
-            }
+    [DataTestMethod]
+    [DataRow(true, DisplayName = "Dense")]
+    [DataRow(false, DisplayName = "Sparse")]
+    public void TestHasConsolidatedMetadata(bool isDense)
+    {
+        using var uri = new TemporaryDirectory("fragment_info_has_consolidated_metadata");
+        CreateArray(uri, isDense);
+        for (uint i = 0; i < FragmentCount; i++)
+        {
+            WriteArray(uri, isDense);
         }
 
-        [DataTestMethod]
-        [DataRow(true, DisplayName = "Dense")]
-        [DataRow(false, DisplayName = "Sparse")]
-        public void TestHasUnconsolidatedMetadata(bool isDense)
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        uint fragmentCount = info.FragmentCount;
+
+        for (uint i = 0; i < fragmentCount; i++)
         {
-            using var uri = new TemporaryDirectory("fragment_info_has_unconsolidated_metadata");
-            CreateArray(uri, isDense);
-            for (uint i = 0; i < FragmentCount; i++)
-            {
-                WriteArray(uri, isDense);
-            }
+            Assert.IsFalse(info.HasConsolidatedMetadata(i));
+        }
+    }
 
-            using FragmentInfo info = new FragmentInfo(_ctx, uri);
-            info.Load();
-
-            Assert.AreEqual(FragmentCount, info.FragmentWithUnconsolidatedMetadataCount);
+    [DataTestMethod]
+    [DataRow(true, DisplayName = "Dense")]
+    [DataRow(false, DisplayName = "Sparse")]
+    public void TestHasUnconsolidatedMetadata(bool isDense)
+    {
+        using var uri = new TemporaryDirectory("fragment_info_has_unconsolidated_metadata");
+        CreateArray(uri, isDense);
+        for (uint i = 0; i < FragmentCount; i++)
+        {
+            WriteArray(uri, isDense);
         }
 
-        private void CreateArray(string arrayUri, bool isDense)
+        using FragmentInfo info = new FragmentInfo(_ctx, uri);
+        info.Load();
+
+        Assert.AreEqual(FragmentCount, info.FragmentWithUnconsolidatedMetadataCount);
+    }
+
+    private void CreateArray(string arrayUri, bool isDense)
+    {
+        if (isDense)
         {
-            if (isDense)
-            {
-                CreateDenseArray(arrayUri);
-            }
-            else
-            {
-                CreateSparseVarDimArray(arrayUri);
-            }
+            CreateDenseArray(arrayUri);
         }
-
-        private void WriteArray(string arrayUri, bool isDense)
+        else
         {
-            if (isDense)
-            {
-                WriteDenseArray(arrayUri);
-            }
-            else
-            {
-                WriteSparseVarDimArray(arrayUri);
-            }
+            CreateSparseVarDimArray(arrayUri);
         }
+    }
 
-        private void CreateDenseArray(string arrayUri)
+    private void WriteArray(string arrayUri, bool isDense)
+    {
+        if (isDense)
         {
-            using Dimension rows = Dimension.Create(_ctx, nameof(rows), 1, 4, 2);
-            using Dimension columns = Dimension.Create(_ctx, nameof(columns), 1, 4, 2);
-
-            using Domain domain = new Domain(_ctx);
-            domain.AddDimension(rows);
-            domain.AddDimension(columns);
-
-            using Attribute a = new Attribute(_ctx, nameof(a), DataType.Int32);
-
-            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Dense);
-            schema.SetTileOrder(LayoutType.RowMajor);
-            schema.SetCellOrder(LayoutType.RowMajor);
-            schema.SetDomain(domain);
-            schema.AddAttribute(a);
-
-            Array.Create(_ctx, arrayUri, schema);
+            WriteDenseArray(arrayUri);
         }
-
-        private void WriteDenseArray(string arrayUri)
+        else
         {
-            int[] data = [1, 2, 3, 4, 5, 6, 7, 8];
-
-            using Array array = new Array(_ctx, arrayUri);
-            array.Open(QueryType.Write);
-            using Query query = new Query(array);
-            query.SetDataBuffer("a", data);
-            using Subarray subarray = new Subarray(array);
-            subarray.SetSubarray(1, 2, 1, 4);
-            query.SetSubarray(subarray);
-
-            query.Submit();
+            WriteSparseVarDimArray(arrayUri);
         }
+    }
 
-        private void CreateSparseVarDimArray(string arrayUri)
+    private void CreateDenseArray(string arrayUri)
+    {
+        using Dimension rows = Dimension.Create(_ctx, nameof(rows), 1, 4, 2);
+        using Dimension columns = Dimension.Create(_ctx, nameof(columns), 1, 4, 2);
+
+        using Domain domain = new Domain(_ctx);
+        domain.AddDimension(rows);
+        domain.AddDimension(columns);
+
+        using Attribute a = new Attribute(_ctx, nameof(a), DataType.Int32);
+
+        using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Dense);
+        schema.SetTileOrder(LayoutType.RowMajor);
+        schema.SetCellOrder(LayoutType.RowMajor);
+        schema.SetDomain(domain);
+        schema.AddAttribute(a);
+
+        Array.Create(_ctx, arrayUri, schema);
+    }
+
+    private void WriteDenseArray(string arrayUri)
+    {
+        int[] data = [1, 2, 3, 4, 5, 6, 7, 8];
+
+        using Array array = new Array(_ctx, arrayUri);
+        array.Open(QueryType.Write);
+        using Query query = new Query(array);
+        query.SetDataBuffer("a", data);
+        using Subarray subarray = new Subarray(array);
+        subarray.SetSubarray(1, 2, 1, 4);
+        query.SetSubarray(subarray);
+
+        query.Submit();
+    }
+
+    private void CreateSparseVarDimArray(string arrayUri)
+    {
+        using Dimension d1 = Dimension.CreateString(_ctx, nameof(d1));
+
+        using Domain domain = new Domain(_ctx);
+        domain.AddDimension(d1);
+
+        using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.Int32);
+
+        using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
+        schema.SetTileOrder(LayoutType.RowMajor);
+        schema.SetCellOrder(LayoutType.RowMajor);
+        schema.SetDomain(domain);
+        schema.AddAttribute(a1);
+
+        Array.Create(_ctx, arrayUri, schema);
+    }
+
+    private void WriteSparseVarDimArray(string arrayUri)
+    {
+        byte[] dData = Encoding.ASCII.GetBytes("abbccddee");
+        ulong[] dOffsets = [0, 2, 4, 6, 8];
+
+        int[] a1 = [1, 2, 3, 4, 5];
+
+        using Array array = new Array(_ctx, arrayUri);
+        array.Open(QueryType.Write);
+        using Query query = new Query(array);
+        query.SetLayout(LayoutType.GlobalOrder);
+
+        query.SetDataBuffer("d1", dData);
+        query.SetOffsetsBuffer("d1", dOffsets);
+        query.SetDataBuffer("a1", a1);
+
+        query.Submit();
+        query.FinalizeQuery();
+    }
+
+    private void CreateSparseArrayNoVarDim(string arrayUri)
+    {
+        using Dimension d1 = Dimension.Create<long>(_ctx, nameof(d1), 1, 10, 5);
+        using Dimension d2 = Dimension.Create<long>(_ctx, nameof(d2), 1, 10, 5);
+
+        using Domain domain = new Domain(_ctx);
+        domain.AddDimension(d1);
+        domain.AddDimension(d2);
+
+        using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.Int32);
+
+        using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
+        schema.SetTileOrder(LayoutType.RowMajor);
+        schema.SetCellOrder(LayoutType.RowMajor);
+        schema.SetCapacity(2);
+        schema.SetDomain(domain);
+        schema.AddAttribute(a1);
+
+        schema.Check();
+        Array.Create(_ctx, arrayUri, schema);
+    }
+
+    private void CreateSparseArrayNoVarDimInt32(string arrayUri)
+    {
+        using Dimension d1 = Dimension.Create<int>(_ctx, nameof(d1), 1, 10, 5);
+        using Dimension d2 = Dimension.Create<int>(_ctx, nameof(d2), 1, 10, 5);
+
+        using Domain domain = new Domain(_ctx);
+        domain.AddDimension(d1);
+        domain.AddDimension(d2);
+
+        using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.Int32);
+
+        using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
+        schema.SetTileOrder(LayoutType.RowMajor);
+        schema.SetCellOrder(LayoutType.RowMajor);
+        schema.SetCapacity(2);
+        schema.SetDomain(domain);
+        schema.AddAttribute(a1);
+
+        schema.Check();
+        Array.Create(_ctx, arrayUri, schema);
+    }
+
+    private void WriteSparseArrayNoVarDim3Frags(string arrayUri)
+    {
+        using Array a = new Array(_ctx, arrayUri);
+        a.Open(QueryType.Write);
+
+        WriteImpl([1, 2], [1, 2], [1, 2]);
+        WriteImpl([1, 2, 7, 8], [1, 2, 7, 8], [9, 10, 11, 12]);
+        WriteImpl([1, 2, 7, 1], [1, 2, 7, 8], [5, 6, 7, 8]);
+
+        void WriteImpl(long[] d1, long[] d2, int[] a1)
         {
-            using Dimension d1 = Dimension.CreateString(_ctx, nameof(d1));
-
-            using Domain domain = new Domain(_ctx);
-            domain.AddDimension(d1);
-
-            using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.Int32);
-
-            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
-            schema.SetTileOrder(LayoutType.RowMajor);
-            schema.SetCellOrder(LayoutType.RowMajor);
-            schema.SetDomain(domain);
-            schema.AddAttribute(a1);
-
-            Array.Create(_ctx, arrayUri, schema);
-        }
-
-        private void WriteSparseVarDimArray(string arrayUri)
-        {
-            byte[] dData = Encoding.ASCII.GetBytes("abbccddee");
-            ulong[] dOffsets = [0, 2, 4, 6, 8];
-
-            int[] a1 = [1, 2, 3, 4, 5];
-
-            using Array array = new Array(_ctx, arrayUri);
-            array.Open(QueryType.Write);
-            using Query query = new Query(array);
-            query.SetLayout(LayoutType.GlobalOrder);
-
-            query.SetDataBuffer("d1", dData);
-            query.SetOffsetsBuffer("d1", dOffsets);
+            using Query query = new Query(a);
+            query.SetLayout(LayoutType.Unordered);
+            query.SetDataBuffer("d1", d1);
+            query.SetDataBuffer("d2", d2);
             query.SetDataBuffer("a1", a1);
 
             query.Submit();
             query.FinalizeQuery();
         }
+    }
 
-        private void CreateSparseArrayNoVarDim(string arrayUri)
+    private void WriteSparseArrayNoVarDim3FragsInt32(string arrayUri)
+    {
+        using Array a = new Array(_ctx, arrayUri);
+        a.Open(QueryType.Write);
+
+        WriteImpl([1, 2], [1, 2], [1, 2]);
+        WriteImpl([1, 2, 7, 8], [1, 2, 7, 8], [9, 10, 11, 12]);
+        WriteImpl([1, 2, 7, 1], [1, 2, 7, 8], [5, 6, 7, 8]);
+
+        void WriteImpl(int[] d1, int[] d2, int[] a1)
         {
-            using Dimension d1 = Dimension.Create<long>(_ctx, nameof(d1), 1, 10, 5);
-            using Dimension d2 = Dimension.Create<long>(_ctx, nameof(d2), 1, 10, 5);
-
-            using Domain domain = new Domain(_ctx);
-            domain.AddDimension(d1);
-            domain.AddDimension(d2);
-
-            using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.Int32);
-
-            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
-            schema.SetTileOrder(LayoutType.RowMajor);
-            schema.SetCellOrder(LayoutType.RowMajor);
-            schema.SetCapacity(2);
-            schema.SetDomain(domain);
-            schema.AddAttribute(a1);
-
-            schema.Check();
-            Array.Create(_ctx, arrayUri, schema);
-        }
-
-        private void CreateSparseArrayNoVarDimInt32(string arrayUri)
-        {
-            using Dimension d1 = Dimension.Create<int>(_ctx, nameof(d1), 1, 10, 5);
-            using Dimension d2 = Dimension.Create<int>(_ctx, nameof(d2), 1, 10, 5);
-
-            using Domain domain = new Domain(_ctx);
-            domain.AddDimension(d1);
-            domain.AddDimension(d2);
-
-            using Attribute a1 = new Attribute(_ctx, nameof(a1), DataType.Int32);
-
-            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
-            schema.SetTileOrder(LayoutType.RowMajor);
-            schema.SetCellOrder(LayoutType.RowMajor);
-            schema.SetCapacity(2);
-            schema.SetDomain(domain);
-            schema.AddAttribute(a1);
-
-            schema.Check();
-            Array.Create(_ctx, arrayUri, schema);
-        }
-
-        private void WriteSparseArrayNoVarDim3Frags(string arrayUri)
-        {
-            using Array a = new Array(_ctx, arrayUri);
-            a.Open(QueryType.Write);
-
-            WriteImpl([1, 2], [1, 2], [1, 2]);
-            WriteImpl([1, 2, 7, 8], [1, 2, 7, 8], [9, 10, 11, 12]);
-            WriteImpl([1, 2, 7, 1], [1, 2, 7, 8], [5, 6, 7, 8]);
-
-            void WriteImpl(long[] d1, long[] d2, int[] a1)
-            {
-                using Query query = new Query(a);
-                query.SetLayout(LayoutType.Unordered);
-                query.SetDataBuffer("d1", d1);
-                query.SetDataBuffer("d2", d2);
-                query.SetDataBuffer("a1", a1);
-
-                query.Submit();
-                query.FinalizeQuery();
-            }
-        }
-
-        private void WriteSparseArrayNoVarDim3FragsInt32(string arrayUri)
-        {
-            using Array a = new Array(_ctx, arrayUri);
-            a.Open(QueryType.Write);
-
-            WriteImpl([1, 2], [1, 2], [1, 2]);
-            WriteImpl([1, 2, 7, 8], [1, 2, 7, 8], [9, 10, 11, 12]);
-            WriteImpl([1, 2, 7, 1], [1, 2, 7, 8], [5, 6, 7, 8]);
-
-            void WriteImpl(int[] d1, int[] d2, int[] a1)
-            {
-                using Query query = new Query(a);
-                query.SetLayout(LayoutType.Unordered);
-                query.SetDataBuffer("d1", d1);
-                query.SetDataBuffer("d2", d2);
-                query.SetDataBuffer("a1", a1);
-
-                query.Submit();
-                query.FinalizeQuery();
-            }
-        }
-
-        private void CreateSparseVarDimArrayForMbrTesting(string arrayUri)
-        {
-            using Dimension d = Dimension.CreateString(_ctx, nameof(d));
-            using Domain domain = new Domain(_ctx);
-            domain.AddDimension(d);
-
-            using Attribute a = new Attribute(_ctx, nameof(a), DataType.Int32);
-            using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
-            schema.SetTileOrder(LayoutType.RowMajor);
-            schema.SetCellOrder(LayoutType.RowMajor);
-            schema.SetDomain(domain);
-            schema.SetCapacity(2);
-            schema.AddAttribute(a);
-
-            Array.Create(_ctx, arrayUri, schema);
-        }
-
-        private void WriteSparseVarDimArrayForMbrTesting(string arrayUri)
-        {
-            byte[] dData = Encoding.ASCII.GetBytes("abbcddd");
-            ulong[] dOffsets = [0, 1, 3, 4];
-
-            int[] a = [11, 12, 13, 14];
-
-            using Array array = new Array(_ctx, arrayUri);
-            array.Open(QueryType.Write);
-            using Query query = new Query(array);
+            using Query query = new Query(a);
             query.SetLayout(LayoutType.Unordered);
-
-            query.SetDataBuffer("d", dData);
-            query.SetOffsetsBuffer("d", dOffsets);
-            query.SetDataBuffer("a", a);
+            query.SetDataBuffer("d1", d1);
+            query.SetDataBuffer("d2", d2);
+            query.SetDataBuffer("a1", a1);
 
             query.Submit();
-
             query.FinalizeQuery();
         }
+    }
+
+    private void CreateSparseVarDimArrayForMbrTesting(string arrayUri)
+    {
+        using Dimension d = Dimension.CreateString(_ctx, nameof(d));
+        using Domain domain = new Domain(_ctx);
+        domain.AddDimension(d);
+
+        using Attribute a = new Attribute(_ctx, nameof(a), DataType.Int32);
+        using ArraySchema schema = new ArraySchema(_ctx, ArrayType.Sparse);
+        schema.SetTileOrder(LayoutType.RowMajor);
+        schema.SetCellOrder(LayoutType.RowMajor);
+        schema.SetDomain(domain);
+        schema.SetCapacity(2);
+        schema.AddAttribute(a);
+
+        Array.Create(_ctx, arrayUri, schema);
+    }
+
+    private void WriteSparseVarDimArrayForMbrTesting(string arrayUri)
+    {
+        byte[] dData = Encoding.ASCII.GetBytes("abbcddd");
+        ulong[] dOffsets = [0, 1, 3, 4];
+
+        int[] a = [11, 12, 13, 14];
+
+        using Array array = new Array(_ctx, arrayUri);
+        array.Open(QueryType.Write);
+        using Query query = new Query(array);
+        query.SetLayout(LayoutType.Unordered);
+
+        query.SetDataBuffer("d", dData);
+        query.SetOffsetsBuffer("d", dOffsets);
+        query.SetDataBuffer("a", a);
+
+        query.Submit();
+
+        query.FinalizeQuery();
     }
 }

--- a/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
+++ b/tests/TileDB.CSharp.Test/FragmentInfoTest.cs
@@ -423,7 +423,7 @@ namespace TileDB.CSharp.Test
 
         private void WriteDenseArray(string arrayUri)
         {
-            int[] data = { 1, 2, 3, 4, 5, 6, 7, 8 };
+            int[] data = [1, 2, 3, 4, 5, 6, 7, 8];
 
             using Array array = new Array(_ctx, arrayUri);
             array.Open(QueryType.Write);
@@ -457,9 +457,9 @@ namespace TileDB.CSharp.Test
         private void WriteSparseVarDimArray(string arrayUri)
         {
             byte[] dData = Encoding.ASCII.GetBytes("abbccddee");
-            ulong[] dOffsets = { 0, 2, 4, 6, 8 };
+            ulong[] dOffsets = [0, 2, 4, 6, 8];
 
-            int[] a1 = { 1, 2, 3, 4, 5 };
+            int[] a1 = [1, 2, 3, 4, 5];
 
             using Array array = new Array(_ctx, arrayUri);
             array.Open(QueryType.Write);
@@ -523,9 +523,9 @@ namespace TileDB.CSharp.Test
             using Array a = new Array(_ctx, arrayUri);
             a.Open(QueryType.Write);
 
-            WriteImpl(new long[] { 1, 2 }, new long[] { 1, 2 }, new int[] { 1, 2 });
-            WriteImpl(new long[] { 1, 2, 7, 8 }, new long[] { 1, 2, 7, 8 }, new int[] { 9, 10, 11, 12 });
-            WriteImpl(new long[] { 1, 2, 7, 1 }, new long[] { 1, 2, 7, 8 }, new int[] { 5, 6, 7, 8 });
+            WriteImpl([1, 2], [1, 2], [1, 2]);
+            WriteImpl([1, 2, 7, 8], [1, 2, 7, 8], [9, 10, 11, 12]);
+            WriteImpl([1, 2, 7, 1], [1, 2, 7, 8], [5, 6, 7, 8]);
 
             void WriteImpl(long[] d1, long[] d2, int[] a1)
             {
@@ -545,9 +545,9 @@ namespace TileDB.CSharp.Test
             using Array a = new Array(_ctx, arrayUri);
             a.Open(QueryType.Write);
 
-            WriteImpl(new int[] { 1, 2 }, new int[] { 1, 2 }, new int[] { 1, 2 });
-            WriteImpl(new int[] { 1, 2, 7, 8 }, new int[] { 1, 2, 7, 8 }, new int[] { 9, 10, 11, 12 });
-            WriteImpl(new int[] { 1, 2, 7, 1 }, new int[] { 1, 2, 7, 8 }, new int[] { 5, 6, 7, 8 });
+            WriteImpl([1, 2], [1, 2], [1, 2]);
+            WriteImpl([1, 2, 7, 8], [1, 2, 7, 8], [9, 10, 11, 12]);
+            WriteImpl([1, 2, 7, 1], [1, 2, 7, 8], [5, 6, 7, 8]);
 
             void WriteImpl(int[] d1, int[] d2, int[] a1)
             {
@@ -582,9 +582,9 @@ namespace TileDB.CSharp.Test
         private void WriteSparseVarDimArrayForMbrTesting(string arrayUri)
         {
             byte[] dData = Encoding.ASCII.GetBytes("abbcddd");
-            ulong[] dOffsets = { 0, 1, 3, 4 };
+            ulong[] dOffsets = [0, 1, 3, 4];
 
-            int[] a = { 11, 12, 13, 14 };
+            int[] a = [11, 12, 13, 14];
 
             using Array array = new Array(_ctx, arrayUri);
             array.Open(QueryType.Write);

--- a/tests/TileDB.CSharp.Test/GroupTest.cs
+++ b/tests/TileDB.CSharp.Test/GroupTest.cs
@@ -2,150 +2,149 @@ using System;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class GroupTest
 {
-    [TestClass]
-    public class GroupTest
+    [TestMethod]
+    public void TestGroupMetadata()
     {
-        [TestMethod]
-        public void TestGroupMetadata()
+        var ctx = Context.GetDefault();
+        using var temp_dir = new TemporaryDirectory("group_metadata");
+        string group1_uri = Path.Combine(temp_dir, "group1");
+        Group.Create(ctx, group1_uri);
+        using var group = new Group(ctx, group1_uri);
+        group.Open(QueryType.Write);
+        group.Close();
+
+        // Put metadata on a group that is not opened
+        int v = 5;
+        Assert.ThrowsException<TileDBException>(() => group.PutMetadata("key", v));
+
+        // Write metadata on a group opened in READ mode
+        group.Open(QueryType.Read);
+        Assert.ThrowsException<TileDBException>(() => group.PutMetadata("key", v));
+
+        // Close and reopen in WRITE mode
+        group.Close();
+        group.Open(QueryType.Write);
+
+        group.PutMetadata("key", v);
+        group.Close();
+
+        group.Open(QueryType.Read);
+        var data = group.GetMetadata<int>("key");
+
+        Assert.AreEqual(5, data[0]);
+
+        group.Close();
+    }
+
+    [TestMethod]
+    public void TestGroupMember()
+    {
+        var ctx = Context.GetDefault();
+        using var temp_dir = new TemporaryDirectory("group_member");
+
+        string array1_uri = Path.Combine(temp_dir, "array1");
+        CreateArray(array1_uri);
+        string array2_uri = Path.Combine(temp_dir, "array2");
+        CreateArray(array2_uri);
+
+        string group1_uri = Path.Combine(temp_dir, "group1");
+        Group.Create(ctx, group1_uri);
+
+        string group2_uri = Path.Combine(temp_dir, "group2");
+        Group.Create(ctx, group2_uri);
+
+        using var group1 = new Group(ctx, group1_uri);
+        group1.Open(QueryType.Write);
+
+        group1.AddMember(array1_uri, false, "array1");
+        group1.AddMember(array2_uri, false, "array2");
+        group1.Close();
+
+        using var group2 = new Group(ctx, group2_uri);
+        group2.Open(QueryType.Write);
+        group2.AddMember(array2_uri, false, "array2");
+        group2.Close();
+
+        //Reopen in read mode
+        group1.Open(QueryType.Read);
+        Assert.AreEqual<ulong>(2, group1.MemberCount());
+        group1.Close();
+
+        //Reopen in write mode
+        group1.Open(QueryType.Write);
+        group1.RemoveMember("array1");
+        group1.Close();
+
+        //Reopen in read mode
+        group1.Open(QueryType.Read);
+        Assert.AreEqual<ulong>(1, group1.MemberCount());
+        group1.Close();
+    }
+
+    [TestMethod]
+    public void TestIsUriRelative()
+    {
+        var ctx = Context.GetDefault();
+        using var uri = new TemporaryDirectory("group_is_uri_relative");
+        string group1Uri = Path.Combine(uri, "group1");
+        Group.Create(ctx, group1Uri);
+
+        var array1Uri = Path.Combine(uri, "array1");
+        CreateArray(array1Uri);
+        var array2Uri = Path.Combine(group1Uri, "array2");
+        CreateArray(array2Uri);
+
+        using (var group = new Group(ctx, group1Uri))
         {
-            var ctx = Context.GetDefault();
-            using var temp_dir = new TemporaryDirectory("group_metadata");
-            string group1_uri = Path.Combine(temp_dir, "group1");
-            Group.Create(ctx, group1_uri);
-            using var group = new Group(ctx, group1_uri);
             group.Open(QueryType.Write);
+
+            group.AddMember(array1Uri, false, "array1");
+            group.AddMember("array2", true, "array2");
             group.Close();
+        }
 
-            // Put metadata on a group that is not opened
-            int v = 5;
-            Assert.ThrowsException<TileDBException>(() => group.PutMetadata("key", v));
-
-            // Write metadata on a group opened in READ mode
+        using (var group = new Group(ctx, group1Uri))
+        {
             group.Open(QueryType.Read);
-            Assert.ThrowsException<TileDBException>(() => group.PutMetadata("key", v));
-
-            // Close and reopen in WRITE mode
-            group.Close();
-            group.Open(QueryType.Write);
-
-            group.PutMetadata("key", v);
-            group.Close();
-
-            group.Open(QueryType.Read);
-            var data = group.GetMetadata<int>("key");
-
-            Assert.AreEqual(5, data[0]);
-
-            group.Close();
+            Assert.IsFalse(group.IsUriRelative("array1"));
+            Assert.IsTrue(group.IsUriRelative("array2"));
         }
+    }
 
-        [TestMethod]
-        public void TestGroupMember()
+    private static void CreateArray(string uri)
+    {
+        string tmpArrayPath = uri;
+        if (Directory.Exists(tmpArrayPath))
         {
-            var ctx = Context.GetDefault();
-            using var temp_dir = new TemporaryDirectory("group_member");
-
-            string array1_uri = Path.Combine(temp_dir, "array1");
-            CreateArray(array1_uri);
-            string array2_uri = Path.Combine(temp_dir, "array2");
-            CreateArray(array2_uri);
-
-            string group1_uri = Path.Combine(temp_dir, "group1");
-            Group.Create(ctx, group1_uri);
-
-            string group2_uri = Path.Combine(temp_dir, "group2");
-            Group.Create(ctx, group2_uri);
-
-            using var group1 = new Group(ctx, group1_uri);
-            group1.Open(QueryType.Write);
-
-            group1.AddMember(array1_uri, false, "array1");
-            group1.AddMember(array2_uri, false, "array2");
-            group1.Close();
-
-            using var group2 = new Group(ctx, group2_uri);
-            group2.Open(QueryType.Write);
-            group2.AddMember(array2_uri, false, "array2");
-            group2.Close();
-
-            //Reopen in read mode
-            group1.Open(QueryType.Read);
-            Assert.AreEqual<ulong>(2, group1.MemberCount());
-            group1.Close();
-
-            //Reopen in write mode
-            group1.Open(QueryType.Write);
-            group1.RemoveMember("array1");
-            group1.Close();
-
-            //Reopen in read mode
-            group1.Open(QueryType.Read);
-            Assert.AreEqual<ulong>(1, group1.MemberCount());
-            group1.Close();
+            Directory.Delete(tmpArrayPath, true);
         }
 
-        [TestMethod]
-        public void TestIsUriRelative()
-        {
-            var ctx = Context.GetDefault();
-            using var uri = new TemporaryDirectory("group_is_uri_relative");
-            string group1Uri = Path.Combine(uri, "group1");
-            Group.Create(ctx, group1Uri);
+        var context = Context.GetDefault();
+        var domain = new Domain(context);
+        Assert.IsNotNull(domain);
 
-            var array1Uri = Path.Combine(uri, "array1");
-            CreateArray(array1Uri);
-            var array2Uri = Path.Combine(group1Uri, "array2");
-            CreateArray(array2Uri);
+        var dim_1 = Dimension.Create(context, "d1", 1, 1, 1);
+        Assert.IsNotNull(dim_1);
+        domain.AddDimension(dim_1);
 
-            using (var group = new Group(ctx, group1Uri))
-            {
-                group.Open(QueryType.Write);
+        var array_schema = new ArraySchema(context, ArrayType.Dense);
+        Assert.IsNotNull(array_schema);
 
-                group.AddMember(array1Uri, false, "array1");
-                group.AddMember("array2", true, "array2");
-                group.Close();
-            }
+        var attr1 = new Attribute(context, "a1", DataType.Float32);
+        Assert.IsNotNull(attr1);
+        array_schema.AddAttribute(attr1);
 
-            using (var group = new Group(ctx, group1Uri))
-            {
-                group.Open(QueryType.Read);
-                Assert.IsFalse(group.IsUriRelative("array1"));
-                Assert.IsTrue(group.IsUriRelative("array2"));
-            }
-        }
+        array_schema.SetDomain(domain);
+        array_schema.SetCellOrder(LayoutType.RowMajor);
+        array_schema.SetTileOrder(LayoutType.RowMajor);
 
-        private static void CreateArray(string uri)
-        {
-            string tmpArrayPath = uri;
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
+        array_schema.Check();
 
-            var context = Context.GetDefault();
-            var domain = new Domain(context);
-            Assert.IsNotNull(domain);
-
-            var dim_1 = Dimension.Create(context, "d1", 1, 1, 1);
-            Assert.IsNotNull(dim_1);
-            domain.AddDimension(dim_1);
-
-            var array_schema = new ArraySchema(context, ArrayType.Dense);
-            Assert.IsNotNull(array_schema);
-
-            var attr1 = new Attribute(context, "a1", DataType.Float32);
-            Assert.IsNotNull(attr1);
-            array_schema.AddAttribute(attr1);
-
-            array_schema.SetDomain(domain);
-            array_schema.SetCellOrder(LayoutType.RowMajor);
-            array_schema.SetTileOrder(LayoutType.RowMajor);
-
-            array_schema.Check();
-
-            Array.Create(context, tmpArrayPath, array_schema);
-        }
+        Array.Create(context, tmpArrayPath, array_schema);
     }
 }

--- a/tests/TileDB.CSharp.Test/IncompleteQueryTest.cs
+++ b/tests/TileDB.CSharp.Test/IncompleteQueryTest.cs
@@ -3,143 +3,142 @@ using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class IncompleteQueryTest
 {
-    [TestClass]
-    public class IncompleteQueryTest
+    private static readonly Context Ctx = Context.GetDefault();
+
+    private static void CreateArray(string path)
     {
-        private static readonly Context Ctx = Context.GetDefault();
+        var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 10, extent: 4);
+        var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 10, extent: 4);
+        var domain = new Domain(Ctx);
+        domain.AddDimension(dim1);
+        domain.AddDimension(dim2);
+        var array_schema = new ArraySchema(Ctx, ArrayType.Sparse);
+        var attr = new Attribute(Ctx, "a", DataType.Int32);
+        attr.SetCellValNum(Attribute.VariableSized);
 
-        private static void CreateArray(string path)
+        array_schema.AddAttribute(attr);
+        array_schema.SetDomain(domain);
+        array_schema.Check();
+
+        Array.Create(Ctx, path, array_schema);
+    }
+
+    private static void WriteArray(string path, Entry[] data)
+    {
+        var dim1_data_buffer = data.Select(x => x.Row).ToArray();
+        var dim2_data_buffer = data.Select(x => x.Column).ToArray();
+        var attr_data_buffer = data.SelectMany(x => x.Data).ToArray();
+        var attr_offsets_buffer = new ulong[data.Length];
+        for (int i = 1; i < data.Length; i++)
         {
-            var dim1 = Dimension.Create(Ctx, "rows", boundLower: 1, boundUpper: 10, extent: 4);
-            var dim2 = Dimension.Create(Ctx, "cols", boundLower: 1, boundUpper: 10, extent: 4);
-            var domain = new Domain(Ctx);
-            domain.AddDimension(dim1);
-            domain.AddDimension(dim2);
-            var array_schema = new ArraySchema(Ctx, ArrayType.Sparse);
-            var attr = new Attribute(Ctx, "a", DataType.Int32);
-            attr.SetCellValNum(Attribute.VariableSized);
-
-            array_schema.AddAttribute(attr);
-            array_schema.SetDomain(domain);
-            array_schema.Check();
-
-            Array.Create(Ctx, path, array_schema);
+            attr_offsets_buffer[i] = attr_offsets_buffer[i - 1] + (ulong)data[i - 1].Data.Length * sizeof(int);
         }
 
-        private static void WriteArray(string path, Entry[] data)
+        using (var array_write = new Array(Ctx, path))
         {
-            var dim1_data_buffer = data.Select(x => x.Row).ToArray();
-            var dim2_data_buffer = data.Select(x => x.Column).ToArray();
-            var attr_data_buffer = data.SelectMany(x => x.Data).ToArray();
-            var attr_offsets_buffer = new ulong[data.Length];
-            for (int i = 1; i < data.Length; i++)
-            {
-                attr_offsets_buffer[i] = attr_offsets_buffer[i - 1] + (ulong)data[i - 1].Data.Length * sizeof(int);
-            }
-
-            using (var array_write = new Array(Ctx, path))
-            {
-                array_write.Open(QueryType.Write);
-                var query_write = new Query(array_write);
-                query_write.SetLayout(LayoutType.Unordered);
-                query_write.SetDataBuffer("rows", dim1_data_buffer);
-                query_write.SetDataBuffer("cols", dim2_data_buffer);
-                query_write.SetDataBuffer("a", attr_data_buffer);
-                query_write.SetOffsetsBuffer("a", attr_offsets_buffer);
-                query_write.Submit();
-                array_write.Close();
-            }
+            array_write.Open(QueryType.Write);
+            var query_write = new Query(array_write);
+            query_write.SetLayout(LayoutType.Unordered);
+            query_write.SetDataBuffer("rows", dim1_data_buffer);
+            query_write.SetDataBuffer("cols", dim2_data_buffer);
+            query_write.SetDataBuffer("a", attr_data_buffer);
+            query_write.SetOffsetsBuffer("a", attr_offsets_buffer);
+            query_write.Submit();
+            array_write.Close();
         }
+    }
 
-        private static List<Entry> ReadArray(string path)
+    private static List<Entry> ReadArray(string path)
+    {
+        var result = new List<Entry>();
+
+        var dim1_data_buffer_read = new int[1];
+        var dim2_data_buffer_read = new int[1];
+        var attr_data_buffer_read = new int[1];
+        var attr_offsets_buffer = new ulong[1];
+
+        using (var array_read = new Array(Ctx, path))
         {
-            var result = new List<Entry>();
+            array_read.Open(QueryType.Read);
+            var query_read = new Query(array_read);
+            query_read.SetLayout(LayoutType.Unordered);
+            query_read.SetDataBuffer("rows", dim1_data_buffer_read);
+            query_read.SetDataBuffer("cols", dim2_data_buffer_read);
+            query_read.SetDataBuffer("a", attr_data_buffer_read);
+            query_read.SetOffsetsBuffer("a", attr_offsets_buffer);
 
-            var dim1_data_buffer_read = new int[1];
-            var dim2_data_buffer_read = new int[1];
-            var attr_data_buffer_read = new int[1];
-            var attr_offsets_buffer = new ulong[1];
-
-            using (var array_read = new Array(Ctx, path))
+            QueryStatus status;
+            do
             {
-                array_read.Open(QueryType.Read);
-                var query_read = new Query(array_read);
-                query_read.SetLayout(LayoutType.Unordered);
-                query_read.SetDataBuffer("rows", dim1_data_buffer_read);
-                query_read.SetDataBuffer("cols", dim2_data_buffer_read);
-                query_read.SetDataBuffer("a", attr_data_buffer_read);
-                query_read.SetOffsetsBuffer("a", attr_offsets_buffer);
+                query_read.Submit();
 
-                QueryStatus status;
-                do
+                status = query_read.Status();
+
+                var resultNum = (int)query_read.GetResultDataElements("rows");
+                var attrNum = (int)query_read.GetResultDataElements("a");
+
+                if (status == QueryStatus.Incomplete && resultNum == 0 && query_read.GetStatusDetails().Reason == QueryStatusDetailsReason.UserBufferSize)
                 {
-                    query_read.Submit();
+                    dim1_data_buffer_read = new int[dim1_data_buffer_read.Length * 2];
+                    query_read.SetDataBuffer("rows", dim1_data_buffer_read);
 
-                    status = query_read.Status();
+                    dim2_data_buffer_read = new int[dim2_data_buffer_read.Length * 2];
+                    query_read.SetDataBuffer("cols", dim2_data_buffer_read);
 
-                    var resultNum = (int)query_read.GetResultDataElements("rows");
-                    var attrNum = (int)query_read.GetResultDataElements("a");
+                    attr_data_buffer_read = new int[attr_data_buffer_read.Length * 2];
+                    query_read.SetDataBuffer("a", attr_data_buffer_read);
 
-                    if (status == QueryStatus.Incomplete && resultNum == 0 && query_read.GetStatusDetails().Reason == QueryStatusDetailsReason.UserBufferSize)
+                    attr_offsets_buffer = new ulong[attr_offsets_buffer.Length * 2];
+                    query_read.SetOffsetsBuffer("a", attr_offsets_buffer);
+                }
+                else
+                {
+                    for (int i = 0; i < resultNum; i++)
                     {
-                        dim1_data_buffer_read = new int[dim1_data_buffer_read.Length * 2];
-                        query_read.SetDataBuffer("rows", dim1_data_buffer_read);
-
-                        dim2_data_buffer_read = new int[dim2_data_buffer_read.Length * 2];
-                        query_read.SetDataBuffer("cols", dim2_data_buffer_read);
-
-                        attr_data_buffer_read = new int[attr_data_buffer_read.Length * 2];
-                        query_read.SetDataBuffer("a", attr_data_buffer_read);
-
-                        attr_offsets_buffer = new ulong[attr_offsets_buffer.Length * 2];
-                        query_read.SetOffsetsBuffer("a", attr_offsets_buffer);
-                    }
-                    else
-                    {
-                        for (int i = 0; i < resultNum; i++)
-                        {
-                            var attrOffsetStart = (int)attr_offsets_buffer[i] / sizeof(int);
-                            var attrOffsetEnd = i == resultNum - 1 ? attrNum : (int)attr_offsets_buffer[i + 1] / sizeof(int);
-                            var attrLength = attrOffsetEnd - attrOffsetStart;
-                            var attrData = attr_data_buffer_read.AsSpan(attrOffsetStart, attrLength).ToArray();
-                            result.Add(new(Row: dim1_data_buffer_read[i], Column: dim2_data_buffer_read[i], Data: attrData));
-                        }
+                        var attrOffsetStart = (int)attr_offsets_buffer[i] / sizeof(int);
+                        var attrOffsetEnd = i == resultNum - 1 ? attrNum : (int)attr_offsets_buffer[i + 1] / sizeof(int);
+                        var attrLength = attrOffsetEnd - attrOffsetStart;
+                        var attrData = attr_data_buffer_read.AsSpan(attrOffsetStart, attrLength).ToArray();
+                        result.Add(new(Row: dim1_data_buffer_read[i], Column: dim2_data_buffer_read[i], Data: attrData));
                     }
                 }
-                while (status == QueryStatus.Incomplete);
-
-                array_read.Close();
             }
+            while (status == QueryStatus.Incomplete);
 
-            return result;
+            array_read.Close();
         }
 
-        [TestMethod]
-        public void TestVariableSizedAttributes()
-        {
-            using var path = new TemporaryDirectory("incomplete-query-variable");
+        return result;
+    }
 
-            Entry[] entries =
-            [
-                new(1, 1, [1]),
-                new(2, 3, [2, 20]),
-                new(3, 4, [3, 30, 300]),
-                new(4, 5, [4, 40, 400, 4000])
-            ];
+    [TestMethod]
+    public void TestVariableSizedAttributes()
+    {
+        using var path = new TemporaryDirectory("incomplete-query-variable");
 
-            CreateArray(path);
-            WriteArray(path, entries);
-            List<Entry> readEntries = ReadArray(path);
+        Entry[] entries =
+        [
+            new(1, 1, [1]),
+            new(2, 3, [2, 20]),
+            new(3, 4, [3, 30, 300]),
+            new(4, 5, [4, 40, 400, 4000])
+        ];
 
-            CollectionAssert.AreEqual(entries, readEntries);
-        }
+        CreateArray(path);
+        WriteArray(path, entries);
+        List<Entry> readEntries = ReadArray(path);
 
-        private record struct Entry(int Row, int Column, int[] Data) : IEquatable<Entry>
-        {
-            public bool Equals(Entry other) =>
-                Row == other.Row && Column == other.Column && Data.AsSpan().SequenceEqual(other.Data);
-        }
+        CollectionAssert.AreEqual(entries, readEntries);
+    }
+
+    private record struct Entry(int Row, int Column, int[] Data) : IEquatable<Entry>
+    {
+        public bool Equals(Entry other) =>
+            Row == other.Row && Column == other.Column && Data.AsSpan().SequenceEqual(other.Data);
     }
 }

--- a/tests/TileDB.CSharp.Test/IncompleteQueryTest.cs
+++ b/tests/TileDB.CSharp.Test/IncompleteQueryTest.cs
@@ -121,13 +121,13 @@ namespace TileDB.CSharp.Test
         {
             using var path = new TemporaryDirectory("incomplete-query-variable");
 
-            Entry[] entries = new Entry[]
-            {
-                new(1, 1, new int[] { 1 }),
-                new(2, 3, new int[] { 2, 20 }),
-                new(3, 4, new int[] { 3, 30, 300 }),
-                new(4, 5, new int[] { 4, 40, 400, 4000 })
-            };
+            Entry[] entries =
+            [
+                new(1, 1, [1]),
+                new(2, 3, [2, 20]),
+                new(3, 4, [3, 30, 300]),
+                new(4, 5, [4, 40, 400, 4000])
+            ];
 
             CreateArray(path);
             WriteArray(path, entries);

--- a/tests/TileDB.CSharp.Test/QueryConditionTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryConditionTest.cs
@@ -1,282 +1,281 @@
 using System;
 using System.IO;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class QueryConditionTest
 {
-    [TestClass]
-    public class QueryConditionTest
+    [TestMethod]
+    public void TestSimpleQueryCondition()
     {
-        [TestMethod]
-        public void TestSimpleQueryCondition()
+        var context = Context.GetDefault();
+        Assert.IsNotNull(context);
+
+        using var dimension1 = Dimension.Create(context, "rows", 1, 4, 2);
+        Assert.IsNotNull(dimension1);
+
+        using var dimension2 = Dimension.Create(context, "cols", 1, 4, 2);
+        Assert.IsNotNull(dimension2);
+
+        using var domain = new Domain(context);
+        Assert.IsNotNull(domain);
+
+        domain.AddDimension(dimension1);
+        domain.AddDimension(dimension2);
+
+        using var array_schema = new ArraySchema(context, ArrayType.Dense);
+        Assert.IsNotNull(array_schema);
+
+
+        using var attr1 = new Attribute(context, "a1", DataType.Int32);
+        Assert.IsNotNull(attr1);
+
+        array_schema.AddAttribute(attr1);
+
+        array_schema.SetDomain(domain);
+
+        array_schema.Check();
+
+        var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_sparse_array");
+
+        if (Directory.Exists(tmpArrayPath))
         {
-            var context = Context.GetDefault();
-            Assert.IsNotNull(context);
-
-            using var dimension1 = Dimension.Create(context, "rows", 1, 4, 2);
-            Assert.IsNotNull(dimension1);
-
-            using var dimension2 = Dimension.Create(context, "cols", 1, 4, 2);
-            Assert.IsNotNull(dimension2);
-
-            using var domain = new Domain(context);
-            Assert.IsNotNull(domain);
-
-            domain.AddDimension(dimension1);
-            domain.AddDimension(dimension2);
-
-            using var array_schema = new ArraySchema(context, ArrayType.Dense);
-            Assert.IsNotNull(array_schema);
-
-
-            using var attr1 = new Attribute(context, "a1", DataType.Int32);
-            Assert.IsNotNull(attr1);
-
-            array_schema.AddAttribute(attr1);
-
-            array_schema.SetDomain(domain);
-
-            array_schema.Check();
-
-            var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_sparse_array");
-
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
-
-            Array.Create(context, tmpArrayPath, array_schema);
-
-            //Write array
-            using var array_write = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array_write);
-
-            array_write.Open(QueryType.Write);
-
-            using var query_write = new Query(array_write);
-
-            var attr1_data_buffer = new int[16] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
-            query_write.SetDataBuffer("a1", attr1_data_buffer);
-            query_write.Submit();
-
-            var status = query_write.Status();
-
-            Assert.AreEqual(QueryStatus.Completed, status);
-
-            array_write.Close();
-
-            using var array_read = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array_read);
-
-            array_read.Open(QueryType.Read);
-
-            using var query_read = new Query(array_read);
-
-            query_read.SetLayout(LayoutType.RowMajor);
-
-            using var subarray = new Subarray(array_read);
-            subarray.SetSubarray(1, 4, 1, 4);
-            query_read.SetSubarray(subarray);
-
-            using QueryCondition qc1 = QueryCondition.Create(context, "a1", 3, QueryConditionOperatorType.GreaterThan);
-            using QueryCondition qc2 = QueryCondition.Create(context, "a1", 7, QueryConditionOperatorType.LessThan);
-            using QueryCondition qc = qc1 & qc2;
-
-            query_read.SetCondition(qc);
-
-            var attr_data_buffer_read = new int[16];
-            query_read.SetDataBuffer("a1", attr_data_buffer_read);
-
-            query_read.Submit();
-            var status_read = query_read.Status();
-
-            Assert.AreEqual(QueryStatus.Completed, status_read);
-
-            array_read.Close();
-
-            // the result query buffer for 3<x<7 should be 4,5,6
-            // Assert.AreEqual<int>(4, attr_data_buffer_read[0]);
-            // Assert.AreEqual<int>(5, attr_data_buffer_read[1]);
-            // Assert.AreEqual<int>(6, attr_data_buffer_read[2]);
+            Directory.Delete(tmpArrayPath, true);
         }
 
-        [TestMethod]
-        public void TestNegateQueryCondition()
+        Array.Create(context, tmpArrayPath, array_schema);
+
+        //Write array
+        using var array_write = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array_write);
+
+        array_write.Open(QueryType.Write);
+
+        using var query_write = new Query(array_write);
+
+        var attr1_data_buffer = new int[16] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        query_write.SetDataBuffer("a1", attr1_data_buffer);
+        query_write.Submit();
+
+        var status = query_write.Status();
+
+        Assert.AreEqual(QueryStatus.Completed, status);
+
+        array_write.Close();
+
+        using var array_read = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array_read);
+
+        array_read.Open(QueryType.Read);
+
+        using var query_read = new Query(array_read);
+
+        query_read.SetLayout(LayoutType.RowMajor);
+
+        using var subarray = new Subarray(array_read);
+        subarray.SetSubarray(1, 4, 1, 4);
+        query_read.SetSubarray(subarray);
+
+        using QueryCondition qc1 = QueryCondition.Create(context, "a1", 3, QueryConditionOperatorType.GreaterThan);
+        using QueryCondition qc2 = QueryCondition.Create(context, "a1", 7, QueryConditionOperatorType.LessThan);
+        using QueryCondition qc = qc1 & qc2;
+
+        query_read.SetCondition(qc);
+
+        var attr_data_buffer_read = new int[16];
+        query_read.SetDataBuffer("a1", attr_data_buffer_read);
+
+        query_read.Submit();
+        var status_read = query_read.Status();
+
+        Assert.AreEqual(QueryStatus.Completed, status_read);
+
+        array_read.Close();
+
+        // the result query buffer for 3<x<7 should be 4,5,6
+        // Assert.AreEqual<int>(4, attr_data_buffer_read[0]);
+        // Assert.AreEqual<int>(5, attr_data_buffer_read[1]);
+        // Assert.AreEqual<int>(6, attr_data_buffer_read[2]);
+    }
+
+    [TestMethod]
+    public void TestNegateQueryCondition()
+    {
+        var context = Context.GetDefault();
+        Assert.IsNotNull(context);
+
+        using var dimension1 = Dimension.Create(context, "rows", 1, 4, 2);
+        Assert.IsNotNull(dimension1);
+
+        using var dimension2 = Dimension.Create(context, "cols", 1, 4, 2);
+        Assert.IsNotNull(dimension2);
+
+        using var domain = new Domain(context);
+        Assert.IsNotNull(domain);
+
+        domain.AddDimension(dimension1);
+        domain.AddDimension(dimension2);
+
+        using var array_schema = new ArraySchema(context, ArrayType.Dense);
+        Assert.IsNotNull(array_schema);
+
+
+        using var attr1 = new Attribute(context, "a1", DataType.Int32);
+        Assert.IsNotNull(attr1);
+
+        array_schema.AddAttribute(attr1);
+
+        array_schema.SetDomain(domain);
+
+        array_schema.Check();
+
+        var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_sparse_array");
+
+        if (Directory.Exists(tmpArrayPath))
         {
-            var context = Context.GetDefault();
-            Assert.IsNotNull(context);
-
-            using var dimension1 = Dimension.Create(context, "rows", 1, 4, 2);
-            Assert.IsNotNull(dimension1);
-
-            using var dimension2 = Dimension.Create(context, "cols", 1, 4, 2);
-            Assert.IsNotNull(dimension2);
-
-            using var domain = new Domain(context);
-            Assert.IsNotNull(domain);
-
-            domain.AddDimension(dimension1);
-            domain.AddDimension(dimension2);
-
-            using var array_schema = new ArraySchema(context, ArrayType.Dense);
-            Assert.IsNotNull(array_schema);
-
-
-            using var attr1 = new Attribute(context, "a1", DataType.Int32);
-            Assert.IsNotNull(attr1);
-
-            array_schema.AddAttribute(attr1);
-
-            array_schema.SetDomain(domain);
-
-            array_schema.Check();
-
-            var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_sparse_array");
-
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
-
-            Array.Create(context, tmpArrayPath, array_schema);
-
-            //Write array
-            using var array_write = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array_write);
-
-            array_write.Open(QueryType.Write);
-
-            using var query_write = new Query(array_write);
-
-            var attr1_data_buffer = new int[16] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
-            query_write.SetDataBuffer("a1", attr1_data_buffer);
-            query_write.Submit();
-
-            var status = query_write.Status();
-
-            Assert.AreEqual(QueryStatus.Completed, status);
-
-            array_write.Close();
-
-            using var array_read = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array_read);
-
-            array_read.Open(QueryType.Read);
-
-            using var query_read = new Query(array_read);
-
-            query_read.SetLayout(LayoutType.RowMajor);
-
-            using var subarray = new Subarray(array_read);
-            subarray.SetSubarray(1, 4, 1, 4);
-            query_read.SetSubarray(subarray);
-
-            using QueryCondition qc1 = QueryCondition.Create(context, "a1", 3, QueryConditionOperatorType.GreaterThan);
-            using QueryCondition qc2 = QueryCondition.Create(context, "a1", 7, QueryConditionOperatorType.LessThan);
-            using QueryCondition qc3 = qc1 & qc2;
-            using QueryCondition qc = !qc3;
-
-            query_read.SetCondition(qc);
-
-            var attr_data_buffer_read = new int[16];
-            query_read.SetDataBuffer("a1", attr_data_buffer_read);
-
-            query_read.Submit();
-            var status_read = query_read.Status();
-
-            Assert.AreEqual(QueryStatus.Completed, status_read);
-
-            array_read.Close();
-
-            // the result query buffer for !(3<x<7) should be 1,2,3,<FILL>,<FILL>,<FILL>7,8,9,10,11,12,13,14,15,16
-            Assert.AreEqual(int.MinValue, attr_data_buffer_read[3]);
-            Assert.AreEqual(int.MinValue, attr_data_buffer_read[4]);
-            Assert.AreEqual(int.MinValue, attr_data_buffer_read[5]);
+            Directory.Delete(tmpArrayPath, true);
         }
 
-        [TestMethod]
-        public void TestIsNotNullCondition()
-        {
-            var context = Context.GetDefault();
+        Array.Create(context, tmpArrayPath, array_schema);
 
-            using var dimension = Dimension.Create(context, "dim", 1, 5, 5);
+        //Write array
+        using var array_write = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array_write);
 
-            using var domain = new Domain(context);
+        array_write.Open(QueryType.Write);
 
-            domain.AddDimension(dimension);
+        using var query_write = new Query(array_write);
 
-            using var array_schema = new ArraySchema(context, ArrayType.Sparse);
+        var attr1_data_buffer = new int[16] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        query_write.SetDataBuffer("a1", attr1_data_buffer);
+        query_write.Submit();
 
-            using var attr = new Attribute(context, "a1", DataType.Int32);
-            attr.SetNullable(true);
+        var status = query_write.Status();
 
-            array_schema.AddAttribute(attr);
+        Assert.AreEqual(QueryStatus.Completed, status);
 
-            array_schema.SetDomain(domain);
+        array_write.Close();
 
-            array_schema.Check();
+        using var array_read = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array_read);
 
-            using var tmpArrayPath = new TemporaryDirectory("query_condition_is_not_null");
+        array_read.Open(QueryType.Read);
 
-            Array.Create(context, tmpArrayPath, array_schema);
+        using var query_read = new Query(array_read);
 
-            //Write array
-            using var array_write = new Array(context, tmpArrayPath);
+        query_read.SetLayout(LayoutType.RowMajor);
 
-            array_write.Open(QueryType.Write);
+        using var subarray = new Subarray(array_read);
+        subarray.SetSubarray(1, 4, 1, 4);
+        query_read.SetSubarray(subarray);
 
-            using var query_write = new Query(array_write);
+        using QueryCondition qc1 = QueryCondition.Create(context, "a1", 3, QueryConditionOperatorType.GreaterThan);
+        using QueryCondition qc2 = QueryCondition.Create(context, "a1", 7, QueryConditionOperatorType.LessThan);
+        using QueryCondition qc3 = qc1 & qc2;
+        using QueryCondition qc = !qc3;
 
-            var attr_data_buffer = new int[] { 1, 2, 3, 4, 5 };
-            var attr_validity_buffer = new byte[] { 1, 1, 0, 1, 1 };
-            query_write.SetDataBuffer("dim", attr_data_buffer);
-            query_write.SetDataBuffer("a1", attr_data_buffer);
-            query_write.SetValidityBuffer("a1", attr_validity_buffer);
-            query_write.Submit();
+        query_read.SetCondition(qc);
 
-            var status = query_write.Status();
+        var attr_data_buffer_read = new int[16];
+        query_read.SetDataBuffer("a1", attr_data_buffer_read);
 
-            Assert.AreEqual(QueryStatus.Completed, status);
+        query_read.Submit();
+        var status_read = query_read.Status();
 
-            array_write.Close();
+        Assert.AreEqual(QueryStatus.Completed, status_read);
 
-            using var array_read = new Array(context, tmpArrayPath);
+        array_read.Close();
 
-            array_read.Open(QueryType.Read);
+        // the result query buffer for !(3<x<7) should be 1,2,3,<FILL>,<FILL>,<FILL>7,8,9,10,11,12,13,14,15,16
+        Assert.AreEqual(int.MinValue, attr_data_buffer_read[3]);
+        Assert.AreEqual(int.MinValue, attr_data_buffer_read[4]);
+        Assert.AreEqual(int.MinValue, attr_data_buffer_read[5]);
+    }
 
-            using var query_read = new Query(array_read);
+    [TestMethod]
+    public void TestIsNotNullCondition()
+    {
+        var context = Context.GetDefault();
 
-            query_read.SetLayout(LayoutType.RowMajor);
+        using var dimension = Dimension.Create(context, "dim", 1, 5, 5);
 
-            using QueryCondition qc = QueryCondition.CreateIsNotNull(context, "a1");
+        using var domain = new Domain(context);
 
-            query_read.SetCondition(qc);
+        domain.AddDimension(dimension);
 
-            var attr_data_buffer_read = new int[5];
-            query_read.SetDataBuffer("dim", attr_data_buffer);
-            query_read.SetDataBuffer("a1", attr_data_buffer_read);
-            query_read.SetValidityBuffer("a1", new byte[5]);
+        using var array_schema = new ArraySchema(context, ArrayType.Sparse);
 
-            query_read.Submit();
-            var status_read = query_read.Status();
+        using var attr = new Attribute(context, "a1", DataType.Int32);
+        attr.SetNullable(true);
 
-            Assert.AreEqual(QueryStatus.Completed, status_read);
+        array_schema.AddAttribute(attr);
 
-            Assert.AreEqual(4UL, query_read.GetResultDataElements("a1"));
-            CollectionAssert.AreEqual(new int[] { 1, 2, 4, 5, 0 }, attr_data_buffer_read);
+        array_schema.SetDomain(domain);
 
-            array_read.Close();
-        }
+        array_schema.Check();
 
-        [TestMethod]
-        public void TestCombineDifferentContexts()
-        {
-            using var context1 = new Context();
-            using var context2 = new Context();
+        using var tmpArrayPath = new TemporaryDirectory("query_condition_is_not_null");
 
-            using var qc1 = QueryCondition.Create(context1, "a1", 5, QueryConditionOperatorType.GreaterThan);
-            using var qc2 = QueryCondition.Create(context2, "a1", 8, QueryConditionOperatorType.LessThan);
+        Array.Create(context, tmpArrayPath, array_schema);
 
-            Assert.ThrowsException<InvalidOperationException>(() => qc1 | qc2);
-        }
+        //Write array
+        using var array_write = new Array(context, tmpArrayPath);
+
+        array_write.Open(QueryType.Write);
+
+        using var query_write = new Query(array_write);
+
+        var attr_data_buffer = new int[] { 1, 2, 3, 4, 5 };
+        var attr_validity_buffer = new byte[] { 1, 1, 0, 1, 1 };
+        query_write.SetDataBuffer("dim", attr_data_buffer);
+        query_write.SetDataBuffer("a1", attr_data_buffer);
+        query_write.SetValidityBuffer("a1", attr_validity_buffer);
+        query_write.Submit();
+
+        var status = query_write.Status();
+
+        Assert.AreEqual(QueryStatus.Completed, status);
+
+        array_write.Close();
+
+        using var array_read = new Array(context, tmpArrayPath);
+
+        array_read.Open(QueryType.Read);
+
+        using var query_read = new Query(array_read);
+
+        query_read.SetLayout(LayoutType.RowMajor);
+
+        using QueryCondition qc = QueryCondition.CreateIsNotNull(context, "a1");
+
+        query_read.SetCondition(qc);
+
+        var attr_data_buffer_read = new int[5];
+        query_read.SetDataBuffer("dim", attr_data_buffer);
+        query_read.SetDataBuffer("a1", attr_data_buffer_read);
+        query_read.SetValidityBuffer("a1", new byte[5]);
+
+        query_read.Submit();
+        var status_read = query_read.Status();
+
+        Assert.AreEqual(QueryStatus.Completed, status_read);
+
+        Assert.AreEqual(4UL, query_read.GetResultDataElements("a1"));
+        CollectionAssert.AreEqual(new int[] { 1, 2, 4, 5, 0 }, attr_data_buffer_read);
+
+        array_read.Close();
+    }
+
+    [TestMethod]
+    public void TestCombineDifferentContexts()
+    {
+        using var context1 = new Context();
+        using var context2 = new Context();
+
+        using var qc1 = QueryCondition.Create(context1, "a1", 5, QueryConditionOperatorType.GreaterThan);
+        using var qc2 = QueryCondition.Create(context2, "a1", 8, QueryConditionOperatorType.LessThan);
+
+        Assert.ThrowsException<InvalidOperationException>(() => qc1 | qc2);
     }
 }

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -107,21 +107,21 @@ namespace TileDB.CSharp.Test
             int[] colsExpected;
             if (arrayType == ArrayType.Dense)
             {
-                a1Expected = new[]
-                {
+                a1Expected =
+                [
                     1, 2, int.MinValue, int.MinValue,
                     3, 4, int.MinValue, int.MinValue,
                     5, 6, int.MinValue, int.MinValue,
                     7, 8, int.MinValue, int.MinValue
-                };
-                rowsExpected = new[] { 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4 };
-                colsExpected = new[] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 };
+                ];
+                rowsExpected = [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4];
+                colsExpected = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4];
             }
             else // Sparse
             {
-                a1Expected = new[] { 1, 2, 3, 4, 5, 6 };
-                rowsExpected = new[] { 1, 2, 2, 3, 4, 4 };
-                colsExpected = new[] { 1, 1, 4, 1, 1, 4 };
+                a1Expected = [1, 2, 3, 4, 5, 6];
+                rowsExpected = [1, 2, 2, 3, 4, 4];
+                colsExpected = [1, 1, 4, 1, 1, 4];
             }
             CollectionAssert.AreEqual(a1Expected, a1Read);
             CollectionAssert.AreEqual(colsExpected, colsRead);
@@ -423,9 +423,9 @@ namespace TileDB.CSharp.Test
             Array.Create(context, tmpArrayPath, array_schema);
 
             // Write array
-            int[] a1_data = new int[4] { 100, 200, 300, 400 };
-            int[] a2_data = new int[8] { 10, 10, 20, 30, 30, 30, 40, 40 };
-            ulong[] a2_el_off = new ulong[4] { 0, 2, 3, 6 };
+            int[] a1_data = [100, 200, 300, 400];
+            int[] a2_data = [10, 10, 20, 30, 30, 30, 40, 40];
+            ulong[] a2_el_off = [0, 2, 3, 6];
             ulong[] a2_off = new ulong[4];
             for (int i = 0; i < a2_el_off.Length; ++i)
             {
@@ -433,16 +433,16 @@ namespace TileDB.CSharp.Test
             }
 
             byte[] a3_data = "abcdewxyz"u8.ToArray();
-            ulong[] a3_el_off = new ulong[4] { 0, 3, 4, 5 };
+            ulong[] a3_el_off = [0, 3, 4, 5];
             ulong[] a3_off = new ulong[4];
             for (int i = 0; i < a3_el_off.Length; ++i)
             {
                 a3_off[i] = a3_el_off[i] * EnumUtil.DataTypeSize(DataType.StringAscii);
             }
 
-            byte[] a1_validity = new byte[4] { 1, 0, 0, 1 };
-            byte[] a2_validity = new byte[4] { 0, 1, 1, 0 };
-            byte[] a3_validity = new byte[4] { 1, 0, 0, 1 };
+            byte[] a1_validity = [1, 0, 0, 1];
+            byte[] a2_validity = [0, 1, 1, 0];
+            byte[] a3_validity = [1, 0, 0, 1];
 
             fixed (int* a1_data_ptr = &a1_data[0])
             fixed (int* a2_data_ptr = &a2_data[0])

--- a/tests/TileDB.CSharp.Test/QueryTest.cs
+++ b/tests/TileDB.CSharp.Test/QueryTest.cs
@@ -3,721 +3,720 @@ using System.Buffers;
 using System.IO;
 using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class QueryTest
 {
-    [TestClass]
-    public class QueryTest
+
+    [DataRow(LayoutType.GlobalOrder, ArrayType.Sparse)]
+    [DataRow(LayoutType.GlobalOrder, ArrayType.Dense)]
+    [DataTestMethod]
+    public void TestGlobalQuery(LayoutType layoutType, ArrayType arrayType)
     {
-
-        [DataRow(LayoutType.GlobalOrder, ArrayType.Sparse)]
-        [DataRow(LayoutType.GlobalOrder, ArrayType.Dense)]
-        [DataTestMethod]
-        public void TestGlobalQuery(LayoutType layoutType, ArrayType arrayType)
+        string arrayPath = TestUtil.MakeTestPath(
+            $"array-query-{EnumUtil.ArrayTypeToStr(arrayType)}-{EnumUtil.LayoutTypeToStr(layoutType)}");
+        Console.WriteLine($"Creating temp test array: {arrayPath}");
+        if (Directory.Exists(arrayPath))
         {
-            string arrayPath = TestUtil.MakeTestPath(
-                $"array-query-{EnumUtil.ArrayTypeToStr(arrayType)}-{EnumUtil.LayoutTypeToStr(layoutType)}");
-            Console.WriteLine($"Creating temp test array: {arrayPath}");
-            if (Directory.Exists(arrayPath))
-            {
-                Directory.Delete(arrayPath, true);
-            }
-
-            var ctx = Context.GetDefault();
-            Assert.IsNotNull(ctx);
-
-            // Create array
-            var rows = Dimension.Create(ctx, "rows", 1, 4, 2);
-            Assert.IsNotNull(rows);
-            var cols = Dimension.Create(ctx, "cols", 1, 4, 2);
-            Assert.IsNotNull(cols);
-            using var domain = new Domain(ctx);
-            Assert.IsNotNull(domain);
-            domain.AddDimensions(rows, cols);
-            Assert.IsTrue(domain.HasDimension("rows"));
-            Assert.IsTrue(domain.HasDimension("cols"));
-            using var schema = new ArraySchema(ctx, arrayType);
-            schema.SetDomain(domain);
-            schema.AddAttribute(Attribute.Create<int>(ctx, "a1"));
-            Array.Create(ctx, arrayPath, schema);
-            var array = new Array(ctx, arrayPath);
-
-            // Write array
-            array.Open(QueryType.Write);
-            Assert.IsTrue(array.IsOpen());
-            using var queryWrite = new Query(array);
-            queryWrite.SetLayout(layoutType);
-            if (arrayType == ArrayType.Dense)
-            {
-                using var subarray = new Subarray(array);
-                subarray.AddRange("rows", 1, 4);
-                Assert.ThrowsException<ArgumentException>(() => subarray.AddRange<long>("rows", 1, 4));
-                Assert.AreEqual((1, 4), subarray.GetRange<int>("rows", 0));
-                Assert.ThrowsException<ArgumentException>(() => subarray.GetRange<long>("rows", 0));
-                subarray.AddRange(1, 1, 2); // cols
-                Assert.ThrowsException<ArgumentException>(() => subarray.AddRange<long>(1, 1, 2));
-                Assert.AreEqual((1, 2), subarray.GetRange<int>(1, 0));
-                Assert.ThrowsException<ArgumentException>(() => subarray.GetRange<long>(1, 0));
-                queryWrite.SetSubarray(subarray);
-                queryWrite.SetDataReadOnlyBuffer<int>("a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8 }.AsMemory());
-            }
-            else // Sparse
-            {
-                queryWrite.SetDataReadOnlyBuffer<int>("rows", new[] { 1, 2, 2, 3, 4, 4 }.AsMemory());
-                queryWrite.SetDataReadOnlyBuffer<int>("cols", new[] { 1, 1, 4, 1, 1, 4 }.AsMemory());
-                queryWrite.SetDataReadOnlyBuffer<int>("a1", new[] { 1, 2, 3, 4, 5, 6 }.AsMemory());
-            }
-            queryWrite.Submit();
-            Assert.AreEqual(QueryStatus.Completed, queryWrite.Status());
-            queryWrite.FinalizeQuery();
-            array.Close();
-
-            // Read array
-            array.Open(QueryType.Read);
-            Assert.IsTrue(array.IsOpen());
-            using var queryRead = new Query(array);
-            // Initially allocate buffers for dense read
-            var a1Read = new int[16];
-            var rowsRead = new int[16];
-            var colsRead = new int[16];
-            if (arrayType == ArrayType.Dense)
-            {
-                using var subarray = new Subarray(array);
-                subarray.SetSubarray(1, 4, 1, 4);
-                queryRead.SetSubarray(subarray);
-            }
-            else // Sparse
-            {
-                // Reallocate buffers for sparse read
-                a1Read = new int[6];
-                rowsRead = new int[6];
-                colsRead = new int[6];
-            }
-
-            // Get coords and attributes for dense and sparse reads
-            queryRead.SetDataBuffer("rows", rowsRead);
-            queryRead.SetDataBuffer("cols", colsRead);
-            queryRead.SetDataBuffer("a1", a1Read);
-            queryRead.Submit();
-            Assert.AreEqual(QueryStatus.Completed, queryRead.Status());
-            array.Close();
-
-            // Check expected values
-            int[] a1Expected;
-            int[] rowsExpected;
-            int[] colsExpected;
-            if (arrayType == ArrayType.Dense)
-            {
-                a1Expected =
-                [
-                    1, 2, int.MinValue, int.MinValue,
-                    3, 4, int.MinValue, int.MinValue,
-                    5, 6, int.MinValue, int.MinValue,
-                    7, 8, int.MinValue, int.MinValue
-                ];
-                rowsExpected = [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4];
-                colsExpected = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4];
-            }
-            else // Sparse
-            {
-                a1Expected = [1, 2, 3, 4, 5, 6];
-                rowsExpected = [1, 2, 2, 3, 4, 4];
-                colsExpected = [1, 1, 4, 1, 1, 4];
-            }
-            CollectionAssert.AreEqual(a1Expected, a1Read);
-            CollectionAssert.AreEqual(colsExpected, colsRead);
-            CollectionAssert.AreEqual(rowsExpected, rowsRead);
+            Directory.Delete(arrayPath, true);
         }
 
-        [TestMethod]
-        public void TestDenseQuery()
+        var ctx = Context.GetDefault();
+        Assert.IsNotNull(ctx);
+
+        // Create array
+        var rows = Dimension.Create(ctx, "rows", 1, 4, 2);
+        Assert.IsNotNull(rows);
+        var cols = Dimension.Create(ctx, "cols", 1, 4, 2);
+        Assert.IsNotNull(cols);
+        using var domain = new Domain(ctx);
+        Assert.IsNotNull(domain);
+        domain.AddDimensions(rows, cols);
+        Assert.IsTrue(domain.HasDimension("rows"));
+        Assert.IsTrue(domain.HasDimension("cols"));
+        using var schema = new ArraySchema(ctx, arrayType);
+        schema.SetDomain(domain);
+        schema.AddAttribute(Attribute.Create<int>(ctx, "a1"));
+        Array.Create(ctx, arrayPath, schema);
+        var array = new Array(ctx, arrayPath);
+
+        // Write array
+        array.Open(QueryType.Write);
+        Assert.IsTrue(array.IsOpen());
+        using var queryWrite = new Query(array);
+        queryWrite.SetLayout(layoutType);
+        if (arrayType == ArrayType.Dense)
         {
-            var context = Context.GetDefault();
-            Assert.IsNotNull(context);
+            using var subarray = new Subarray(array);
+            subarray.AddRange("rows", 1, 4);
+            Assert.ThrowsException<ArgumentException>(() => subarray.AddRange<long>("rows", 1, 4));
+            Assert.AreEqual((1, 4), subarray.GetRange<int>("rows", 0));
+            Assert.ThrowsException<ArgumentException>(() => subarray.GetRange<long>("rows", 0));
+            subarray.AddRange(1, 1, 2); // cols
+            Assert.ThrowsException<ArgumentException>(() => subarray.AddRange<long>(1, 1, 2));
+            Assert.AreEqual((1, 2), subarray.GetRange<int>(1, 0));
+            Assert.ThrowsException<ArgumentException>(() => subarray.GetRange<long>(1, 0));
+            queryWrite.SetSubarray(subarray);
+            queryWrite.SetDataReadOnlyBuffer<int>("a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8 }.AsMemory());
+        }
+        else // Sparse
+        {
+            queryWrite.SetDataReadOnlyBuffer<int>("rows", new[] { 1, 2, 2, 3, 4, 4 }.AsMemory());
+            queryWrite.SetDataReadOnlyBuffer<int>("cols", new[] { 1, 1, 4, 1, 1, 4 }.AsMemory());
+            queryWrite.SetDataReadOnlyBuffer<int>("a1", new[] { 1, 2, 3, 4, 5, 6 }.AsMemory());
+        }
+        queryWrite.Submit();
+        Assert.AreEqual(QueryStatus.Completed, queryWrite.Status());
+        queryWrite.FinalizeQuery();
+        array.Close();
 
-            const sbyte boundLower = 0;
-            const sbyte boundUpper = 9;
-            const sbyte extent = 2;
-            var dimension = Dimension.Create(context, "dim1", boundLower, boundUpper, extent);
-            Assert.IsNotNull(dimension);
+        // Read array
+        array.Open(QueryType.Read);
+        Assert.IsTrue(array.IsOpen());
+        using var queryRead = new Query(array);
+        // Initially allocate buffers for dense read
+        var a1Read = new int[16];
+        var rowsRead = new int[16];
+        var colsRead = new int[16];
+        if (arrayType == ArrayType.Dense)
+        {
+            using var subarray = new Subarray(array);
+            subarray.SetSubarray(1, 4, 1, 4);
+            queryRead.SetSubarray(subarray);
+        }
+        else // Sparse
+        {
+            // Reallocate buffers for sparse read
+            a1Read = new int[6];
+            rowsRead = new int[6];
+            colsRead = new int[6];
+        }
 
-            var domain = new Domain(context);
-            Assert.IsNotNull(domain);
+        // Get coords and attributes for dense and sparse reads
+        queryRead.SetDataBuffer("rows", rowsRead);
+        queryRead.SetDataBuffer("cols", colsRead);
+        queryRead.SetDataBuffer("a1", a1Read);
+        queryRead.Submit();
+        Assert.AreEqual(QueryStatus.Completed, queryRead.Status());
+        array.Close();
 
-            domain.AddDimension(dimension);
+        // Check expected values
+        int[] a1Expected;
+        int[] rowsExpected;
+        int[] colsExpected;
+        if (arrayType == ArrayType.Dense)
+        {
+            a1Expected =
+            [
+                1, 2, int.MinValue, int.MinValue,
+                3, 4, int.MinValue, int.MinValue,
+                5, 6, int.MinValue, int.MinValue,
+                7, 8, int.MinValue, int.MinValue
+            ];
+            rowsExpected = [1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4];
+            colsExpected = [1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4];
+        }
+        else // Sparse
+        {
+            a1Expected = [1, 2, 3, 4, 5, 6];
+            rowsExpected = [1, 2, 2, 3, 4, 4];
+            colsExpected = [1, 1, 4, 1, 1, 4];
+        }
+        CollectionAssert.AreEqual(a1Expected, a1Read);
+        CollectionAssert.AreEqual(colsExpected, colsRead);
+        CollectionAssert.AreEqual(rowsExpected, rowsRead);
+    }
 
-            var array_schema = new ArraySchema(context, ArrayType.Dense);
-            Assert.IsNotNull(array_schema);
+    [TestMethod]
+    public void TestDenseQuery()
+    {
+        var context = Context.GetDefault();
+        Assert.IsNotNull(context);
 
-            var a1 = new Attribute(context, "a1", DataType.Int32);
-            Assert.IsNotNull(a1);
+        const sbyte boundLower = 0;
+        const sbyte boundUpper = 9;
+        const sbyte extent = 2;
+        var dimension = Dimension.Create(context, "dim1", boundLower, boundUpper, extent);
+        Assert.IsNotNull(dimension);
 
-            var a2 = new Attribute(context, "a2", DataType.Float32);
-            Assert.IsNotNull(a2);
+        var domain = new Domain(context);
+        Assert.IsNotNull(domain);
 
-            a2.SetCellValNum(Attribute.VariableSized);
+        domain.AddDimension(dimension);
 
-            array_schema.AddAttributes(a1, a2);
+        var array_schema = new ArraySchema(context, ArrayType.Dense);
+        Assert.IsNotNull(array_schema);
 
-            array_schema.SetDomain(domain);
+        var a1 = new Attribute(context, "a1", DataType.Int32);
+        Assert.IsNotNull(a1);
 
-            array_schema.Check();
+        var a2 = new Attribute(context, "a2", DataType.Float32);
+        Assert.IsNotNull(a2);
 
-            var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_array");
+        a2.SetCellValNum(Attribute.VariableSized);
 
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
+        array_schema.AddAttributes(a1, a2);
 
-            var array = new Array(context, tmpArrayPath);
-            Assert.IsNotNull(array);
+        array_schema.SetDomain(domain);
 
-            array.Create(array_schema);
+        array_schema.Check();
 
-            array.Open(QueryType.Write);
+        var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_array");
 
-            var query = new Query(array);
+        if (Directory.Exists(tmpArrayPath))
+        {
+            Directory.Delete(tmpArrayPath, true);
+        }
 
-            using (var subarray = new Subarray(array))
-            {
-                subarray.SetSubarray<sbyte>(0, 1);
-                Assert.ThrowsException<ArgumentException>(() => subarray.SetSubarray(0, 1));
-                Assert.ThrowsException<ArgumentException>(() => subarray.SetSubarray(0));
-                query.SetSubarray(subarray);
-            }
+        var array = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array);
 
-            query.SetLayout(LayoutType.RowMajor);
+        array.Create(array_schema);
 
-            var a1_data_buffer = new int[2] { 1, 2 };
+        array.Open(QueryType.Write);
 
-            query.SetDataBuffer("a1", a1_data_buffer);
+        var query = new Query(array);
 
-            var a2_data_buffer = new float[5] { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f };
+        using (var subarray = new Subarray(array))
+        {
+            subarray.SetSubarray<sbyte>(0, 1);
+            Assert.ThrowsException<ArgumentException>(() => subarray.SetSubarray(0, 1));
+            Assert.ThrowsException<ArgumentException>(() => subarray.SetSubarray(0));
+            query.SetSubarray(subarray);
+        }
 
-            query.SetDataBuffer("a2", a2_data_buffer);
+        query.SetLayout(LayoutType.RowMajor);
 
-            var a2_offset_buffer = new ulong[2] { 0, 3 };
+        var a1_data_buffer = new int[2] { 1, 2 };
 
-            query.SetOffsetsBuffer("a2", a2_offset_buffer);
+        query.SetDataBuffer("a1", a1_data_buffer);
 
-            query.Submit();
+        var a2_data_buffer = new float[5] { 1.0f, 2.0f, 3.0f, 4.0f, 5.0f };
 
-            var status = query.Status();
+        query.SetDataBuffer("a2", a2_data_buffer);
+
+        var a2_offset_buffer = new ulong[2] { 0, 3 };
+
+        query.SetOffsetsBuffer("a2", a2_offset_buffer);
+
+        query.Submit();
+
+        var status = query.Status();
+
+        Assert.AreEqual(QueryStatus.Completed, status);
+
+        query.FinalizeQuery();
+
+        array.Close();
+
+        //Start to read
+        var array_read = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array_read);
+
+        array_read.Open(QueryType.Read);
+
+        var query_read = new Query(array_read);
+
+        using (var subarray = new Subarray(array_read))
+        {
+            subarray.SetSubarray<sbyte>(0, 1);
+
+            query_read.SetSubarray(subarray);
+        }
+
+        query_read.SetLayout(LayoutType.RowMajor);
+
+        var a1_data_buffer_read = new int[2];
+
+        query_read.SetDataBuffer("a1", a1_data_buffer_read);
+
+        var a2_data_buffer_read = new float[5];
+
+        query_read.SetDataBuffer("a2", a2_data_buffer_read);
+
+        var a2_offset_buffer_read = new ulong[2];
+
+        query_read.SetOffsetsBuffer("a2", a2_offset_buffer_read);
+
+        query_read.Submit();
+        var status_read = query_read.Status();
+
+        Assert.AreEqual(QueryStatus.Completed, status_read);
+
+        query_read.FinalizeQuery();
+
+        array_read.Close();
+
+        CollectionAssert.AreEqual(a1_data_buffer, a1_data_buffer_read);
+
+        CollectionAssert.AreEqual(a2_data_buffer, a2_data_buffer_read);
+
+        CollectionAssert.AreEqual(a2_offset_buffer, a2_offset_buffer_read);
+    }
+
+    [TestMethod]
+    public void TestSimpleSparseArrayQuery()
+    {
+        var context = Context.GetDefault();
+        Assert.IsNotNull(context);
+
+        // Create array
+        int dim1_bound_lower = 1;
+        int dim1_bound_upper = 4;
+        int dim1_extent = 4;
+        var dim1 = Dimension.Create(context, "rows", dim1_bound_lower, dim1_bound_upper, dim1_extent);
+
+        int dim2_bound_lower = 1;
+        int dim2_bound_upper = 4;
+        int dim2_extent = 4;
+        var dim2 = Dimension.Create(context, "cols", dim2_bound_lower, dim2_bound_upper, dim2_extent);
+
+        var domain = new Domain(context);
+        Assert.IsNotNull(domain);
+
+        domain.AddDimension(dim1);
+        domain.AddDimension(dim2);
+
+        var array_schema = new ArraySchema(context, ArrayType.Sparse);
+        Assert.IsNotNull(array_schema);
+
+        var attr = new Attribute(context, "a", DataType.Int32);
+        Assert.IsNotNull(attr);
+
+        array_schema.AddAttribute(attr);
+
+        array_schema.SetDomain(domain);
+
+        array_schema.Check();
+
+        var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_sparse_array");
+
+        if (Directory.Exists(tmpArrayPath))
+        {
+            Directory.Delete(tmpArrayPath, true);
+        }
+
+        Array.Create(context, tmpArrayPath, array_schema);
+
+        //Write array
+        var dim1_data_buffer = new int[3] { 1, 2, 3 };
+        var dim2_data_buffer = new int[3] { 1, 3, 4 };
+        var attr_data_buffer = new int[3] { 1, 2, 3 };
+
+        using (var array_write = new Array(context, tmpArrayPath))
+        {
+            Assert.IsNotNull(array_write);
+
+            array_write.Open(QueryType.Write);
+
+            var query_write = new Query(array_write);
+
+            query_write.SetLayout(LayoutType.Unordered);
+
+            query_write.SetDataBuffer("rows", dim1_data_buffer);
+            query_write.SetDataBuffer("cols", dim2_data_buffer);
+            query_write.SetDataBuffer("a", attr_data_buffer);
+
+            query_write.Submit();
+
+            var status = query_write.Status();
 
             Assert.AreEqual(QueryStatus.Completed, status);
 
-            query.FinalizeQuery();
+            array_write.Close();
+        }//array_write
 
-            array.Close();
 
-            //Start to read
-            var array_read = new Array(context, tmpArrayPath);
+        //Read array
+        var dim1_data_buffer_read = new int[3];
+        var dim2_data_buffer_read = new int[3];
+        var attr_data_buffer_read = new int[3];
+
+        using (var array_read = new Array(context, tmpArrayPath))
+        {
             Assert.IsNotNull(array_read);
 
             array_read.Open(QueryType.Read);
 
             var query_read = new Query(array_read);
 
-            using (var subarray = new Subarray(array_read))
-            {
-                subarray.SetSubarray<sbyte>(0, 1);
-
-                query_read.SetSubarray(subarray);
-            }
-
             query_read.SetLayout(LayoutType.RowMajor);
 
-            var a1_data_buffer_read = new int[2];
+            query_read.SetDataBuffer("rows", dim1_data_buffer_read);
 
-            query_read.SetDataBuffer("a1", a1_data_buffer_read);
+            query_read.SetDataBuffer("cols", dim2_data_buffer_read);
 
-            var a2_data_buffer_read = new float[5];
-
-            query_read.SetDataBuffer("a2", a2_data_buffer_read);
-
-            var a2_offset_buffer_read = new ulong[2];
-
-            query_read.SetOffsetsBuffer("a2", a2_offset_buffer_read);
+            query_read.SetDataBuffer("a", attr_data_buffer_read);
 
             query_read.Submit();
             var status_read = query_read.Status();
 
             Assert.AreEqual(QueryStatus.Completed, status_read);
 
-            query_read.FinalizeQuery();
-
             array_read.Close();
-
-            CollectionAssert.AreEqual(a1_data_buffer, a1_data_buffer_read);
-
-            CollectionAssert.AreEqual(a2_data_buffer, a2_data_buffer_read);
-
-            CollectionAssert.AreEqual(a2_offset_buffer, a2_offset_buffer_read);
         }
 
-        [TestMethod]
-        public void TestSimpleSparseArrayQuery()
+
+        CollectionAssert.AreEqual(dim1_data_buffer, dim1_data_buffer_read);
+
+        CollectionAssert.AreEqual(dim2_data_buffer, dim2_data_buffer_read);
+
+        CollectionAssert.AreEqual(attr_data_buffer, attr_data_buffer_read);
+    }
+
+    [TestMethod]
+    public unsafe void TestNullableAttributeArrayQuery()
+    {
+        var context = Context.GetDefault();
+        Assert.IsNotNull(context);
+
+        // Create array
+        int dim1_bound_lower = 1;
+        int dim1_bound_upper = 2;
+        int dim1_extent = 2;
+        var dim1 = Dimension.Create(context, "rows", dim1_bound_lower, dim1_bound_upper, dim1_extent);
+
+        int dim2_bound_lower = 1;
+        int dim2_bound_upper = 2;
+        int dim2_extent = 2;
+        var dim2 = Dimension.Create(context, "cols", dim2_bound_lower, dim2_bound_upper, dim2_extent);
+
+        var domain = new Domain(context);
+        Assert.IsNotNull(domain);
+
+        domain.AddDimension(dim1);
+        domain.AddDimension(dim2);
+
+        var array_schema = new ArraySchema(context, ArrayType.Dense);
+        Assert.IsNotNull(array_schema);
+
+        var attr1 = new Attribute(context, "a1", DataType.Int32);
+        Assert.IsNotNull(attr1);
+        attr1.SetNullable(true);
+        array_schema.AddAttribute(attr1);
+
+        var attr2 = new Attribute(context, "a2", DataType.Int32);
+        Assert.IsNotNull(attr2);
+        attr2.SetNullable(true);
+        attr2.SetCellValNum(Attribute.VariableSized);
+        array_schema.AddAttribute(attr2);
+
+        var attr3 = new Attribute(context, "a3", DataType.StringAscii);
+        Assert.IsNotNull(attr3);
+        attr3.SetNullable(true);
+        array_schema.AddAttribute(attr3);
+
+        array_schema.SetDomain(domain);
+        array_schema.SetTileOrder(LayoutType.RowMajor);
+        array_schema.SetCellOrder(LayoutType.RowMajor);
+
+        array_schema.Check();
+
+        var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_nullable_array");
+
+        if (Directory.Exists(tmpArrayPath))
         {
-            var context = Context.GetDefault();
-            Assert.IsNotNull(context);
-
-            // Create array
-            int dim1_bound_lower = 1;
-            int dim1_bound_upper = 4;
-            int dim1_extent = 4;
-            var dim1 = Dimension.Create(context, "rows", dim1_bound_lower, dim1_bound_upper, dim1_extent);
-
-            int dim2_bound_lower = 1;
-            int dim2_bound_upper = 4;
-            int dim2_extent = 4;
-            var dim2 = Dimension.Create(context, "cols", dim2_bound_lower, dim2_bound_upper, dim2_extent);
-
-            var domain = new Domain(context);
-            Assert.IsNotNull(domain);
-
-            domain.AddDimension(dim1);
-            domain.AddDimension(dim2);
-
-            var array_schema = new ArraySchema(context, ArrayType.Sparse);
-            Assert.IsNotNull(array_schema);
-
-            var attr = new Attribute(context, "a", DataType.Int32);
-            Assert.IsNotNull(attr);
-
-            array_schema.AddAttribute(attr);
-
-            array_schema.SetDomain(domain);
-
-            array_schema.Check();
-
-            var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_sparse_array");
-
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
-
-            Array.Create(context, tmpArrayPath, array_schema);
-
-            //Write array
-            var dim1_data_buffer = new int[3] { 1, 2, 3 };
-            var dim2_data_buffer = new int[3] { 1, 3, 4 };
-            var attr_data_buffer = new int[3] { 1, 2, 3 };
-
-            using (var array_write = new Array(context, tmpArrayPath))
-            {
-                Assert.IsNotNull(array_write);
-
-                array_write.Open(QueryType.Write);
-
-                var query_write = new Query(array_write);
-
-                query_write.SetLayout(LayoutType.Unordered);
-
-                query_write.SetDataBuffer("rows", dim1_data_buffer);
-                query_write.SetDataBuffer("cols", dim2_data_buffer);
-                query_write.SetDataBuffer("a", attr_data_buffer);
-
-                query_write.Submit();
-
-                var status = query_write.Status();
-
-                Assert.AreEqual(QueryStatus.Completed, status);
-
-                array_write.Close();
-            }//array_write
-
-
-            //Read array
-            var dim1_data_buffer_read = new int[3];
-            var dim2_data_buffer_read = new int[3];
-            var attr_data_buffer_read = new int[3];
-
-            using (var array_read = new Array(context, tmpArrayPath))
-            {
-                Assert.IsNotNull(array_read);
-
-                array_read.Open(QueryType.Read);
-
-                var query_read = new Query(array_read);
-
-                query_read.SetLayout(LayoutType.RowMajor);
-
-                query_read.SetDataBuffer("rows", dim1_data_buffer_read);
-
-                query_read.SetDataBuffer("cols", dim2_data_buffer_read);
-
-                query_read.SetDataBuffer("a", attr_data_buffer_read);
-
-                query_read.Submit();
-                var status_read = query_read.Status();
-
-                Assert.AreEqual(QueryStatus.Completed, status_read);
-
-                array_read.Close();
-            }
-
-
-            CollectionAssert.AreEqual(dim1_data_buffer, dim1_data_buffer_read);
-
-            CollectionAssert.AreEqual(dim2_data_buffer, dim2_data_buffer_read);
-
-            CollectionAssert.AreEqual(attr_data_buffer, attr_data_buffer_read);
+            Directory.Delete(tmpArrayPath, true);
         }
 
-        [TestMethod]
-        public unsafe void TestNullableAttributeArrayQuery()
+        Array.Create(context, tmpArrayPath, array_schema);
+
+        // Write array
+        int[] a1_data = [100, 200, 300, 400];
+        int[] a2_data = [10, 10, 20, 30, 30, 30, 40, 40];
+        ulong[] a2_el_off = [0, 2, 3, 6];
+        ulong[] a2_off = new ulong[4];
+        for (int i = 0; i < a2_el_off.Length; ++i)
         {
-            var context = Context.GetDefault();
-            Assert.IsNotNull(context);
+            a2_off[i] = a2_el_off[i] * EnumUtil.DataTypeSize(DataType.Int32);
+        }
 
-            // Create array
-            int dim1_bound_lower = 1;
-            int dim1_bound_upper = 2;
-            int dim1_extent = 2;
-            var dim1 = Dimension.Create(context, "rows", dim1_bound_lower, dim1_bound_upper, dim1_extent);
-
-            int dim2_bound_lower = 1;
-            int dim2_bound_upper = 2;
-            int dim2_extent = 2;
-            var dim2 = Dimension.Create(context, "cols", dim2_bound_lower, dim2_bound_upper, dim2_extent);
-
-            var domain = new Domain(context);
-            Assert.IsNotNull(domain);
-
-            domain.AddDimension(dim1);
-            domain.AddDimension(dim2);
-
-            var array_schema = new ArraySchema(context, ArrayType.Dense);
-            Assert.IsNotNull(array_schema);
-
-            var attr1 = new Attribute(context, "a1", DataType.Int32);
-            Assert.IsNotNull(attr1);
-            attr1.SetNullable(true);
-            array_schema.AddAttribute(attr1);
-
-            var attr2 = new Attribute(context, "a2", DataType.Int32);
-            Assert.IsNotNull(attr2);
-            attr2.SetNullable(true);
-            attr2.SetCellValNum(Attribute.VariableSized);
-            array_schema.AddAttribute(attr2);
-
-            var attr3 = new Attribute(context, "a3", DataType.StringAscii);
-            Assert.IsNotNull(attr3);
-            attr3.SetNullable(true);
-            array_schema.AddAttribute(attr3);
-
-            array_schema.SetDomain(domain);
-            array_schema.SetTileOrder(LayoutType.RowMajor);
-            array_schema.SetCellOrder(LayoutType.RowMajor);
-
-            array_schema.Check();
-
-            var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_nullable_array");
-
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
-
-            Array.Create(context, tmpArrayPath, array_schema);
-
-            // Write array
-            int[] a1_data = [100, 200, 300, 400];
-            int[] a2_data = [10, 10, 20, 30, 30, 30, 40, 40];
-            ulong[] a2_el_off = [0, 2, 3, 6];
-            ulong[] a2_off = new ulong[4];
-            for (int i = 0; i < a2_el_off.Length; ++i)
-            {
-                a2_off[i] = a2_el_off[i] * EnumUtil.DataTypeSize(DataType.Int32);
-            }
-
-            byte[] a3_data = "abcdewxyz"u8.ToArray();
-            ulong[] a3_el_off = [0, 3, 4, 5];
-            ulong[] a3_off = new ulong[4];
-            for (int i = 0; i < a3_el_off.Length; ++i)
-            {
-                a3_off[i] = a3_el_off[i] * EnumUtil.DataTypeSize(DataType.StringAscii);
-            }
-
-            byte[] a1_validity = [1, 0, 0, 1];
-            byte[] a2_validity = [0, 1, 1, 0];
-            byte[] a3_validity = [1, 0, 0, 1];
-
-            fixed (int* a1_data_ptr = &a1_data[0])
-            fixed (int* a2_data_ptr = &a2_data[0])
-            fixed (ulong* a2_off_ptr = &a2_off[0])
-            fixed (byte* a2_validity_ptr = &a2_validity[0])
-            {
-                using var array_write = new Array(context, tmpArrayPath);
-                Assert.IsNotNull(array_write);
-
-                array_write.Open(QueryType.Write);
-
-                using var query_write = new Query(array_write);
-                query_write.SetLayout(LayoutType.RowMajor);
-
-                query_write.SetDataBuffer("a1", a1_data_ptr, (ulong)a1_data.Length);
-                query_write.SetValidityBuffer("a1", a1_validity);
-                Assert.ThrowsException<ArgumentException>(() => query_write.UnsafeSetDataReadOnlyBuffer("a1", ReadOnlyMemory<byte>.Empty));
-
-                query_write.UnsafeSetDataBuffer("a2", (void*)a2_data_ptr, (ulong)a2_data.Length * sizeof(int));
-                query_write.SetOffsetsBuffer("a2", a2_off_ptr, (ulong)a2_off.Length);
-                query_write.SetValidityBuffer("a2", a2_validity_ptr, (ulong)a2_validity.Length);
-
-                query_write.SetDataBuffer("a3", a3_data);
-                query_write.SetOffsetsBuffer("a3", a3_off);
-                query_write.SetValidityBuffer("a3", a3_validity);
-
-                query_write.Submit();
-
-                var status = query_write.Status();
-
-                Assert.AreEqual(QueryStatus.Completed, status);
-
-                array_write.Close();
-            }
-
-            // Read array
-            int[] a1_data_read = new int[4];
-            byte[] a1_validity_read = new byte[4];
-
-            int[] a2_data_read = new int[8];
-            ulong[] a2_off_read = new ulong[4];
-            byte[] a2_validity_read = new byte[4];
-
-            byte[] a3_data_read = new byte[9];
-            ulong[] a3_off_read = new ulong[4];
-            byte[] a3_validity_read = new byte[4];
-
-            using (var array_read = new Array(context, tmpArrayPath))
-            {
-                Assert.IsNotNull(array_read);
-
-                array_read.Open(QueryType.Read);
-
-                using var query_read = new Query(array_read);
-
-                query_read.SetLayout(LayoutType.RowMajor);
-                using var subarray = new Subarray(array_read);
-                subarray.SetSubarray(1, 2, 1, 2);
-                query_read.SetSubarray(subarray);
-
-                query_read.UnsafeSetDataBuffer("a1", a1_data_read.AsMemory().Pin(), (ulong)a1_data_read.Length * sizeof(int));
-                query_read.SetValidityBuffer("a1", a1_validity_read);
-
-                query_read.UnsafeSetDataBuffer("a2", a2_data_read.AsMemory().Pin(), (ulong)a2_data_read.Length * sizeof(int));
-                query_read.SetOffsetsBuffer("a2", a2_off_read);
-                query_read.SetValidityBuffer("a2", a2_validity_read);
-
-                query_read.UnsafeSetDataBuffer("a3", a3_data_read.AsMemory());
-                Assert.ThrowsException<ArgumentException>(() => query_read.UnsafeSetDataBuffer("a3", default(MemoryHandle), 0));
-                query_read.SetOffsetsBuffer("a3", a3_off_read);
-                query_read.SetValidityBuffer("a3", a3_validity_read);
-
-                query_read.Submit();
-                var status_read = query_read.Status();
-
-                Assert.AreEqual(QueryStatus.Completed, status_read);
-                Assert.AreEqual((ulong)a1_data_read.Length * sizeof(int), query_read.GetResultDataBytes("a1"));
-                Assert.AreEqual((ulong)a2_data_read.Length * sizeof(int), query_read.GetResultDataBytes("a2"));
-                Assert.AreEqual((ulong)a3_data_read.Length * sizeof(byte), query_read.GetResultDataBytes("a3"));
-                Assert.ThrowsException<InvalidOperationException>(() => query_read.GetResultDataElements("a1"));
-                Assert.ThrowsException<InvalidOperationException>(() => query_read.GetResultDataElements("a2"));
-                Assert.ThrowsException<InvalidOperationException>(() => query_read.GetResultDataElements("a3"));
-
-                Assert.AreEqual((ulong)a2_off_read.Length, query_read.GetResultOffsets("a2"));
-                Assert.AreEqual((ulong)a3_off_read.Length, query_read.GetResultOffsets("a3"));
-
-                Assert.AreEqual((ulong)a2_validity_read.Length, query_read.GetResultValidities("a2"));
-                Assert.AreEqual((ulong)a3_validity_read.Length, query_read.GetResultValidities("a3"));
-
-                array_read.Close();
-            }
-
-            CollectionAssert.AreEqual(a1_data, a1_data_read);
-            CollectionAssert.AreEqual(a1_validity, a1_validity_read);
-
-            CollectionAssert.AreEqual(a2_data, a2_data_read);
-            CollectionAssert.AreEqual(a2_validity, a2_validity_read);
-            CollectionAssert.AreEqual(a2_off, a2_off_read);
-
-            CollectionAssert.AreEqual(a3_data, a3_data_read);
-            CollectionAssert.AreEqual(a3_validity, a3_validity_read);
-            CollectionAssert.AreEqual(a3_off, a3_off_read);
-        }// public void TestNullableAttributeArrayQuery
-
-        [TestMethod]
-        public void TestBoolAttributeArrayQuery()
+        byte[] a3_data = "abcdewxyz"u8.ToArray();
+        ulong[] a3_el_off = [0, 3, 4, 5];
+        ulong[] a3_off = new ulong[4];
+        for (int i = 0; i < a3_el_off.Length; ++i)
         {
-            // Create array
-            var context = Context.GetDefault();
-            Assert.IsNotNull(context);
+            a3_off[i] = a3_el_off[i] * EnumUtil.DataTypeSize(DataType.StringAscii);
+        }
 
-            var dim1 = Dimension.Create(context, "rows", 1, 2, 2);
-            var dim2 = Dimension.Create(context, "cols", 1, 2, 2);
-            var domain = new Domain(context);
-            domain.AddDimensions(dim1, dim2);
+        byte[] a1_validity = [1, 0, 0, 1];
+        byte[] a2_validity = [0, 1, 1, 0];
+        byte[] a3_validity = [1, 0, 0, 1];
 
-            var a1 = new Attribute(context, "a1", DataType.Boolean);
-
-            var array_schema = new ArraySchema(context, ArrayType.Dense);
-            array_schema.AddAttribute(a1);
-            array_schema.SetDomain(domain);
-            array_schema.Check();
-
-            var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_bool_array");
-            if (Directory.Exists(tmpArrayPath))
-            {
-                Directory.Delete(tmpArrayPath, true);
-            }
-
-            // Write to array
-            var array_write = new Array(context, tmpArrayPath);
+        fixed (int* a1_data_ptr = &a1_data[0])
+        fixed (int* a2_data_ptr = &a2_data[0])
+        fixed (ulong* a2_off_ptr = &a2_off[0])
+        fixed (byte* a2_validity_ptr = &a2_validity[0])
+        {
+            using var array_write = new Array(context, tmpArrayPath);
             Assert.IsNotNull(array_write);
-            array_write.Create(array_schema);
+
             array_write.Open(QueryType.Write);
 
-            var query_write = new Query(array_write);
-            using (var subarray = new Subarray(array_write))
-            {
-                subarray.SetSubarray(1, 2, 1, 2);
-                query_write.SetSubarray(subarray);
-            }
+            using var query_write = new Query(array_write);
             query_write.SetLayout(LayoutType.RowMajor);
 
-            var a1_data = new bool[] { false, true, true, false };
-            query_write.SetDataBuffer("a1", a1_data);
+            query_write.SetDataBuffer("a1", a1_data_ptr, (ulong)a1_data.Length);
+            query_write.SetValidityBuffer("a1", a1_validity);
+            Assert.ThrowsException<ArgumentException>(() => query_write.UnsafeSetDataReadOnlyBuffer("a1", ReadOnlyMemory<byte>.Empty));
+
+            query_write.UnsafeSetDataBuffer("a2", (void*)a2_data_ptr, (ulong)a2_data.Length * sizeof(int));
+            query_write.SetOffsetsBuffer("a2", a2_off_ptr, (ulong)a2_off.Length);
+            query_write.SetValidityBuffer("a2", a2_validity_ptr, (ulong)a2_validity.Length);
+
+            query_write.SetDataBuffer("a3", a3_data);
+            query_write.SetOffsetsBuffer("a3", a3_off);
+            query_write.SetValidityBuffer("a3", a3_validity);
 
             query_write.Submit();
-            var status = query_write.Status();
-            Assert.AreEqual(status, QueryStatus.Completed);
-            query_write.FinalizeQuery();
-            query_write.Dispose();
-            array_write.Close();
 
-            // Read from array into bool[]
-            var array_read = new Array(context, tmpArrayPath);
+            var status = query_write.Status();
+
+            Assert.AreEqual(QueryStatus.Completed, status);
+
+            array_write.Close();
+        }
+
+        // Read array
+        int[] a1_data_read = new int[4];
+        byte[] a1_validity_read = new byte[4];
+
+        int[] a2_data_read = new int[8];
+        ulong[] a2_off_read = new ulong[4];
+        byte[] a2_validity_read = new byte[4];
+
+        byte[] a3_data_read = new byte[9];
+        ulong[] a3_off_read = new ulong[4];
+        byte[] a3_validity_read = new byte[4];
+
+        using (var array_read = new Array(context, tmpArrayPath))
+        {
             Assert.IsNotNull(array_read);
+
             array_read.Open(QueryType.Read);
 
-            var query_read = new Query(array_read);
-            using (var subarray = new Subarray(array_read))
-            {
-                subarray.SetSubarray(1, 2, 1, 2);
-                query_read.SetSubarray(subarray);
-            }
-            query_read.SetLayout(LayoutType.RowMajor);
+            using var query_read = new Query(array_read);
 
-            var a1_data_read = new bool[4];
-            query_read.SetDataBuffer("a1", a1_data_read);
+            query_read.SetLayout(LayoutType.RowMajor);
+            using var subarray = new Subarray(array_read);
+            subarray.SetSubarray(1, 2, 1, 2);
+            query_read.SetSubarray(subarray);
+
+            query_read.UnsafeSetDataBuffer("a1", a1_data_read.AsMemory().Pin(), (ulong)a1_data_read.Length * sizeof(int));
+            query_read.SetValidityBuffer("a1", a1_validity_read);
+
+            query_read.UnsafeSetDataBuffer("a2", a2_data_read.AsMemory().Pin(), (ulong)a2_data_read.Length * sizeof(int));
+            query_read.SetOffsetsBuffer("a2", a2_off_read);
+            query_read.SetValidityBuffer("a2", a2_validity_read);
+
+            query_read.UnsafeSetDataBuffer("a3", a3_data_read.AsMemory());
+            Assert.ThrowsException<ArgumentException>(() => query_read.UnsafeSetDataBuffer("a3", default(MemoryHandle), 0));
+            query_read.SetOffsetsBuffer("a3", a3_off_read);
+            query_read.SetValidityBuffer("a3", a3_validity_read);
 
             query_read.Submit();
-            status = query_read.Status();
-            Assert.AreEqual(status, QueryStatus.Completed);
-            CollectionAssert.AreEqual(a1_data, a1_data_read);
+            var status_read = query_read.Status();
 
-            query_read.FinalizeQuery();
-            query_read.Dispose();
+            Assert.AreEqual(QueryStatus.Completed, status_read);
+            Assert.AreEqual((ulong)a1_data_read.Length * sizeof(int), query_read.GetResultDataBytes("a1"));
+            Assert.AreEqual((ulong)a2_data_read.Length * sizeof(int), query_read.GetResultDataBytes("a2"));
+            Assert.AreEqual((ulong)a3_data_read.Length * sizeof(byte), query_read.GetResultDataBytes("a3"));
+            Assert.ThrowsException<InvalidOperationException>(() => query_read.GetResultDataElements("a1"));
+            Assert.ThrowsException<InvalidOperationException>(() => query_read.GetResultDataElements("a2"));
+            Assert.ThrowsException<InvalidOperationException>(() => query_read.GetResultDataElements("a3"));
 
-            // Read from array into byte[]
-            query_read = new Query(array_read);
-            using (var subarray = new Subarray(array_read))
-            {
-                subarray.SetSubarray(1, 2, 1, 2);
-                query_read.SetSubarray(subarray);
-            }
-            query_read.SetLayout(LayoutType.RowMajor);
+            Assert.AreEqual((ulong)a2_off_read.Length, query_read.GetResultOffsets("a2"));
+            Assert.AreEqual((ulong)a3_off_read.Length, query_read.GetResultOffsets("a3"));
 
-            var a1_data_read_bytes = new byte[4];
-            query_read.SetDataBuffer("a1", a1_data_read_bytes);
+            Assert.AreEqual((ulong)a2_validity_read.Length, query_read.GetResultValidities("a2"));
+            Assert.AreEqual((ulong)a3_validity_read.Length, query_read.GetResultValidities("a3"));
 
-            query_read.Submit();
-            status = query_read.Status();
-            Assert.AreEqual(status, QueryStatus.Completed);
-            CollectionAssert.AreEqual(a1_data, System.Array.ConvertAll(a1_data_read_bytes, b => b == 1));
-
-            query_read.FinalizeQuery();
-            query_read.Dispose();
             array_read.Close();
         }
 
-        [TestMethod]
-        public void TestMemoryHandleGetsUnpinned()
+        CollectionAssert.AreEqual(a1_data, a1_data_read);
+        CollectionAssert.AreEqual(a1_validity, a1_validity_read);
+
+        CollectionAssert.AreEqual(a2_data, a2_data_read);
+        CollectionAssert.AreEqual(a2_validity, a2_validity_read);
+        CollectionAssert.AreEqual(a2_off, a2_off_read);
+
+        CollectionAssert.AreEqual(a3_data, a3_data_read);
+        CollectionAssert.AreEqual(a3_validity, a3_validity_read);
+        CollectionAssert.AreEqual(a3_off, a3_off_read);
+    }// public void TestNullableAttributeArrayQuery
+
+    [TestMethod]
+    public void TestBoolAttributeArrayQuery()
+    {
+        // Create array
+        var context = Context.GetDefault();
+        Assert.IsNotNull(context);
+
+        var dim1 = Dimension.Create(context, "rows", 1, 2, 2);
+        var dim2 = Dimension.Create(context, "cols", 1, 2, 2);
+        var domain = new Domain(context);
+        domain.AddDimensions(dim1, dim2);
+
+        var a1 = new Attribute(context, "a1", DataType.Boolean);
+
+        var array_schema = new ArraySchema(context, ArrayType.Dense);
+        array_schema.AddAttribute(a1);
+        array_schema.SetDomain(domain);
+        array_schema.Check();
+
+        var tmpArrayPath = TestUtil.MakeTestPath("tiledb_test_bool_array");
+        if (Directory.Exists(tmpArrayPath))
         {
-            // Create array
-            var context = Context.GetDefault();
-            Assert.IsNotNull(context);
-
-            using var dim1 = Dimension.Create(context, "rows", 1, 2, 2);
-            using var dim2 = Dimension.Create(context, "cols", 1, 2, 2);
-            using var domain = new Domain(context);
-            domain.AddDimensions(dim1, dim2);
-
-            using var a1 = new Attribute(context, "a1", DataType.Boolean);
-
-            using var array_schema = new ArraySchema(context, ArrayType.Dense);
-            array_schema.AddAttribute(a1);
-            array_schema.SetDomain(domain);
-            array_schema.Check();
-
-            using var tmpArrayPath = new TemporaryDirectory("query_unpin");
-
-            var disposalCanary = new DisposalCanary();
-
-            using var array = new Array(context, tmpArrayPath);
-            array.Create(array_schema);
-            array.Open(QueryType.Read);
-
-            // From the documentation, the memory will be unpinned if:
-
-            // the query is disposed,
-            using (var q = new Query(array))
-            {
-                q.UnsafeSetDataBuffer("rows", disposalCanary.Memory.Pin(), 1 * sizeof(int));
-            }
-            Assert.AreEqual(1, disposalCanary.UnpinCount);
-
-            // the buffer is reassigned,
-            using (var q = new Query(array))
-            {
-                q.UnsafeSetDataBuffer("rows", disposalCanary.Memory.Pin(), 1 * sizeof(int));
-                q.SetDataBuffer("rows", new int[1]);
-                Assert.AreEqual(2, disposalCanary.UnpinCount);
-            }
-
-            // or setting the buffer fails.
-            using (var q = new Query(array))
-            {
-                Assert.ThrowsException<TileDBException>(() => q.UnsafeSetDataBuffer("foo", disposalCanary.Memory.Pin(), 1 * sizeof(int)));
-                Assert.AreEqual(3, disposalCanary.UnpinCount);
-            }
+            Directory.Delete(tmpArrayPath, true);
         }
 
-        /// <summary>
-        /// Holds an array and tracks how many times it was unpinned.
-        /// </summary>
-        private sealed unsafe class DisposalCanary : MemoryManager<int>
+        // Write to array
+        var array_write = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array_write);
+        array_write.Create(array_schema);
+        array_write.Open(QueryType.Write);
+
+        var query_write = new Query(array_write);
+        using (var subarray = new Subarray(array_write))
         {
-            private readonly int[] _array = new int[1];
-
-            public int UnpinCount { get; private set; }
-
-            public override Span<int> GetSpan() => _array;
-
-            public override MemoryHandle Pin(int elementIndex = 0)
-            {
-                var gcHandle = GCHandle.Alloc(_array, GCHandleType.Pinned);
-                var ptr = (void*)gcHandle.AddrOfPinnedObject();
-                return new(ptr, gcHandle, this);
-            }
-
-            public override void Unpin()
-            {
-                UnpinCount++;
-            }
-
-            protected override void Dispose(bool disposing) { }
+            subarray.SetSubarray(1, 2, 1, 2);
+            query_write.SetSubarray(subarray);
         }
+        query_write.SetLayout(LayoutType.RowMajor);
+
+        var a1_data = new bool[] { false, true, true, false };
+        query_write.SetDataBuffer("a1", a1_data);
+
+        query_write.Submit();
+        var status = query_write.Status();
+        Assert.AreEqual(status, QueryStatus.Completed);
+        query_write.FinalizeQuery();
+        query_write.Dispose();
+        array_write.Close();
+
+        // Read from array into bool[]
+        var array_read = new Array(context, tmpArrayPath);
+        Assert.IsNotNull(array_read);
+        array_read.Open(QueryType.Read);
+
+        var query_read = new Query(array_read);
+        using (var subarray = new Subarray(array_read))
+        {
+            subarray.SetSubarray(1, 2, 1, 2);
+            query_read.SetSubarray(subarray);
+        }
+        query_read.SetLayout(LayoutType.RowMajor);
+
+        var a1_data_read = new bool[4];
+        query_read.SetDataBuffer("a1", a1_data_read);
+
+        query_read.Submit();
+        status = query_read.Status();
+        Assert.AreEqual(status, QueryStatus.Completed);
+        CollectionAssert.AreEqual(a1_data, a1_data_read);
+
+        query_read.FinalizeQuery();
+        query_read.Dispose();
+
+        // Read from array into byte[]
+        query_read = new Query(array_read);
+        using (var subarray = new Subarray(array_read))
+        {
+            subarray.SetSubarray(1, 2, 1, 2);
+            query_read.SetSubarray(subarray);
+        }
+        query_read.SetLayout(LayoutType.RowMajor);
+
+        var a1_data_read_bytes = new byte[4];
+        query_read.SetDataBuffer("a1", a1_data_read_bytes);
+
+        query_read.Submit();
+        status = query_read.Status();
+        Assert.AreEqual(status, QueryStatus.Completed);
+        CollectionAssert.AreEqual(a1_data, System.Array.ConvertAll(a1_data_read_bytes, b => b == 1));
+
+        query_read.FinalizeQuery();
+        query_read.Dispose();
+        array_read.Close();
+    }
+
+    [TestMethod]
+    public void TestMemoryHandleGetsUnpinned()
+    {
+        // Create array
+        var context = Context.GetDefault();
+        Assert.IsNotNull(context);
+
+        using var dim1 = Dimension.Create(context, "rows", 1, 2, 2);
+        using var dim2 = Dimension.Create(context, "cols", 1, 2, 2);
+        using var domain = new Domain(context);
+        domain.AddDimensions(dim1, dim2);
+
+        using var a1 = new Attribute(context, "a1", DataType.Boolean);
+
+        using var array_schema = new ArraySchema(context, ArrayType.Dense);
+        array_schema.AddAttribute(a1);
+        array_schema.SetDomain(domain);
+        array_schema.Check();
+
+        using var tmpArrayPath = new TemporaryDirectory("query_unpin");
+
+        var disposalCanary = new DisposalCanary();
+
+        using var array = new Array(context, tmpArrayPath);
+        array.Create(array_schema);
+        array.Open(QueryType.Read);
+
+        // From the documentation, the memory will be unpinned if:
+
+        // the query is disposed,
+        using (var q = new Query(array))
+        {
+            q.UnsafeSetDataBuffer("rows", disposalCanary.Memory.Pin(), 1 * sizeof(int));
+        }
+        Assert.AreEqual(1, disposalCanary.UnpinCount);
+
+        // the buffer is reassigned,
+        using (var q = new Query(array))
+        {
+            q.UnsafeSetDataBuffer("rows", disposalCanary.Memory.Pin(), 1 * sizeof(int));
+            q.SetDataBuffer("rows", new int[1]);
+            Assert.AreEqual(2, disposalCanary.UnpinCount);
+        }
+
+        // or setting the buffer fails.
+        using (var q = new Query(array))
+        {
+            Assert.ThrowsException<TileDBException>(() => q.UnsafeSetDataBuffer("foo", disposalCanary.Memory.Pin(), 1 * sizeof(int)));
+            Assert.AreEqual(3, disposalCanary.UnpinCount);
+        }
+    }
+
+    /// <summary>
+    /// Holds an array and tracks how many times it was unpinned.
+    /// </summary>
+    private sealed unsafe class DisposalCanary : MemoryManager<int>
+    {
+        private readonly int[] _array = new int[1];
+
+        public int UnpinCount { get; private set; }
+
+        public override Span<int> GetSpan() => _array;
+
+        public override MemoryHandle Pin(int elementIndex = 0)
+        {
+            var gcHandle = GCHandle.Alloc(_array, GCHandleType.Pinned);
+            var ptr = (void*)gcHandle.AddrOfPinnedObject();
+            return new(ptr, gcHandle, this);
+        }
+
+        public override void Unpin()
+        {
+            UnpinCount++;
+        }
+
+        protected override void Dispose(bool disposing) { }
     }
 }

--- a/tests/TileDB.CSharp.Test/StatsTest.cs
+++ b/tests/TileDB.CSharp.Test/StatsTest.cs
@@ -1,47 +1,46 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class StatsTest
 {
-    [TestClass]
-    public class StatsTest
+    private static readonly string ArrayUri = TestUtil.MakeTestPath("test-stats");
+
+    [TestMethod]
+    public void TestStats()
     {
-        private static readonly string ArrayUri = TestUtil.MakeTestPath("test-stats");
+        Stats.Enable();
 
-        [TestMethod]
-        public void TestStats()
-        {
-            Stats.Enable();
+        var ctx = Context.GetDefault();
+        var row = Dimension.Create(ctx, "rows", 1, 4, 2);
+        var col = Dimension.Create(ctx, "cols", 1, 4, 2);
+        var domain = new Domain(ctx);
+        domain.AddDimensions(row, col);
+        var schema = new ArraySchema(ctx, ArrayType.Dense);
+        schema.SetDomain(domain);
+        schema.AddAttribute(new Attribute(ctx, "a1", DataType.Int32));
+        schema.Check();
+        TestUtil.CreateArray(ctx, ArrayUri, schema);
 
-            var ctx = Context.GetDefault();
-            var row = Dimension.Create(ctx, "rows", 1, 4, 2);
-            var col = Dimension.Create(ctx, "cols", 1, 4, 2);
-            var domain = new Domain(ctx);
-            domain.AddDimensions(row, col);
-            var schema = new ArraySchema(ctx, ArrayType.Dense);
-            schema.SetDomain(domain);
-            schema.AddAttribute(new Attribute(ctx, "a1", DataType.Int32));
-            schema.Check();
-            TestUtil.CreateArray(ctx, ArrayUri, schema);
+        var array = new Array(ctx, ArrayUri);
+        array.Open(QueryType.Write);
+        var query = new Query(array);
+        query.SetLayout(LayoutType.RowMajor);
+        var subarray = new Subarray(array);
+        subarray.SetSubarray(1, 4, 1, 4);
+        query.SetSubarray(subarray);
+        query.SetDataBuffer("a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
+        query.Submit();
+        Assert.AreEqual(query.Status(), QueryStatus.Completed);
 
-            var array = new Array(ctx, ArrayUri);
-            array.Open(QueryType.Write);
-            var query = new Query(array);
-            query.SetLayout(LayoutType.RowMajor);
-            var subarray = new Subarray(array);
-            subarray.SetSubarray(1, 4, 1, 4);
-            query.SetSubarray(subarray);
-            query.SetDataBuffer("a1", new[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 });
-            query.Submit();
-            Assert.AreEqual(query.Status(), QueryStatus.Completed);
+        string? stats = null;
+        stats = Stats.Get();
+        Assert.IsNotNull(stats);
+        var filePath = TestUtil.MakeTestPath("test-stats-dump");
+        Stats.Dump(filePath);
+        Assert.IsTrue(System.IO.File.Exists(filePath));
 
-            string? stats = null;
-            stats = Stats.Get();
-            Assert.IsNotNull(stats);
-            var filePath = TestUtil.MakeTestPath("test-stats-dump");
-            Stats.Dump(filePath);
-            Assert.IsTrue(System.IO.File.Exists(filePath));
-
-            Stats.Dump();
-        }
+        Stats.Dump();
     }
 }

--- a/tests/TileDB.CSharp.Test/TemporaryDirectory.cs
+++ b/tests/TileDB.CSharp.Test/TemporaryDirectory.cs
@@ -1,36 +1,35 @@
 ﻿using System;
 using System.IO;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+internal readonly struct TemporaryDirectory : IDisposable
 {
-    internal readonly struct TemporaryDirectory : IDisposable
+    private readonly string _path;
+
+    public TemporaryDirectory(string directoryName)
     {
-        private readonly string _path;
+        _path = Path.Join(Path.GetTempPath(), "tiledb-csharp-tests", directoryName);
+        DeleteDirectory(_path);
+        Directory.CreateDirectory(_path);
+    }
 
-        public TemporaryDirectory(string directoryName)
+    public void Dispose()
+    {
+        DeleteDirectory(_path);
+    }
+
+    public static implicit operator string(TemporaryDirectory directory) => directory._path;
+
+    public static void DeleteDirectory(string directory)
+    {
+        try
         {
-            _path = Path.Join(Path.GetTempPath(), "tiledb-csharp-tests", directoryName);
-            DeleteDirectory(_path);
-            Directory.CreateDirectory(_path);
+            Directory.Delete(directory, true);
         }
-
-        public void Dispose()
+        catch (DirectoryNotFoundException)
         {
-            DeleteDirectory(_path);
-        }
-
-        public static implicit operator string(TemporaryDirectory directory) => directory._path;
-
-        public static void DeleteDirectory(string directory)
-        {
-            try
-            {
-                Directory.Delete(directory, true);
-            }
-            catch (DirectoryNotFoundException)
-            {
-                // Don't fail if the directory does not exist.
-            }
+            // Don't fail if the directory does not exist.
         }
     }
 }

--- a/tests/TileDB.CSharp.Test/TestUtil.cs
+++ b/tests/TileDB.CSharp.Test/TestUtil.cs
@@ -7,242 +7,241 @@ using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+public static class TestUtil
 {
-    public static class TestUtil
+    static TestUtil()
     {
-        static TestUtil()
+        if (!Directory.Exists(MakeTestPath("")))
         {
-            if (!Directory.Exists(MakeTestPath("")))
+            Directory.CreateDirectory(MakeTestPath(""));
+        }
+    }
+
+    public static long GetDirectorySize(string directory)
+    {
+        var enumeration = new FileSystemEnumerable<long>(
+            directory,
+            (ref FileSystemEntry entry) => entry.Length,
+            new() { RecurseSubdirectories = true }
+        );
+
+        return enumeration.Sum();
+    }
+
+    /// <summary>
+    /// Normalizes temp directory
+    /// </summary>
+    /// <param name="tempFile">Name of file to create temp path</param>
+    /// <returns>A full path to the local tempFile</returns>
+    public static string MakeTempPath(string tempFile) =>
+        Path.Join(Path.Join(Path.GetTempPath(), "tiledb-csharp-temp"), tempFile);
+
+    /// <summary>
+    /// Normalizes temp directory for all tests
+    /// </summary>
+    /// <param name="fileName">Name of file to create temp path</param>
+    /// <returns>A full path to a local temp directory using provided fileName</returns>
+    public static string MakeTestPath(string fileName) => Path.Join(MakeTempPath("test"), fileName);
+
+    /// <summary>
+    /// Create a new array with a given name and schema to use for testing.
+    /// If the array already exists, it will be removed and recreated.
+    /// </summary>
+    /// <param name="ctx">Current TileDB Context</param>
+    /// <param name="name">Name of array to create</param>
+    /// <param name="schema">Schema to use for new array</param>
+    public static void CreateArray(Context ctx, string name, ArraySchema schema)
+    {
+        if (Directory.Exists(name))
+        {
+            Directory.Delete(name, true);
+        }
+        Array.Create(ctx, name, schema);
+    }
+
+    /// <summary>
+    /// Writes to a TileDB array. Used for tests where we may write to several arrays many times.
+    /// </summary>
+    /// <param name="array">Initialized TileDB Array object to write to</param>
+    /// <param name="layout">Layout to use when writing to the array</param>
+    /// <param name="buffers">Dictionary using buffer name for key mapping to buffer values for writing</param>
+    /// <param name="timestampRange">Optionally provide timestamp range to use for the write</param>
+    /// <param name="ctx">Optionally provide a context from the caller to apply to the write</param>
+    /// <param name="offsets">Dictionary using buffer name for key mapping to offsets to use for writing</param>
+    /// <param name="keepOpen">If set to false, the query will be disposed at the end of the method and null will be returned.</param>
+    /// <returns>Query object used to perform the write for caller context</returns>
+    public static Query WriteArray(
+        Array array,
+        LayoutType layout,
+        Dictionary<string, System.Array> buffers,
+        (ulong, ulong)? timestampRange = null,
+        Context? ctx = null,
+        Dictionary<string, ulong[]>? offsets = null,
+        bool keepOpen = true)
+    {
+        if (timestampRange is (ulong start, ulong end))
+        {
+            array.SetOpenTimestampStart(start);
+            array.SetOpenTimestampEnd(end);
+        }
+        array.Open(QueryType.Write);
+
+        // Use context if provided; Else get default context
+        ctx ??= Context.GetDefault();
+
+        var writeQuery = new Query(array, QueryType.Write);
+        // Sparse arrays can't write using row major; Can read using row-major, but not preferred for performance
+        if (array.Schema().ArrayType() == ArrayType.Sparse && layout == LayoutType.RowMajor)
+        {
+            writeQuery.SetLayout(LayoutType.Unordered);
+        }
+        else
+        {
+            writeQuery.SetLayout(layout);
+        }
+
+        foreach (var buffer in buffers)
+        {
+            // TODO: Remove cast to dynamic
+            writeQuery.SetDataBuffer(buffer.Key, (dynamic)buffer.Value);
+            // Set offset buffer if the attribute or dimension is variable size
+            if (array.Schema().IsVarSize(buffer.Key))
             {
-                Directory.CreateDirectory(MakeTestPath(""));
+                writeQuery.SetOffsetsBuffer(buffer.Key, offsets![buffer.Key]);
             }
         }
 
-        public static long GetDirectorySize(string directory)
-        {
-            var enumeration = new FileSystemEnumerable<long>(
-                directory,
-                (ref FileSystemEntry entry) => entry.Length,
-                new() { RecurseSubdirectories = true }
-            );
+        writeQuery.Submit();
 
-            return enumeration.Sum();
+        // Global order writes must finalize the query.
+        if (layout == LayoutType.GlobalOrder)
+        {
+            writeQuery.FinalizeQuery();
         }
 
-        /// <summary>
-        /// Normalizes temp directory
-        /// </summary>
-        /// <param name="tempFile">Name of file to create temp path</param>
-        /// <returns>A full path to the local tempFile</returns>
-        public static string MakeTempPath(string tempFile) =>
-            Path.Join(Path.Join(Path.GetTempPath(), "tiledb-csharp-temp"), tempFile);
+        Assert.AreEqual(QueryStatus.Completed, writeQuery.Status());
+        array.Close();
 
-        /// <summary>
-        /// Normalizes temp directory for all tests
-        /// </summary>
-        /// <param name="fileName">Name of file to create temp path</param>
-        /// <returns>A full path to a local temp directory using provided fileName</returns>
-        public static string MakeTestPath(string fileName) => Path.Join(MakeTempPath("test"), fileName);
-
-        /// <summary>
-        /// Create a new array with a given name and schema to use for testing.
-        /// If the array already exists, it will be removed and recreated.
-        /// </summary>
-        /// <param name="ctx">Current TileDB Context</param>
-        /// <param name="name">Name of array to create</param>
-        /// <param name="schema">Schema to use for new array</param>
-        public static void CreateArray(Context ctx, string name, ArraySchema schema)
+        if (!keepOpen)
         {
-            if (Directory.Exists(name))
-            {
-                Directory.Delete(name, true);
-            }
-            Array.Create(ctx, name, schema);
+            writeQuery.Dispose();
+            return null!;
         }
 
-        /// <summary>
-        /// Writes to a TileDB array. Used for tests where we may write to several arrays many times.
-        /// </summary>
-        /// <param name="array">Initialized TileDB Array object to write to</param>
-        /// <param name="layout">Layout to use when writing to the array</param>
-        /// <param name="buffers">Dictionary using buffer name for key mapping to buffer values for writing</param>
-        /// <param name="timestampRange">Optionally provide timestamp range to use for the write</param>
-        /// <param name="ctx">Optionally provide a context from the caller to apply to the write</param>
-        /// <param name="offsets">Dictionary using buffer name for key mapping to offsets to use for writing</param>
-        /// <param name="keepOpen">If set to false, the query will be disposed at the end of the method and null will be returned.</param>
-        /// <returns>Query object used to perform the write for caller context</returns>
-        public static Query WriteArray(
-            Array array,
-            LayoutType layout,
-            Dictionary<string, System.Array> buffers,
-            (ulong, ulong)? timestampRange = null,
-            Context? ctx = null,
-            Dictionary<string, ulong[]>? offsets = null,
-            bool keepOpen = true)
+        // Return write query for context
+        return writeQuery;
+    }
+
+    /// <summary>
+    /// Reads a TileDB array into buffers object. Used for tests where we may read from several arrays many times.
+    /// When the read completes the buffers Dictionary will contain values storing read buffer data.
+    /// </summary>
+    /// <param name="array">Initialized TileDB Array object to read from</param>
+    /// <param name="layout">Layout to use when reading from the array</param>
+    /// <param name="buffers">Dictionary using buffer name for key mapping to container for writing to</param>
+    /// <param name="timestampRange">Optionally provide timestamp range to use for the read</param>
+    /// <param name="ctx">Optionally provide a context from the caller to apply to the read</param>
+    /// <param name="offsets">Dictionary using buffer name for key mapping to offsets to use for writing</param>
+    /// <param name="keepOpen">If set to false, the query will be disposed at the end of the method and null will be returned.</param>
+    /// <returns>Query object used to perform the read for caller context</returns>
+    public static Query ReadArray(
+        Array array,
+        LayoutType layout,
+        Dictionary<string, System.Array> buffers,
+        (ulong, ulong)? timestampRange = null,
+        Context? ctx = null,
+        Dictionary<string, ulong[]>? offsets = null,
+        bool keepOpen = true)
+    {
+        if (timestampRange is (ulong start, ulong end))
         {
-            if (timestampRange is (ulong start, ulong end))
+            array.SetOpenTimestampStart(start);
+            array.SetOpenTimestampEnd(end);
+        }
+        array.Open(QueryType.Read);
+
+        // Use context if provided; Else get default context
+        ctx ??= Context.GetDefault();
+
+        var readQuery = new Query(array, QueryType.Read);
+        readQuery.SetLayout(layout);
+        foreach (var buffer in buffers)
+        {
+            // TODO: Remove cast to dynamic
+            readQuery.SetDataBuffer(buffer.Key, (dynamic)buffer.Value);
+            // Set offset buffer if the attribute or dimension is variable size
+            if (array.Schema().IsVarSize(buffer.Key))
             {
-                array.SetOpenTimestampStart(start);
-                array.SetOpenTimestampEnd(end);
+                readQuery.SetOffsetsBuffer(buffer.Key, offsets![buffer.Key]);
             }
-            array.Open(QueryType.Write);
+        }
 
-            // Use context if provided; Else get default context
-            ctx ??= Context.GetDefault();
+        readQuery.Submit();
+        Assert.AreEqual(QueryStatus.Completed, readQuery.Status());
+        array.Close();
 
-            var writeQuery = new Query(array, QueryType.Write);
-            // Sparse arrays can't write using row major; Can read using row-major, but not preferred for performance
-            if (array.Schema().ArrayType() == ArrayType.Sparse && layout == LayoutType.RowMajor)
+        if (!keepOpen)
+        {
+            readQuery.Dispose();
+            return null!;
+        }
+
+        return readQuery;
+    }
+
+    /// <summary>
+    /// Checks expected buffer values are present in actual buffers.
+    /// </summary>
+    /// <param name="expected">Dictionary using buffer name for key mapping to expected contents</param>
+    /// <param name="actual">Dictionary using buffer name for key mapping to actual contents</param>
+    /// <param name="duplicates">True if duplicates are enabled</param>
+    public static void CompareBuffers(
+        Dictionary<string, System.Array> expected,
+        Dictionary<string, System.Array> actual,
+        bool duplicates)
+    {
+        foreach (var buffer in expected)
+        {
+            if (duplicates)
             {
-                writeQuery.SetLayout(LayoutType.Unordered);
+                CollectionAssert.AreEquivalent(buffer.Value, actual[buffer.Key]);
             }
             else
             {
-                writeQuery.SetLayout(layout);
-            }
-
-            foreach (var buffer in buffers)
-            {
-                // TODO: Remove cast to dynamic
-                writeQuery.SetDataBuffer(buffer.Key, (dynamic)buffer.Value);
-                // Set offset buffer if the attribute or dimension is variable size
-                if (array.Schema().IsVarSize(buffer.Key))
-                {
-                    writeQuery.SetOffsetsBuffer(buffer.Key, offsets![buffer.Key]);
-                }
-            }
-
-            writeQuery.Submit();
-
-            // Global order writes must finalize the query.
-            if (layout == LayoutType.GlobalOrder)
-            {
-                writeQuery.FinalizeQuery();
-            }
-
-            Assert.AreEqual(QueryStatus.Completed, writeQuery.Status());
-            array.Close();
-
-            if (!keepOpen)
-            {
-                writeQuery.Dispose();
-                return null!;
-            }
-
-            // Return write query for context
-            return writeQuery;
-        }
-
-        /// <summary>
-        /// Reads a TileDB array into buffers object. Used for tests where we may read from several arrays many times.
-        /// When the read completes the buffers Dictionary will contain values storing read buffer data.
-        /// </summary>
-        /// <param name="array">Initialized TileDB Array object to read from</param>
-        /// <param name="layout">Layout to use when reading from the array</param>
-        /// <param name="buffers">Dictionary using buffer name for key mapping to container for writing to</param>
-        /// <param name="timestampRange">Optionally provide timestamp range to use for the read</param>
-        /// <param name="ctx">Optionally provide a context from the caller to apply to the read</param>
-        /// <param name="offsets">Dictionary using buffer name for key mapping to offsets to use for writing</param>
-        /// <param name="keepOpen">If set to false, the query will be disposed at the end of the method and null will be returned.</param>
-        /// <returns>Query object used to perform the read for caller context</returns>
-        public static Query ReadArray(
-            Array array,
-            LayoutType layout,
-            Dictionary<string, System.Array> buffers,
-            (ulong, ulong)? timestampRange = null,
-            Context? ctx = null,
-            Dictionary<string, ulong[]>? offsets = null,
-            bool keepOpen = true)
-        {
-            if (timestampRange is (ulong start, ulong end))
-            {
-                array.SetOpenTimestampStart(start);
-                array.SetOpenTimestampEnd(end);
-            }
-            array.Open(QueryType.Read);
-
-            // Use context if provided; Else get default context
-            ctx ??= Context.GetDefault();
-
-            var readQuery = new Query(array, QueryType.Read);
-            readQuery.SetLayout(layout);
-            foreach (var buffer in buffers)
-            {
-                // TODO: Remove cast to dynamic
-                readQuery.SetDataBuffer(buffer.Key, (dynamic)buffer.Value);
-                // Set offset buffer if the attribute or dimension is variable size
-                if (array.Schema().IsVarSize(buffer.Key))
-                {
-                    readQuery.SetOffsetsBuffer(buffer.Key, offsets![buffer.Key]);
-                }
-            }
-
-            readQuery.Submit();
-            Assert.AreEqual(QueryStatus.Completed, readQuery.Status());
-            array.Close();
-
-            if (!keepOpen)
-            {
-                readQuery.Dispose();
-                return null!;
-            }
-
-            return readQuery;
-        }
-
-        /// <summary>
-        /// Checks expected buffer values are present in actual buffers.
-        /// </summary>
-        /// <param name="expected">Dictionary using buffer name for key mapping to expected contents</param>
-        /// <param name="actual">Dictionary using buffer name for key mapping to actual contents</param>
-        /// <param name="duplicates">True if duplicates are enabled</param>
-        public static void CompareBuffers(
-            Dictionary<string, System.Array> expected,
-            Dictionary<string, System.Array> actual,
-            bool duplicates)
-        {
-            foreach (var buffer in expected)
-            {
-                if (duplicates)
-                {
-                    CollectionAssert.AreEquivalent(buffer.Value, actual[buffer.Key]);
-                }
-                else
-                {
-                    CollectionAssert.AreEqual(buffer.Value, actual[buffer.Key]);
-                }
+                CollectionAssert.AreEqual(buffer.Value, actual[buffer.Key]);
             }
         }
+    }
 
-        /// <summary>
-        /// Print schema of a local TileDB array
-        /// </summary>
-        /// <param name="arrayUri">Full path to existing TileDB array</param>
-        public static void PrintLocalSchema(string arrayUri)
+    /// <summary>
+    /// Print schema of a local TileDB array
+    /// </summary>
+    /// <param name="arrayUri">Full path to existing TileDB array</param>
+    public static void PrintLocalSchema(string arrayUri)
+    {
+        var context = Context.GetDefault();
+        using Array array = new Array(context, arrayUri);
+        array.Open(QueryType.Read);
+        PrintLocalSchema(array.Schema());
+        array.Close();
+    }
+
+    /// <summary>
+    /// Print schema of a local TileDB array
+    /// </summary>
+    /// <param name="schema"></param>
+    public static void PrintLocalSchema(ArraySchema schema)
+    {
+        foreach (var pair in schema.Dimensions())
         {
-            var context = Context.GetDefault();
-            using Array array = new Array(context, arrayUri);
-            array.Open(QueryType.Read);
-            PrintLocalSchema(array.Schema());
-            array.Close();
+            Console.WriteLine($"Dimension: {pair.Key}; Data type: {pair.Value.Type()}");
         }
-
-        /// <summary>
-        /// Print schema of a local TileDB array
-        /// </summary>
-        /// <param name="schema"></param>
-        public static void PrintLocalSchema(ArraySchema schema)
+        foreach (var pair in schema.Attributes())
         {
-            foreach (var pair in schema.Dimensions())
-            {
-                Console.WriteLine($"Dimension: {pair.Key}; Data type: {pair.Value.Type()}");
-            }
-            foreach (var pair in schema.Attributes())
-            {
-                Console.WriteLine($"Attribute: {pair.Key}; Data type: {pair.Value.Type()}; " +
-                                  $"Nullable: {pair.Value.Nullable()};");
-            }
+            Console.WriteLine($"Attribute: {pair.Key}; Data type: {pair.Value.Type()}; " +
+                              $"Nullable: {pair.Value.Nullable()};");
         }
     }
 }

--- a/tests/TileDB.CSharp.Test/VFSTest.cs
+++ b/tests/TileDB.CSharp.Test/VFSTest.cs
@@ -3,155 +3,154 @@ using System;
 using System.IO;
 using System.Security.Cryptography;
 
-namespace TileDB.CSharp.Test
+namespace TileDB.CSharp.Test;
+
+[TestClass]
+public class VFSTest
 {
-    [TestClass]
-    public class VFSTest
+    private static void WriteRandomData(VFS vfs, string fileUri, int byteCount, out byte[] data)
     {
-        private static void WriteRandomData(VFS vfs, string fileUri, int byteCount, out byte[] data)
+        data = new byte[byteCount];
+        RandomNumberGenerator.Fill(data);
+        using var f = vfs.Open(fileUri, VfsMode.Write);
+        f.Write(data);
+    }
+
+    [TestMethod]
+    public void TestCreateWithConfig()
+    {
+        using var config = new Config();
+        config.Set("test", "test");
+        using var vfs = new VFS(config: config);
+        using var retrievedConfig = vfs.Config();
+        Assert.AreEqual("test", retrievedConfig.Get("test"));
+    }
+
+    [TestMethod]
+    public void TestDir()
+    {
+        using var vfs = new VFS();
+
+        string dirname = "tempdir";
+        if (vfs.IsDir(dirname))
         {
-            data = new byte[byteCount];
-            RandomNumberGenerator.Fill(data);
-            using var f = vfs.Open(fileUri, VfsMode.Write);
-            f.Write(data);
-        }
-
-        [TestMethod]
-        public void TestCreateWithConfig()
-        {
-            using var config = new Config();
-            config.Set("test", "test");
-            using var vfs = new VFS(config: config);
-            using var retrievedConfig = vfs.Config();
-            Assert.AreEqual("test", retrievedConfig.Get("test"));
-        }
-
-        [TestMethod]
-        public void TestDir()
-        {
-            using var vfs = new VFS();
-
-            string dirname = "tempdir";
-            if (vfs.IsDir(dirname))
-            {
-                vfs.RemoveDir(dirname);
-            }
-
-            vfs.CreateDir(dirname);
-            Assert.IsTrue(vfs.IsDir(dirname));
-            Assert.IsTrue(Directory.Exists(dirname));
-
             vfs.RemoveDir(dirname);
         }
 
-        [TestMethod]
-        public void TestReadWrite()
+        vfs.CreateDir(dirname);
+        Assert.IsTrue(vfs.IsDir(dirname));
+        Assert.IsTrue(Directory.Exists(dirname));
+
+        vfs.RemoveDir(dirname);
+    }
+
+    [TestMethod]
+    public void TestReadWrite()
+    {
+        const int DataSize = 4096;
+
+        using var dir = new TemporaryDirectory("vfs-read-write");
+        var fileUri = Path.Combine(dir, "file");
+
+        using var vfs = new VFS();
+
+        WriteRandomData(vfs, fileUri, DataSize, out var dataWrite);
+        Assert.AreEqual((ulong)DataSize, vfs.FileSize(fileUri));
+
+        using (var f = vfs.Open(fileUri, VfsMode.Read))
         {
-            const int DataSize = 4096;
-
-            using var dir = new TemporaryDirectory("vfs-read-write");
-            var fileUri = Path.Combine(dir, "file");
-
-            using var vfs = new VFS();
-
-            WriteRandomData(vfs, fileUri, DataSize, out var dataWrite);
-            Assert.AreEqual((ulong)DataSize, vfs.FileSize(fileUri));
-
-            using (var f = vfs.Open(fileUri, VfsMode.Read))
-            {
-                byte[] dataRead = new byte[DataSize];
-                f.ReadExactly(0, dataRead);
-                CollectionAssert.AreEqual(dataWrite, dataRead);
-            }
+            byte[] dataRead = new byte[DataSize];
+            f.ReadExactly(0, dataRead);
+            CollectionAssert.AreEqual(dataWrite, dataRead);
         }
+    }
 
-        [TestMethod]
-        public void TestCopyMove()
+    [TestMethod]
+    public void TestCopyMove()
+    {
+        const int DataSize = 4096;
+
+        using var dir = new TemporaryDirectory("vfs-copy-move");
+        var file1Uri = Path.Combine(dir, "file1");
+        var file2Uri = Path.Combine(dir, "file2");
+
+        using var vfs = new VFS();
+
+        WriteRandomData(vfs, file1Uri, DataSize, out var dataWrite);
+        Assert.AreEqual((ulong)DataSize, vfs.FileSize(file1Uri));
+        vfs.MoveFile(file1Uri, file2Uri);
+        Assert.IsFalse(vfs.IsFile(file1Uri));
+        Assert.AreEqual((ulong)DataSize, vfs.FileSize(file2Uri));
+        if (OperatingSystem.IsWindows())
         {
-            const int DataSize = 4096;
-
-            using var dir = new TemporaryDirectory("vfs-copy-move");
-            var file1Uri = Path.Combine(dir, "file1");
-            var file2Uri = Path.Combine(dir, "file2");
-
-            using var vfs = new VFS();
-
-            WriteRandomData(vfs, file1Uri, DataSize, out var dataWrite);
-            Assert.AreEqual((ulong)DataSize, vfs.FileSize(file1Uri));
-            vfs.MoveFile(file1Uri, file2Uri);
-            Assert.IsFalse(vfs.IsFile(file1Uri));
-            Assert.AreEqual((ulong)DataSize, vfs.FileSize(file2Uri));
-            if (OperatingSystem.IsWindows())
-            {
-                // Copying files on Windows is not yet supported.
-                System.IO.File.Copy(file2Uri, file1Uri);
-            }
-            else
-            {
-                vfs.CopyFile(file2Uri, file1Uri);
-            }
-            Assert.IsTrue(vfs.IsFile(file1Uri));
-            Assert.IsTrue(vfs.IsFile(file2Uri));
-            Assert.AreEqual((ulong)DataSize * 2, vfs.DirSize(dir));
+            // Copying files on Windows is not yet supported.
+            System.IO.File.Copy(file2Uri, file1Uri);
         }
-
-        [TestMethod]
-        public void TestVisit()
+        else
         {
-            using var dir = new TemporaryDirectory("vfs-visit");
+            vfs.CopyFile(file2Uri, file1Uri);
+        }
+        Assert.IsTrue(vfs.IsFile(file1Uri));
+        Assert.IsTrue(vfs.IsFile(file2Uri));
+        Assert.AreEqual((ulong)DataSize * 2, vfs.DirSize(dir));
+    }
 
-            using var vfs = new VFS();
-            vfs.Touch(Path.Combine(dir, "file1"));
-            vfs.Touch(Path.Combine(dir, "file2"));
-            vfs.Touch(Path.Combine(dir, "file3"));
+    [TestMethod]
+    public void TestVisit()
+    {
+        using var dir = new TemporaryDirectory("vfs-visit");
 
-            int i = 0;
+        using var vfs = new VFS();
+        vfs.Touch(Path.Combine(dir, "file1"));
+        vfs.Touch(Path.Combine(dir, "file2"));
+        vfs.Touch(Path.Combine(dir, "file3"));
 
-            vfs.VisitChildren(dir, (uri, arg) =>
+        int i = 0;
+
+        vfs.VisitChildren(dir, (uri, arg) =>
+        {
+            string path = new Uri(uri).LocalPath;
+            Assert.IsTrue(System.IO.File.Exists(path));
+            Assert.AreEqual((string)dir, Path.GetDirectoryName(path));
+            Assert.AreEqual(555, arg);
+
+            i++;
+            return i != 2;
+        }, 555);
+
+        Assert.AreEqual(2, i);
+    }
+
+    [TestMethod]
+    public void TestVisitPropagatesExceptions()
+    {
+        using var dir = new TemporaryDirectory("vfs-visit-exceptions");
+
+        const string ExceptionKey = "foo";
+
+        using var vfs = new VFS();
+        vfs.Touch(Path.Combine(dir, "file1"));
+        vfs.Touch(Path.Combine(dir, "file2"));
+        vfs.Touch(Path.Combine(dir, "file3"));
+
+        int i = 0;
+
+        try
+        {
+            vfs.VisitChildren(dir, (_, _) =>
             {
-                string path = new Uri(uri).LocalPath;
-                Assert.IsTrue(System.IO.File.Exists(path));
-                Assert.AreEqual((string)dir, Path.GetDirectoryName(path));
-                Assert.AreEqual(555, arg);
-
                 i++;
-                return i != 2;
-            }, 555);
-
-            Assert.AreEqual(2, i);
+                throw new Exception(ExceptionKey);
+            }, 0);
         }
-
-        [TestMethod]
-        public void TestVisitPropagatesExceptions()
+        catch (Exception e)
         {
-            using var dir = new TemporaryDirectory("vfs-visit-exceptions");
-
-            const string ExceptionKey = "foo";
-
-            using var vfs = new VFS();
-            vfs.Touch(Path.Combine(dir, "file1"));
-            vfs.Touch(Path.Combine(dir, "file2"));
-            vfs.Touch(Path.Combine(dir, "file3"));
-
-            int i = 0;
-
-            try
-            {
-                vfs.VisitChildren(dir, (_, _) =>
-                {
-                    i++;
-                    throw new Exception(ExceptionKey);
-                }, 0);
-            }
-            catch (Exception e)
-            {
-                Assert.AreEqual(1, i);
-                Assert.AreEqual(typeof(Exception), e.GetType());
-                Assert.AreEqual(ExceptionKey, e.Message);
-                return;
-            }
-
-            Assert.Fail("Exception was not propagated.");
+            Assert.AreEqual(1, i);
+            Assert.AreEqual(typeof(Exception), e.GetType());
+            Assert.AreEqual(ExceptionKey, e.Message);
+            return;
         }
+
+        Assert.Fail("Exception was not propagated.");
     }
 }


### PR DESCRIPTION
> [!IMPORTANT]
> Please review this with whitespace diffs turned off.

Similar to #141, this PR updates the required version of the .NET SDK to .NET 8, and uses some new and less new C# language features along the way. We update the SDK primarily because .NET 7 will go out of support in May 2024, and to enable updating the ClangSharpPInvokeGenerator whose latest version runs on .NET 8.

Like the previous PR, this does not affect the C# API's runtime targeting of .NET 5. .NET 8 will be required only to build it from source.