### PR TITLE
Revert floating the Core's version in tests and fix CI.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -144,7 +144,10 @@ jobs:
 
       - name: Run examples (.NET 5)
         shell: bash
-        run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0
+        # macos-latest runs on Apple Silicon, which .NET 5 does not support.
+        # The tests run fine for some reason, but the examples do not. Explicitly
+        # specify the architecture to avoid this issue.
+        run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0 -a x64
 
       - name: Run examples (.NET 6)
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu-latest
             platform: linux-x86_64
           - os: macos-latest
-            platform: macos-x86_64
+            platform: macos-arm64
           - os: windows-latest
             platform: windows-x86_64
           - tag: dev
@@ -145,9 +145,8 @@ jobs:
       - name: Run examples (.NET 5)
         shell: bash
         # macos-latest runs on Apple Silicon, which .NET 5 does not support.
-        # The tests run fine for some reason, but the examples do not. Explicitly
-        # specify the architecture to avoid this issue.
-        run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0 -a x64
+        if: matrix.os != 'macos-latest'
+        run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0
 
       - name: Run examples (.NET 6)
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -142,13 +142,7 @@ jobs:
       - name: Test TileDB-CSharp
         run: dotnet test tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj -c Release
 
-      - name: Run examples (.NET 5)
-        shell: bash
-        # macos-latest runs on Apple Silicon, which .NET 5 does not support.
-        if: matrix.os != 'macos-latest'
-        run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0
-
-      - name: Run examples (.NET 6)
+      - name: Run examples
         shell: bash
         run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net6.0
 

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -65,8 +65,11 @@ jobs:
 
       - name: Run examples (.NET 5)
         shell: bash
+        # macos-latest runs on Apple Silicon, which .NET 5 does not support.
+        # The tests run fine for some reason, but the examples do not. Explicitly
+        # specify the architecture to avoid this issue.
         run: |
-          find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0
+          find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0 -a x64
 
       - name: Run examples (.NET 6)
         shell: bash

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -74,4 +74,4 @@ jobs:
       - name: Run examples (.NET 6)
         shell: bash
         run: |
-          find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0
+          find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net6.0

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -63,15 +63,7 @@ jobs:
         run: |
           dotnet test -c Release tests/TileDB.CSharp.Test
 
-      - name: Run examples (.NET 5)
-        shell: bash
-        # macos-latest runs on Apple Silicon, which .NET 5 does not support.
-        # The tests run fine for some reason, but the examples do not. Explicitly
-        # specify the architecture to avoid this issue.
-        run: |
-          find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net5.0 -a x64
-
-      - name: Run examples (.NET 6)
+      - name: Run examples
         shell: bash
         run: |
           find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net6.0

--- a/examples/TileDB.CSharp.Example/TileDB.CSharp.Example.csproj
+++ b/examples/TileDB.CSharp.Example/TileDB.CSharp.Example.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RollForward>Major</RollForward>
     <RootNamespace>TileDB.CSharp.Examples</RootNamespace>
-    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
 

--- a/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
+++ b/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
@@ -20,6 +20,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\sources\TileDB.CSharp\TileDB.CSharp.csproj" />
-    <PackageVersion Include="TileDB.Native" Version="$(TileDBNativeVersionMajor).$(TileDBNativeVersionMajor).*" />
+    <!-- To run tests with a TileDB patch, uncomment the following lines: -->
+    <!-- 
+    <PackageReference Include="TileDB.Native" />
+    <PackageVersion Update="TileDB.Native" Version="<version>" />
+    -->
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes nightly builds.

For some backstory, the packaging system of the C# API enables Core patches to be released without any changes to the C# API package. This has the downside that by default the earliest (`.0`) Core patch gets used, which means that to update the Core users have to install the `TileDB.Native` package themselves.

c3f0ace9525cfb401721c032ccaaa6ba74d831e4 tried to make the tests always use the latest Core version, but it caused nightlies to fail because we cannot install floating versions of packages because we have enabled [NuGet Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management). This PR reverts that commit. The `.0` patch will still get used, and I left instructions in the tests for how to run tests with a subsequent patch version. Core patches still get tested in nightly builds, by building the Core from the `release-*` branch.