### PR TITLE
Remove pin to MSVC toolset version in nightly builds.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -44,7 +44,6 @@ jobs:
         if: matrix.os == 'windows-latest'
         with:
           arch: x64
-          toolset: 14.39
       - name: Export GitHub Actions cache variables
         uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Part of [SC-48973](https://app.shortcut.com/tiledb-inc/story/48973/revert-pins-to-msvc-toolset-14-39)

GitHub Actions is starting to update the MSVC toolset version in CI, causing [occasional failures in the Core](https://github.com/TileDB-Inc/TileDB/actions/runs/9386900730/job/25848568717). This PR removes the pin to version 14.39 added in #388.