### PR TITLE
Configure macOS `SDKROOT` when building native components et al.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           mkdir -p build
           mkdir -p artifacts/${{ matrix.platform }}
-          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DTILEDB_SERIALIZATION=ON -DTILEDB_S3=ON -DTILEDB_VCPKG=ON -DCOMPILER_SUPPORTS_AVX2=OFF -DTILEDB_CMAKE_IDE=ON
+          cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DTILEDB_TESTS=OFF -DCOMPILER_SUPPORTS_AVX2=OFF
           cmake --build build -j --target tiledb
           cmake --install build --prefix artifacts/${{ matrix.platform }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,6 +43,9 @@ jobs:
         if: matrix.os == 'windows-latest'
         with:
           arch: x64
+      - name: Configure macOS SDKROOT
+        if: runner.os == 'macOS'
+        run: echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
       - name: Export GitHub Actions cache variables
         uses: actions/github-script@v8
         with:


### PR DESCRIPTION
Fixes #576.

Due to changes in CMake 4.0, we have to explicitly configure `SDKROOT`, like we do in TileDB-Inc/TileDB#5633. We also remove some outdated CMake options, and disable S3, serialization and testing, which are not used by the C# tests.

Validated by [successfully running a nightly build](https://github.com/teo-tsirpanis/TileDB-CSharp/actions/runs/17764976537).