### PR TITLE
Fix nightlies et al.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      mstest:
+        # Update MSTest packages together, they are sometimes incompatible with each other.
+        patterns: ["MSTest.*"]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up .NET SDK from global.json
-        uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.4xx
       - name: Display .NET versions
         run: dotnet --info
       - name: Restore .NET local tools

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,10 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Remove existing .NET versions
-        shell: bash
-        run: |
-          rm -rf $DOTNET_ROOT
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v4
       - name: Display .NET versions

--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -21,11 +21,6 @@ jobs:
       # Checks out repository
       - uses: actions/checkout@v4
 
-      - name: Remove existing .NET versions
-        shell: bash
-        run: |
-          rm -rf $DOTNET_ROOT
-
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v4
 

--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -21,8 +21,9 @@ jobs:
       # Checks out repository
       - uses: actions/checkout@v4
 
-      - name: Set up .NET SDK from global.json
-        uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.4xx
 
       - name: Display .NET versions
         run: dotnet --info

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,8 +77,9 @@ jobs:
       - name: Checkout TileDB-CSharp
         uses: actions/checkout@v4
 
-      - name: Set up .NET SDK from global.json
-        uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.4xx
 
       - name: Display dotnet versions
         run: dotnet --info

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -77,11 +77,6 @@ jobs:
       - name: Checkout TileDB-CSharp
         uses: actions/checkout@v4
 
-      # GitHub runners come with several versions of .NET preinstalled; Remove them to target version
-      - name: Remove existing .NET versions
-        shell: bash
-        run: rm -rf $DOTNET_ROOT
-
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v4
 
@@ -117,11 +112,6 @@ jobs:
     steps:
       - name: Checkout TileDB-CSharp
         uses: actions/checkout@v4
-
-      # GitHub runners come with several versions of .NET preinstalled; Remove them to target version
-      - name: Remove existing .NET versions
-        shell: bash
-        run: rm -rf $DOTNET_ROOT
 
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,6 @@ jobs:
     needs: Run-Tests
     steps:
       - uses: actions/checkout@v4
-      - name: Remove existing .NET versions
-        shell: bash
-        run: |
-          rm -rf $DOTNET_ROOT
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v4
       - name: Display .NET versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,9 @@ jobs:
     needs: Run-Tests
     steps:
       - uses: actions/checkout@v4
-      - name: Set up .NET SDK from global.json
-        uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.4xx
       - name: Display .NET versions
         run: dotnet --info
       - name: Pack TileDB.CSharp

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -15,11 +15,6 @@ jobs:
       # Checks out repository
       - uses: actions/checkout@v4
 
-      - name: Remove existing .NET versions
-        shell: bash
-        run: |
-          rm -rf $DOTNET_ROOT
-
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v4
 
@@ -41,11 +36,6 @@ jobs:
     steps:
       # Checks out repository
       - uses: actions/checkout@v4
-
-      - name: Remove existing .NET versions
-        shell: bash
-        run: |
-          rm -rf $DOTNET_ROOT
 
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -15,8 +15,9 @@ jobs:
       # Checks out repository
       - uses: actions/checkout@v4
 
-      - name: Set up .NET SDK from global.json
-        uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.4xx
 
       - name: Display .NET versions
         run: dotnet --info
@@ -37,8 +38,9 @@ jobs:
       # Checks out repository
       - uses: actions/checkout@v4
 
-      - name: Set up .NET SDK from global.json
-        uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.4xx
 
       - name: Display .NET versions
         run: dotnet --info

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.400",
     "rollForward": "major"
   }
 }


### PR DESCRIPTION
Fixes #485.

* The "Remove existing .NET versions" step was removed. It is not necessary because the .NET SDK version to use is pinned by the `global.json` file. ~~Moreover it's likely that the forced deletion of the `$DOTNET_ROOT` folder corrupts the installation and causes nightlies to fail because the `dotnet --info` command fails with an exception.~~
* The .NET SDK used was updated from 8.0.1xx to 8.0.4xx.