### PR TITLE
Update Core to 2.22

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,7 +27,7 @@ jobs:
           - os: windows-latest
             platform: windows-x86_64
           - tag: dev
-        tag: [release-2.21, dev]
+        tag: [release-2.22, dev]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout TileDB
@@ -72,7 +72,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [release-2.21, dev]
+        tag: [release-2.22, dev]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout TileDB-CSharp
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        tag: [release-2.21, dev]
+        tag: [release-2.22, dev]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout TileDB-CSharp

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <TileDBNativePackageName>TileDB.Native</TileDBNativePackageName>
     <TileDBNativeVersionMajor>2</TileDBNativeVersionMajor>
-    <TileDBNativeVersionMinor>21</TileDBNativeVersionMinor>
+    <TileDBNativeVersionMinor>22</TileDBNativeVersionMinor>
     <TileDBNativePackageVersion>[$(TileDBNativeVersionMajor).$(TileDBNativeVersionMinor).0,$(TileDBNativeVersionMajor).$([MSBuild]::Add($(TileDBNativeVersionMinor), 1)).0)</TileDBNativePackageVersion>
 
     <!-- The DevelopmentBuild property switches to the locally built native packages.

--- a/sources/TileDB.CSharp/TileDB.CSharp.csproj
+++ b/sources/TileDB.CSharp/TileDB.CSharp.csproj
@@ -6,12 +6,12 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <RootNamespace>TileDB.CSharp</RootNamespace>
-    <Version>5.11.0</Version>
+    <Version>5.12.0</Version>
     <Description>C# wrapper of the TileDB Embedded universal data engine.</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <EnablePackageValidation>true</EnablePackageValidation>
-    <PackageValidationBaselineVersion>5.10.0</PackageValidationBaselineVersion>
+    <PackageValidationBaselineVersion>5.11.0</PackageValidationBaselineVersion>
     <NoWarn>$(NoWarn);TILEDB0012;TILEDB0013;TILEDB0014</NoWarn>
   </PropertyGroup>
 

--- a/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
+++ b/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
@@ -7,7 +7,7 @@
     <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-		<VSTestLogger Condition="'$(GITHUB_ACTIONS)' != ''">GitHubActions</VSTestLogger>
+    <VSTestLogger Condition="'$(GITHUB_ACTIONS)' != ''">GitHubActions</VSTestLogger>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,5 +20,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\sources\TileDB.CSharp\TileDB.CSharp.csproj" />
+    <PackageVersion Include="TileDB.Native" Version="$(TileDBNativeVersionMajor).$(TileDBNativeVersionMajor).*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Since 2.22 did not expose any new C API, no changes to C# code are required.