### PR TITLE
Create native NuGet packages for linux-arm64.

### DIFF
--- a/scripts/nuget/GenerateNuGetPackages.proj
+++ b/scripts/nuget/GenerateNuGetPackages.proj
@@ -21,6 +21,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <NativePlatform Include="linux-x86_64" RuntimeId="linux-x64" LibraryPath="lib/libtiledb.so" />
+    <NativePlatform Include="linux-arm64" RuntimeId="linux-arm64" LibraryPath="lib/libtiledb.so" />
     <NativePlatform Include="macos-x86_64" RuntimeId="osx-x64" LibraryPath="lib/libtiledb.dylib" />
     <NativePlatform Include="macos-arm64" RuntimeId="osx-arm64" LibraryPath="lib/libtiledb.dylib" />
     <NativePlatform Include="windows-x86_64" RuntimeId="win-x64" LibraryPath="bin/tiledb.dll" ArchiveExtension="zip" />


### PR DESCRIPTION
Starting with TileDB version 2.27.0 we ship binaries for linux-arm64. This PR updates the NuGet package generation script to pack them as well.

If we need to make a patch release for a pre-2.27 release, we will have to generate the NuGet packages with an earlier version of the script.