### PR TITLE
Update target framework to .NET 8.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Run examples
         shell: bash
-        run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net6.0
+        run: find examples/ -name *.csproj | xargs -I{} dotnet run --project {}
 
   Create-Issue:
     needs: Test-NuGet

--- a/.github/workflows/tiledb-csharp.yml
+++ b/.github/workflows/tiledb-csharp.yml
@@ -52,4 +52,4 @@ jobs:
       - name: Run examples
         shell: bash
         run: |
-          find examples/ -name *.csproj | xargs -I{} dotnet run --project {} -f net6.0
+          find examples/ -name *.csproj | xargs -I{} dotnet run --project {}

--- a/examples/TileDB.CSharp.Example/TileDB.CSharp.Example.csproj
+++ b/examples/TileDB.CSharp.Example/TileDB.CSharp.Example.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <RollForward>Major</RollForward>
     <RootNamespace>TileDB.CSharp.Examples</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
   </PropertyGroup>
 

--- a/sources/TileDB.CSharp/CompatibilitySuppressions.xml
+++ b/sources/TileDB.CSharp/CompatibilitySuppressions.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- https://learn.microsoft.com/en-us/dotnet/fundamentals/package-validation/diagnostic-ids -->
+<Suppressions xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Suppression>
+    <DiagnosticId>PKV006</DiagnosticId>
+    <Target>net5.0</Target>
+  </Suppression>
+</Suppressions>

--- a/sources/TileDB.CSharp/TileDB.CSharp.csproj
+++ b/sources/TileDB.CSharp/TileDB.CSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="../NuGet.props" />
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable Condition="$(DevelopmentBuild) == true OR '$(LocalLibraryFile)' != ''">false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>

--- a/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
+++ b/tests/TileDB.CSharp.Test/TileDB.CSharp.Test.csproj
@@ -4,7 +4,7 @@
     <Nullable>enable</Nullable>
     <RollForward>Major</RollForward>
     <RootNamespace>TileDB.CSharp.Test</RootNamespace>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <UseCurrentRuntimeIdentifier>true</UseCurrentRuntimeIdentifier>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <VSTestLogger Condition="'$(GITHUB_ACTIONS)' != ''">GitHubActions</VSTestLogger>


### PR DESCRIPTION
[SC-64485](https://app.shortcut.com/tiledb-inc/story/64485/update-target-framework-to-net-8)

Consistent with the [.NET support policy](https://dotnet.microsoft.com/en-us/platform/support/policy), this PR updates the minimum supported target framework of TileDB-CSharp to .NET 8. This will open the door to some substantial improvements down the road. More details in the story.