### PR TITLE
Fix nightlies.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,8 +26,7 @@ jobs:
             platform: macos-arm64
           - os: windows-latest
             platform: windows-x86_64
-          - tag: dev
-        tag: [release-2.27, dev]
+        tag: [release-2.27, main]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout TileDB
@@ -71,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tag: [release-2.27, dev]
+        tag: [release-2.27, main]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout TileDB-CSharp
@@ -108,7 +107,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        tag: [release-2.27, dev]
+        tag: [release-2.27, main]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout TileDB-CSharp


### PR DESCRIPTION
The main branch name in the Core was changed to `dev`.

Fixes #505