### PR TITLE
Obsolete `ConfigIterator` and add standard enumerators to `Config`.

### DIFF
--- a/docs/obsoletions.md
+++ b/docs/obsoletions.md
@@ -8,7 +8,8 @@ Following [the deprecation policy of TileDB Embedded][core-deprecation], obsolet
 |----------------|---------------------|------------------|
 |[`TILEDB0001`](#TILEDB0001) …[`TILEDB0011`](#TILEDB0011)|5.3.0|5.5.0|
 |[`TILEDB0012`](#TILEDB0012) …[`TILEDB0013`](#TILEDB0013)|5.7.0|5.9.0|
-|[`TILEDB0012`](#TILEDB0014) …[`TILEDB0013`](#TILEDB0014)|5.8.0|5.10.0|
+|[`TILEDB0014`](#TILEDB0014) …[`TILEDB0014`](#TILEDB0014)|5.8.0|5.10.0|
+|[`TILEDB0015`](#TILEDB0015) …[`TILEDB0015`](#TILEDB0015)|5.13.0|5.15.0|
 
 ## `TILEDB0001` - Enum value names that start with `TILEDB_` were replaced with C#-friendly names.
 
@@ -347,5 +348,19 @@ Some APIs in the `TileDB.Interop` namespace that were inadvertently removed in v
 ### Recommended action
 
 Stop using the obsoleted APIs. No other public API of `TileDB.CSharp` depends on them.
+
+## `TILEDB0015` - `ConfigIterator` is obsolete.
+
+<a name="TILEDB0015"></a>
+
+The `ConfigIterator` class is unintuitive to use. In version 5.13.0 it was marked as obsolete and replaced by `Config` implementing `IEnumerable<KeyValuePair<string,string>>`.
+
+### Version introduced
+
+5.13.0
+
+### Recommended action
+
+Replace uses of `ConfigIterator` with enumerating the `Config` object directly using a `foreach` loop or LINQ. To get only the config options that start with a specific prefix, call the `Config.EnumerateOptions` method and enumerate its returned object.
 
 [core-deprecation]: https://github.com/TileDB-Inc/TileDB/blob/dev/doc/policy/api_changes.md

--- a/sources/TileDB.CSharp/Config.cs
+++ b/sources/TileDB.CSharp/Config.cs
@@ -206,7 +206,11 @@ public sealed unsafe class Config : IDisposable, IEnumerable<KeyValuePair<string
 
     private sealed class Enumerator(Config config, string prefix) : IEnumerator<KeyValuePair<string, string>>
     {
+#pragma warning disable TILEDB0015 // Type or member is obsolete
+        // We use ConfigIterator as an implementation detail.
+        // In the future, ConfigIterator will become internal and replace this class.
         private readonly ConfigIterator _iterator = new(config.Handle, prefix);
+#pragma warning restore TILEDB0015 // Type or member is obsolete
 
         private readonly string _prefix = prefix;
 

--- a/sources/TileDB.CSharp/ConfigIterator.cs
+++ b/sources/TileDB.CSharp/ConfigIterator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using TileDB.CSharp.Marshalling.SafeHandles;
 using TileDB.Interop;
 using ConfigHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigHandle;
@@ -36,7 +37,8 @@ public sealed unsafe class ConfigIterator : IDisposable
 
     internal ConfigIteratorHandle Handle => _handle;
 
-    public Tuple<string, string> Here()
+    // Internal overload that returns KVP to avoid the Tuple allocation.
+    internal KeyValuePair<string, string> HereImpl()
     {
         tiledb_error_t* p_tiledb_error;
         sbyte* paramPtr;
@@ -51,7 +53,13 @@ public sealed unsafe class ConfigIterator : IDisposable
 
         string param = MarshaledStringOut.GetStringFromNullTerminated(paramPtr);
         string value = MarshaledStringOut.GetStringFromNullTerminated(valuePtr);
-        return new Tuple<string, string>(param, value);
+        return new KeyValuePair<string, string>(param, value);
+    }
+
+    public Tuple<string, string> Here()
+    {
+        var here = HereImpl();
+        return new Tuple<string, string>(here.Key, here.Value);
     }
 
     public void Next()

--- a/sources/TileDB.CSharp/ConfigIterator.cs
+++ b/sources/TileDB.CSharp/ConfigIterator.cs
@@ -7,6 +7,7 @@ using ConfigIteratorHandle = TileDB.CSharp.Marshalling.SafeHandles.ConfigIterato
 
 namespace TileDB.CSharp;
 
+[Obsolete(Obsoletions.ConfigIteratorMessage, DiagnosticId = Obsoletions.ConfigIteratorDiagId, UrlFormat = Obsoletions.SharedUrlFormat)]
 public sealed unsafe class ConfigIterator : IDisposable
 {
     private readonly ConfigIteratorHandle _handle;

--- a/sources/TileDB.CSharp/Obsoletions.cs
+++ b/sources/TileDB.CSharp/Obsoletions.cs
@@ -47,4 +47,7 @@ internal static class Obsoletions
 
     public const string TileDBInterop3Message = "Members of the TileDB.Interop namespace should not be used by user code and will become internal in a future version.";
     public const string TileDBInterop3DiagId = "TILEDB0014";
+
+    public const string ConfigIteratorMessage = "ConfigIterator is obsolete. Directly enumerate a Config or call its EnumerateOptions method instead.";
+    public const string ConfigIteratorDiagId = "TILEDB0015";
 }

--- a/tests/TileDB.CSharp.Test/ConfigTest.cs
+++ b/tests/TileDB.CSharp.Test/ConfigTest.cs
@@ -89,112 +89,108 @@ public class ConfigTest
         // Iterate the configuration
         var iter = config.Iterate("vfs.s3.");
 
-        while (!iter.Done())
+        foreach (var config_entry_pair in config.EnumerateOptions("vfs.s3."))
         {
-
-            // Get current param, value from iterator
-            var config_entry_pair = iter.Here();
-
-            switch (config_entry_pair.Item1)
+            switch (config_entry_pair.Key)
             {
                 case "aws_access_key_id":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "aws_external_id":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "aws_load_frequency":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "aws_role_arn":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "aws_secret_access_key":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "aws_session_name":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "aws_session_token":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "bucket_canned_acl":
-                    Assert.AreEqual("NOT_SET", config_entry_pair.Item2);
+                    Assert.AreEqual("NOT_SET", config_entry_pair.Value);
                     break;
                 case "ca_file":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "ca_path":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "connect_max_tries":
-                    Assert.AreEqual("5", config_entry_pair.Item2);
+                    Assert.AreEqual("5", config_entry_pair.Value);
                     break;
                 case "connect_scale_factor":
-                    Assert.AreEqual("25", config_entry_pair.Item2);
+                    Assert.AreEqual("25", config_entry_pair.Value);
                     break;
                 case "connect_timeout_ms":
-                    Assert.AreEqual("10800", config_entry_pair.Item2);
+                    Assert.AreEqual("10800", config_entry_pair.Value);
                     break;
                 case "endpoint_override":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "logging_level":
-                    Assert.AreEqual("Off", config_entry_pair.Item2);
+                    Assert.AreEqual("Off", config_entry_pair.Value);
                     break;
                 case "max_parallel_ops":
-                    Assert.AreEqual(Environment.ProcessorCount.ToString(), config_entry_pair.Item2);
+                    Assert.AreEqual(Environment.ProcessorCount.ToString(), config_entry_pair.Value);
                     break;
                 case "multipart_part_size":
-                    Assert.AreEqual("5242880", config_entry_pair.Item2);
+                    Assert.AreEqual("5242880", config_entry_pair.Value);
                     break;
                 case "object_canned_acl":
-                    Assert.AreEqual("NOT_SET", config_entry_pair.Item2);
+                    Assert.AreEqual("NOT_SET", config_entry_pair.Value);
                     break;
                 case "proxy_host":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "proxy_password":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "proxy_port":
-                    Assert.AreEqual("0", config_entry_pair.Item2);
+                    Assert.AreEqual("0", config_entry_pair.Value);
                     break;
                 case "proxy_scheme":
-                    Assert.AreEqual("http", config_entry_pair.Item2);
+                    Assert.AreEqual("http", config_entry_pair.Value);
                     break;
                 case "proxy_username":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "region":
-                    Assert.AreEqual("us-east-1", config_entry_pair.Item2);
+                    Assert.AreEqual("us-east-1", config_entry_pair.Value);
                     break;
                 case "request_timeout_ms":
-                    Assert.AreEqual("3000", config_entry_pair.Item2);
+                    Assert.AreEqual("3000", config_entry_pair.Value);
                     break;
                 case "requester_pays":
-                    Assert.AreEqual("false", config_entry_pair.Item2);
+                    Assert.AreEqual("false", config_entry_pair.Value);
                     break;
                 case "scheme":
-                    Assert.AreEqual("https", config_entry_pair.Item2);
+                    Assert.AreEqual("https", config_entry_pair.Value);
                     break;
                 case "skip_init":
-                    Assert.AreEqual("false", config_entry_pair.Item2);
+                    Assert.AreEqual("false", config_entry_pair.Value);
                     break;
                 case "sse":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "sse_kms_key_id":
-                    Assert.AreEqual("", config_entry_pair.Item2);
+                    Assert.AreEqual("", config_entry_pair.Value);
                     break;
                 case "use_multipart_upload":
-                    Assert.AreEqual("true", config_entry_pair.Item2);
+                    Assert.AreEqual("true", config_entry_pair.Value);
                     break;
                 case "use_virtual_addressing":
-                    Assert.AreEqual("true", config_entry_pair.Item2);
+                    Assert.AreEqual("true", config_entry_pair.Value);
                     break;
                 case "verify_ssl":
-                    Assert.AreEqual("true", config_entry_pair.Item2);
+                    Assert.AreEqual("true", config_entry_pair.Value);
                     break;
             }
             iter.Next();


### PR DESCRIPTION
[SC-47208](https://app.shortcut.com/tiledb-inc/story/47208/deprecate-configiterator-and-replace-it-with-standard-net-enumerators)

This PR adds an implementation of `IEnumerable<KeyValuePair<string,string>>` to `Config`, providing a much more intuitive interface to enumerate the options of a `Config`, and replacing `ConfigIterator` which was obsoleted. To enumerate config options with a specific prefix, an `EnumerateOptions` method was introduced.

Tests were updated.