### PR TITLE
Update the download/upload artifact actions to version 4.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,9 +56,9 @@ jobs:
 
       # We combine the binaries of the many platforms per tag by uploading them to the same artifact.
       - name: Upload native artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: tiledb-native-${{ matrix.tag }}
+          name: tiledb-native-${{ matrix.tag }}-${{ matrix.platform }}
           path: artifacts/
           retention-days: 1
 
@@ -85,9 +85,10 @@ jobs:
         run: dotnet --info
 
       - name: Download native artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: tiledb-native-${{ matrix.tag }}
+          pattern: tiledb-native-${{ matrix.tag }}-*
+          merge-multiple: true
           path: scripts/nuget/temp
 
       - name: Build native NuGet packages
@@ -95,7 +96,7 @@ jobs:
         run: dotnet pack ./scripts/nuget/GenerateNuGetPackages.proj -p:DevelopmentBuild=true -p:VersionTag=${{ matrix.tag }}
 
       - name: Upload native NuGet packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: tiledb-nuget-${{ matrix.tag }}
           path: scripts/nuget/packages/
@@ -125,7 +126,7 @@ jobs:
         run: dotnet --info
 
       - name: Download native NuGet packages
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: tiledb-nuget-${{ matrix.tag }}
           path: packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       # In case pushing to NuGet fails we upload the packages as artifacts to push them ourselves.
       # We must push these packages GitHub Actions generated because they are marked as deterministic.
       - name: Upload packages as artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nuget-release
           path: pack/


### PR DESCRIPTION
Artifacts are now immutable and we can't upload many times to the same one, but what we can do is upload to many artifacts with a common prefix, and download all of them with a pattern.

Validated by [successfully launching a nightly build](https://github.com/teo-tsirpanis/TileDB-CSharp/actions/runs/7561966064).