### PR TITLE
Remove "Display .NET versions" GHA steps.

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,8 +12,6 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.4xx
-      - name: Display .NET versions
-        run: dotnet --info
       - name: Restore .NET local tools
         run: dotnet tool restore
       - name: Build docs

--- a/.github/workflows/generate-bindings.yml
+++ b/.github/workflows/generate-bindings.yml
@@ -25,9 +25,6 @@ jobs:
         with:
           dotnet-version: 8.0.4xx
 
-      - name: Display .NET versions
-        run: dotnet --info
-
       - name: Run the binding generation script
         run: dotnet msbuild ./scripts/generate-bindings/GenerateBindings.proj -p:Version=${{ inputs.version }} -p:VersionTag=${{ inputs.commit_id }} /restore
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,9 +80,6 @@ jobs:
         with:
           dotnet-version: 8.0.4xx
 
-      - name: Display dotnet versions
-        run: dotnet --info
-
       - name: Download native artifacts
         uses: actions/download-artifact@v4
         with:
@@ -115,9 +112,6 @@ jobs:
 
       - name: Set up .NET SDK from global.json
         uses: actions/setup-dotnet@v4
-
-      - name: Display dotnet versions
-        run: dotnet --info
 
       - name: Download native NuGet packages
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.4xx
-      - name: Display .NET versions
-        run: dotnet --info
       - name: Pack TileDB.CSharp
         run: dotnet pack -c Release ./sources/TileDB.CSharp/TileDB.CSharp.csproj -o pack
       # In case pushing to NuGet fails we upload the packages as artifacts to push them ourselves.

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -19,9 +19,6 @@ jobs:
         with:
           dotnet-version: 8.0.4xx
 
-      - name: Display .NET versions
-        run: dotnet --info
-
       # Package validation runs as part of packing.
       - name: Dotnet pack for TileDB.CSharp
         run: |
@@ -41,9 +38,6 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 8.0.4xx
-
-      - name: Display .NET versions
-        run: dotnet --info
 
       # DotNet build
       - name: Dotnet build for TileDB.CSharp


### PR DESCRIPTION
[SC-62651](https://app.shortcut.com/tiledb-inc/story/62651/c-ci-has-been-failing-to-run-dotnet-info-on-windows)

They are not actually needed and have been failing to run on Windows. The .NET SDK version we are using is being set by `global.json` file, and installed by the steps just above.

Fixes #512